### PR TITLE
feat: Server-side compose generation and config persistence

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -27,7 +27,7 @@ func main() {
 		}
 	}
 
-	configPath := flag.String("config", "config.yml", "Path to configuration file")
+	configPath := flag.String("config", "", "Path to configuration file")
 	showVersion := flag.Bool("version", false, "Print version information")
 	flag.Parse()
 
@@ -36,12 +36,14 @@ func main() {
 		return
 	}
 
-	cfg, err := config.Load(*configPath)
+	resolvedConfigPath := config.FindConfigPath(*configPath)
+	cfg, err := config.Load(resolvedConfigPath)
 	if err != nil {
-		log.Fatalf("Failed to load config: %v", err)
+		log.Fatalf("Failed to load config from %s: %v", resolvedConfigPath, err)
 	}
 
 	log.Printf("Starting Flatrun Agent v%s", version.Version)
+	log.Printf("Config loaded from: %s", resolvedConfigPath)
 	log.Printf("Deployments path: %s", cfg.DeploymentsPath)
 	log.Printf("API listening on: %s:%d", cfg.API.Host, cfg.API.Port)
 
@@ -53,7 +55,7 @@ func main() {
 
 	go fileWatcher.Start()
 
-	apiServer := api.New(cfg, *configPath)
+	apiServer := api.New(cfg, resolvedConfigPath)
 	go func() {
 		if err := apiServer.Start(); err != nil {
 			log.Fatalf("Failed to start API server: %v", err)

--- a/config.example.yml
+++ b/config.example.yml
@@ -22,7 +22,7 @@ nginx:
     enabled: false
     image: nginx:alpine
     container_name: nginx
-    config_path: /deployments/nginx/conf.d
+    config_path: ""
     reload_command: nginx -s reload
     external: false
 certbot:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -141,6 +141,7 @@ func (s *Server) setupRoutes() {
 			protected.GET("/templates", s.listTemplates)
 			protected.GET("/templates/categories", s.getTemplateCategories)
 			protected.POST("/templates/refresh", s.refreshTemplates)
+			protected.GET("/templates/:id/compose", s.getTemplateCompose)
 			protected.GET("/stats", s.getSystemStats)
 			protected.GET("/containers", s.listContainers)
 			protected.POST("/containers/:id/start", s.startContainer)
@@ -258,7 +259,7 @@ func (s *Server) getDeployment(c *gin.Context) {
 func (s *Server) createDeployment(c *gin.Context) {
 	var req struct {
 		Name              string                  `json:"name" binding:"required"`
-		ComposeContent    string                  `json:"compose_content" binding:"required"`
+		ComposeContent    string                  `json:"compose_content"`
 		TemplateID        string                  `json:"template_id,omitempty"`
 		Metadata          *models.ServiceMetadata `json:"metadata,omitempty"`
 		EnvVars           []EnvVar                `json:"env_vars,omitempty"`
@@ -271,6 +272,17 @@ func (s *Server) createDeployment(c *gin.Context) {
 			"error": err.Error(),
 		})
 		return
+	}
+
+	if req.ComposeContent == "" {
+		generated, err := s.generateComposeContent(req.Name, req.TemplateID)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "compose_content is required when template cannot be resolved: " + err.Error(),
+			})
+			return
+		}
+		req.ComposeContent = generated
 	}
 
 	networkName := s.config.Infrastructure.DefaultProxyNetwork
@@ -924,6 +936,7 @@ func (s *Server) updateSettings(c *gin.Context) {
 	}
 
 	s.infraManager.UpdateConfig(s.config)
+	s.proxyOrchestrator.UpdateConfig(s.config)
 
 	if s.configPath != "" {
 		if err := config.Save(s.config, s.configPath); err != nil {
@@ -1206,6 +1219,25 @@ func (s *Server) getTemplateCategories(c *gin.Context) {
 	})
 }
 
+func (s *Server) getTemplateCompose(c *gin.Context) {
+	templateID := c.Param("id")
+	name := c.DefaultQuery("name", "my-app")
+
+	content, err := s.generateComposeContent(name, templateID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"template_id": templateID,
+		"name":        name,
+		"content":     content,
+	})
+}
+
 func (s *Server) ensureBuiltinTemplates(templatesDir string) {
 	builtinList, err := templates.List()
 	if err != nil {
@@ -1234,6 +1266,82 @@ func (s *Server) ensureBuiltinTemplates(templatesDir string) {
 			_ = os.WriteFile(composePath, composeContent, 0644)
 		}
 	}
+}
+
+func (s *Server) generateComposeContent(name, templateID string) (string, error) {
+	if templateID == "" {
+		templateID = "static"
+	}
+
+	composeBytes, err := templates.GetCompose(templateID)
+	if err != nil {
+		templatesDir := filepath.Join(s.config.DeploymentsPath, ".flatrun", "templates")
+		composePath := filepath.Join(templatesDir, templateID, "docker-compose.yml")
+		composeBytes, err = os.ReadFile(composePath)
+		if err != nil {
+			return "", fmt.Errorf("template '%s' not found", templateID)
+		}
+	}
+
+	content := string(composeBytes)
+
+	content = strings.ReplaceAll(content, "${NAME}", name)
+
+	networkName := s.config.Infrastructure.DefaultProxyNetwork
+	content = strings.ReplaceAll(content, "${PROXY_NETWORK}", networkName)
+
+	content = replaceHardcodedNetwork(content, "proxy", networkName)
+
+	return content, nil
+}
+
+func replaceHardcodedNetwork(content, oldNetwork, newNetwork string) string {
+	if oldNetwork == newNetwork {
+		return content
+	}
+
+	lines := strings.Split(content, "\n")
+	var result []string
+	inNetworks := false
+	inServicesNetworks := false
+	indentLevel := 0
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		currentIndent := len(line) - len(strings.TrimLeft(line, " \t"))
+
+		if trimmed == "networks:" {
+			if currentIndent == 0 {
+				inNetworks = true
+				indentLevel = currentIndent
+			} else {
+				inServicesNetworks = true
+				indentLevel = currentIndent
+			}
+			result = append(result, line)
+			continue
+		}
+
+		if inNetworks && currentIndent > indentLevel {
+			if strings.HasPrefix(trimmed, oldNetwork+":") {
+				line = strings.Replace(line, oldNetwork+":", newNetwork+":", 1)
+			}
+		} else if inNetworks && currentIndent <= indentLevel && trimmed != "" {
+			inNetworks = false
+		}
+
+		if inServicesNetworks && currentIndent > indentLevel {
+			if trimmed == "- "+oldNetwork {
+				line = strings.Replace(line, "- "+oldNetwork, "- "+newNetwork, 1)
+			}
+		} else if inServicesNetworks && currentIndent <= indentLevel && trimmed != "" {
+			inServicesNetworks = false
+		}
+
+		result = append(result, line)
+	}
+
+	return strings.Join(result, "\n")
 }
 
 func (s *Server) processTemplateFiles(deploymentName, templateID string) {

--- a/internal/docker/executor.go
+++ b/internal/docker/executor.go
@@ -1,0 +1,64 @@
+package docker
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/flatrun/agent/pkg/config"
+)
+
+type ServiceExecutor struct {
+	config *config.ServiceExecConfig
+}
+
+func NewServiceExecutor(cfg *config.ServiceExecConfig) *ServiceExecutor {
+	return &ServiceExecutor{config: cfg}
+}
+
+func (e *ServiceExecutor) Execute(args []string) ([]byte, error) {
+	if e.config.ShouldUseDockerRun() {
+		return e.executeWithDockerRun(args)
+	}
+	return e.executeWithDockerExec(args)
+}
+
+func (e *ServiceExecutor) executeWithDockerRun(args []string) ([]byte, error) {
+	image := e.config.Image
+	if image == "" {
+		return nil, fmt.Errorf("image is required for docker run")
+	}
+
+	dockerArgs := []string{"run", "--rm"}
+
+	for _, vol := range e.config.Volumes {
+		dockerArgs = append(dockerArgs, "-v", vol)
+	}
+
+	for _, net := range e.config.Networks {
+		dockerArgs = append(dockerArgs, "--network", net)
+	}
+
+	dockerArgs = append(dockerArgs, image)
+	dockerArgs = append(dockerArgs, args...)
+
+	cmd := exec.Command("docker", dockerArgs...)
+	return cmd.CombinedOutput()
+}
+
+func (e *ServiceExecutor) executeWithDockerExec(args []string) ([]byte, error) {
+	container := e.config.Container
+	if container == "" {
+		return nil, fmt.Errorf("container name is required for docker exec")
+	}
+
+	dockerArgs := []string{"exec", container}
+	dockerArgs = append(dockerArgs, args...)
+
+	cmd := exec.Command("docker", dockerArgs...)
+	return cmd.CombinedOutput()
+}
+
+func ExecuteService(cfg *config.ServiceExecConfig, args []string) ([]byte, error) {
+	executor := NewServiceExecutor(cfg)
+	return executor.Execute(args)
+}

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -44,6 +44,25 @@ func (m *Manager) ConfigPath() string {
 	return m.configPath
 }
 
+func (m *Manager) UpdateConfig(cfg *config.NginxConfig, deploymentsPath string, webrootPath string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.config = cfg
+
+	configPath := cfg.ConfigPath
+	if configPath == "" {
+		configPath = filepath.Join(deploymentsPath, "nginx", "conf.d")
+	}
+	m.configPath = configPath
+
+	if webrootPath == "" {
+		webrootPath = filepath.Join(deploymentsPath, "nginx", "webroot")
+	}
+	m.webrootPath = webrootPath
+	m.basePath = deploymentsPath
+}
+
 func (m *Manager) CreateVirtualHost(deployment *models.Deployment) error {
 	if deployment.Metadata == nil {
 		return fmt.Errorf("deployment has no metadata")

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -30,6 +30,11 @@ func (o *Orchestrator) SSLManager() *ssl.Manager {
 	return o.ssl
 }
 
+func (o *Orchestrator) UpdateConfig(cfg *config.Config) {
+	o.nginx.UpdateConfig(&cfg.Nginx, cfg.DeploymentsPath, cfg.Certbot.WebrootPath)
+	o.ssl.UpdateConfig(&cfg.Certbot, cfg.DeploymentsPath)
+}
+
 func (o *Orchestrator) SetupDeployment(deployment *models.Deployment) (*SetupResult, error) {
 	result := &SetupResult{
 		DeploymentName: deployment.Name,

--- a/internal/ssl/manager.go
+++ b/internal/ssl/manager.go
@@ -5,12 +5,12 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/flatrun/agent/internal/docker"
 	"github.com/flatrun/agent/pkg/config"
 	"github.com/flatrun/agent/pkg/models"
 )
@@ -44,13 +44,28 @@ func (m *Manager) CertsPath() string {
 	return m.certsPath
 }
 
-func (m *Manager) RequestCertificate(domain string) (*CertificateResult, error) {
+func (m *Manager) UpdateConfig(cfg *config.CertbotConfig, deploymentsPath string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.config.ContainerName == "" {
-		return nil, fmt.Errorf("certbot container name not configured")
+	m.config = cfg
+
+	certsPath := cfg.CertsPath
+	if certsPath == "" {
+		certsPath = filepath.Join(deploymentsPath, "nginx", "certs", "live")
 	}
+	m.certsPath = certsPath
+
+	webRoot := cfg.WebrootPath
+	if webRoot == "" {
+		webRoot = filepath.Join(deploymentsPath, "nginx", "webroot")
+	}
+	m.webRoot = webRoot
+}
+
+func (m *Manager) RequestCertificate(domain string) (*CertificateResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	if m.config.Email == "" {
 		return nil, fmt.Errorf("certbot email not configured")
@@ -60,11 +75,10 @@ func (m *Manager) RequestCertificate(domain string) (*CertificateResult, error) 
 		return nil, fmt.Errorf("failed to create webroot: %w", err)
 	}
 
-	args := []string{
-		"exec", m.config.ContainerName,
-		"certbot", "certonly",
+	certbotArgs := []string{
+		"certonly",
 		"--webroot",
-		"--webroot-path=" + m.webRoot,
+		"--webroot-path=/var/www/certbot",
 		"--email", m.config.Email,
 		"--agree-tos",
 		"--no-eff-email",
@@ -72,11 +86,10 @@ func (m *Manager) RequestCertificate(domain string) (*CertificateResult, error) 
 	}
 
 	if m.config.Staging {
-		args = append(args, "--staging")
+		certbotArgs = append(certbotArgs, "--staging")
 	}
 
-	cmd := exec.Command("docker", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := m.executeCertbot(certbotArgs)
 	if err != nil {
 		return nil, fmt.Errorf("certbot failed: %s - %w", string(output), err)
 	}
@@ -88,16 +101,35 @@ func (m *Manager) RequestCertificate(domain string) (*CertificateResult, error) 
 	}, nil
 }
 
+func (m *Manager) getServiceExecConfig() *config.ServiceExecConfig {
+	image := m.config.Image
+	if image == "" {
+		image = "certbot/certbot"
+	}
+
+	certsDir := filepath.Dir(m.certsPath)
+
+	return &config.ServiceExecConfig{
+		Image:        image,
+		KeepAlive:    false,
+		RunOnRequest: true,
+		Volumes: []string{
+			certsDir + ":/etc/letsencrypt",
+			m.webRoot + ":/var/www/certbot",
+		},
+	}
+}
+
+func (m *Manager) executeCertbot(args []string) ([]byte, error) {
+	cfg := m.getServiceExecConfig()
+	return docker.ExecuteService(cfg, args)
+}
+
 func (m *Manager) RenewCertificates() (*RenewalResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.config.ContainerName == "" {
-		return nil, fmt.Errorf("certbot container name not configured")
-	}
-
-	cmd := exec.Command("docker", "exec", m.config.ContainerName, "certbot", "renew")
-	output, err := cmd.CombinedOutput()
+	output, err := m.executeCertbot([]string{"renew"})
 	if err != nil {
 		return nil, fmt.Errorf("renewal failed: %s - %w", string(output), err)
 	}
@@ -112,15 +144,8 @@ func (m *Manager) RevokeCertificate(domain string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.config.ContainerName == "" {
-		return fmt.Errorf("certbot container name not configured")
-	}
-
 	certPath := fmt.Sprintf("/etc/letsencrypt/live/%s/cert.pem", domain)
-
-	cmd := exec.Command("docker", "exec", m.config.ContainerName,
-		"certbot", "revoke", "--cert-path", certPath, "--non-interactive")
-	output, err := cmd.CombinedOutput()
+	output, err := m.executeCertbot([]string{"revoke", "--cert-path", certPath, "--non-interactive"})
 	if err != nil {
 		return fmt.Errorf("revocation failed: %s - %w", string(output), err)
 	}
@@ -132,13 +157,7 @@ func (m *Manager) DeleteCertificate(domain string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.config.ContainerName == "" {
-		return fmt.Errorf("certbot container name not configured")
-	}
-
-	cmd := exec.Command("docker", "exec", m.config.ContainerName,
-		"certbot", "delete", "--cert-name", domain, "--non-interactive")
-	output, err := cmd.CombinedOutput()
+	output, err := m.executeCertbot([]string{"delete", "--cert-name", domain, "--non-interactive"})
 	if err != nil {
 		return fmt.Errorf("deletion failed: %s - %w", string(output), err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,14 +50,26 @@ type NginxConfig struct {
 }
 
 type CertbotConfig struct {
-	Enabled       bool   `yaml:"enabled" json:"enabled"`
-	Image         string `yaml:"image" json:"image"`
-	ContainerName string `yaml:"container_name" json:"container_name"`
-	Email         string `yaml:"email" json:"email"`
-	Staging       bool   `yaml:"staging" json:"staging"`
-	CertsPath     string `yaml:"certs_path" json:"certs_path"`
-	WebrootPath   string `yaml:"webroot_path" json:"webroot_path"`
-	DNSProvider   string `yaml:"dns_provider" json:"dns_provider"`
+	Enabled     bool   `yaml:"enabled" json:"enabled"`
+	Image       string `yaml:"image" json:"image"`
+	Email       string `yaml:"email" json:"email"`
+	Staging     bool   `yaml:"staging" json:"staging"`
+	CertsPath   string `yaml:"certs_path" json:"certs_path"`
+	WebrootPath string `yaml:"webroot_path" json:"webroot_path"`
+	DNSProvider string `yaml:"dns_provider" json:"dns_provider"`
+}
+
+type ServiceExecConfig struct {
+	Image        string   `yaml:"image" json:"image"`
+	Container    string   `yaml:"container" json:"container"`
+	KeepAlive    bool     `yaml:"keep_alive" json:"keep_alive"`
+	RunOnRequest bool     `yaml:"run_on_request" json:"run_on_request"`
+	Volumes      []string `yaml:"volumes" json:"volumes"`
+	Networks     []string `yaml:"networks" json:"networks"`
+}
+
+func (c *ServiceExecConfig) ShouldUseDockerRun() bool {
+	return !c.KeepAlive && c.RunOnRequest
 }
 
 type LoggingConfig struct {
@@ -95,8 +107,39 @@ type SharedRedisConfig struct {
 	Password  string `yaml:"password" json:"password"`
 }
 
+func FindConfigPath(providedPath string) string {
+	if providedPath != "" && providedPath != "config.yml" {
+		return providedPath
+	}
+
+	candidates := []string{
+		"/etc/flatrun/config.yml",
+		"/opt/flatrun/config.yml",
+		"./config.yml",
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err == nil {
+		candidates = append([]string{
+			homeDir + "/.config/flatrun/config.yml",
+		}, candidates...)
+	}
+
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+
+	if providedPath != "" {
+		return providedPath
+	}
+	return "/etc/flatrun/config.yml"
+}
+
 func Load(path string) (*Config, error) {
-	data, err := os.ReadFile(path)
+	actualPath := FindConfigPath(path)
+	data, err := os.ReadFile(actualPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Add server-side compose generation with network name substitution
- Add GET /api/templates/:id/compose endpoint for template preview
- Make compose_content optional in deployment creation API
- Add ServiceExecConfig with keep_alive/run_on_request flags
- Add docker executor for on-demand service execution
- Update SSL manager to use new executor pattern
- Add config path resolution for consistent config persistence
- Search multiple locations for config file on startup