### PR TITLE
feat: add system stats and container stats APIs

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -149,6 +149,9 @@ func (s *Server) setupRoutes() {
 			protected.POST("/containers/:id/restart", s.restartContainer)
 			protected.DELETE("/containers/:id", s.removeContainer)
 			protected.GET("/containers/:id/logs", s.getContainerLogs)
+			protected.GET("/containers/:id/stats", s.getContainerStats)
+			protected.GET("/containers/stats", s.getAllContainerStats)
+			protected.GET("/deployments/:name/stats", s.getDeploymentContainerStats)
 			protected.GET("/images", s.listImages)
 			protected.DELETE("/images/:id", s.removeImage)
 			protected.POST("/images/pull", s.pullImage)
@@ -1547,11 +1550,14 @@ func (s *Server) getSystemStats(c *gin.Context) {
 	imageStats, _ := s.networksManager.GetImageStats()
 	volumeStats, _ := s.networksManager.GetVolumeStats()
 
+	systemStats, _ := system.GetSystemStats()
+
 	c.JSON(http.StatusOK, gin.H{
 		"deployments": stats,
 		"containers":  containerStats,
 		"images":      imageStats,
 		"volumes":     volumeStats,
+		"system":      systemStats,
 	})
 }
 
@@ -1653,6 +1659,72 @@ func (s *Server) getContainerLogs(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"id":   id,
 		"logs": logs,
+	})
+}
+
+func (s *Server) getContainerStats(c *gin.Context) {
+	id := c.Param("id")
+
+	stats, err := docker.GetContainerStats(id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"stats": stats,
+	})
+}
+
+func (s *Server) getAllContainerStats(c *gin.Context) {
+	stats, err := docker.GetAllContainerStats()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"stats": stats,
+	})
+}
+
+func (s *Server) getDeploymentContainerStats(c *gin.Context) {
+	name := c.Param("name")
+
+	if _, err := s.manager.GetDeployment(name); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "deployment not found",
+		})
+		return
+	}
+
+	stats, _ := docker.GetDeploymentStats(name)
+	if stats == nil {
+		stats = []docker.ContainerStats{}
+	}
+
+	var totalCPU, totalMemPercent float64
+	var totalMemUsage, totalMemLimit uint64
+	for _, s := range stats {
+		totalCPU += s.CPUPercent
+		totalMemPercent += s.MemoryPercent
+		totalMemUsage += s.MemoryUsage
+		totalMemLimit += s.MemoryLimit
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"deployment": name,
+		"services":   stats,
+		"summary": gin.H{
+			"cpu_percent":    totalCPU,
+			"memory_percent": totalMemPercent,
+			"memory_usage":   totalMemUsage,
+			"memory_limit":   totalMemLimit,
+		},
 	})
 }
 

--- a/internal/docker/stats.go
+++ b/internal/docker/stats.go
@@ -1,0 +1,171 @@
+package docker
+
+import (
+	"encoding/json"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type ContainerStats struct {
+	ContainerID   string  `json:"container_id"`
+	Name          string  `json:"name"`
+	CPUPercent    float64 `json:"cpu_percent"`
+	MemoryUsage   uint64  `json:"memory_usage"`
+	MemoryLimit   uint64  `json:"memory_limit"`
+	MemoryPercent float64 `json:"memory_percent"`
+	NetworkRx     uint64  `json:"network_rx"`
+	NetworkTx     uint64  `json:"network_tx"`
+	BlockRead     uint64  `json:"block_read"`
+	BlockWrite    uint64  `json:"block_write"`
+	PIDs          int     `json:"pids"`
+}
+
+type dockerStatsJSON struct {
+	Container    string `json:"Container"`
+	Name         string `json:"Name"`
+	CPUPerc      string `json:"CPUPerc"`
+	MemUsage     string `json:"MemUsage"`
+	MemPerc      string `json:"MemPerc"`
+	NetIO        string `json:"NetIO"`
+	BlockIO      string `json:"BlockIO"`
+	PIDs         string `json:"PIDs"`
+}
+
+func GetContainerStats(containerID string) (*ContainerStats, error) {
+	cmd := exec.Command("docker", "stats", "--no-stream", "--format", "{{json .}}", containerID)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var raw dockerStatsJSON
+	if err := json.Unmarshal(output, &raw); err != nil {
+		return nil, err
+	}
+
+	return parseStats(&raw), nil
+}
+
+func GetAllContainerStats() ([]ContainerStats, error) {
+	cmd := exec.Command("docker", "stats", "--no-stream", "--format", "{{json .}}")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var stats []ContainerStats
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var raw dockerStatsJSON
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			continue
+		}
+		stats = append(stats, *parseStats(&raw))
+	}
+
+	return stats, nil
+}
+
+func GetDeploymentStats(projectName string) ([]ContainerStats, error) {
+	if projectName == "" {
+		return []ContainerStats{}, nil
+	}
+
+	// Get container names by docker-compose project label
+	psCmd := exec.Command("docker", "ps", "-q",
+		"--filter", "label=com.docker.compose.project="+projectName)
+	containerIDs, err := psCmd.Output()
+	if err != nil || len(strings.TrimSpace(string(containerIDs))) == 0 {
+		return []ContainerStats{}, nil
+	}
+
+	ids := strings.Fields(strings.TrimSpace(string(containerIDs)))
+	if len(ids) == 0 {
+		return []ContainerStats{}, nil
+	}
+
+	args := append([]string{"stats", "--no-stream", "--format", "{{json .}}"}, ids...)
+	cmd := exec.Command("docker", args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return []ContainerStats{}, nil
+	}
+
+	var stats []ContainerStats
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var raw dockerStatsJSON
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			continue
+		}
+		stats = append(stats, *parseStats(&raw))
+	}
+
+	return stats, nil
+}
+
+func parseStats(raw *dockerStatsJSON) *ContainerStats {
+	stats := &ContainerStats{
+		ContainerID: raw.Container,
+		Name:        raw.Name,
+	}
+
+	stats.CPUPercent = parsePercent(raw.CPUPerc)
+	stats.MemoryPercent = parsePercent(raw.MemPerc)
+
+	memParts := strings.Split(raw.MemUsage, " / ")
+	if len(memParts) == 2 {
+		stats.MemoryUsage = parseBytes(strings.TrimSpace(memParts[0]))
+		stats.MemoryLimit = parseBytes(strings.TrimSpace(memParts[1]))
+	}
+
+	netParts := strings.Split(raw.NetIO, " / ")
+	if len(netParts) == 2 {
+		stats.NetworkRx = parseBytes(strings.TrimSpace(netParts[0]))
+		stats.NetworkTx = parseBytes(strings.TrimSpace(netParts[1]))
+	}
+
+	blockParts := strings.Split(raw.BlockIO, " / ")
+	if len(blockParts) == 2 {
+		stats.BlockRead = parseBytes(strings.TrimSpace(blockParts[0]))
+		stats.BlockWrite = parseBytes(strings.TrimSpace(blockParts[1]))
+	}
+
+	stats.PIDs, _ = strconv.Atoi(raw.PIDs)
+
+	return stats
+}
+
+func parsePercent(s string) float64 {
+	s = strings.TrimSuffix(s, "%")
+	val, _ := strconv.ParseFloat(s, 64)
+	return val
+}
+
+func parseBytes(s string) uint64 {
+	s = strings.ToUpper(s)
+	multiplier := uint64(1)
+
+	if strings.HasSuffix(s, "KIB") || strings.HasSuffix(s, "KB") {
+		multiplier = 1024
+		s = strings.TrimSuffix(strings.TrimSuffix(s, "KIB"), "KB")
+	} else if strings.HasSuffix(s, "MIB") || strings.HasSuffix(s, "MB") {
+		multiplier = 1024 * 1024
+		s = strings.TrimSuffix(strings.TrimSuffix(s, "MIB"), "MB")
+	} else if strings.HasSuffix(s, "GIB") || strings.HasSuffix(s, "GB") {
+		multiplier = 1024 * 1024 * 1024
+		s = strings.TrimSuffix(strings.TrimSuffix(s, "GIB"), "GB")
+	} else if strings.HasSuffix(s, "B") {
+		s = strings.TrimSuffix(s, "B")
+	}
+
+	val, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	return uint64(val * float64(multiplier))
+}

--- a/internal/system/stats.go
+++ b/internal/system/stats.go
@@ -1,0 +1,264 @@
+package system
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type SystemStats struct {
+	CPU     CPUStats     `json:"cpu"`
+	Memory  MemoryStats  `json:"memory"`
+	Disk    DiskStats    `json:"disk"`
+	Uptime  int64        `json:"uptime"`
+	LoadAvg LoadAverage  `json:"load_avg"`
+}
+
+type CPUStats struct {
+	UsagePercent float64 `json:"usage_percent"`
+	Cores        int     `json:"cores"`
+}
+
+type MemoryStats struct {
+	Total        uint64  `json:"total"`
+	Used         uint64  `json:"used"`
+	Free         uint64  `json:"free"`
+	Available    uint64  `json:"available"`
+	UsagePercent float64 `json:"usage_percent"`
+}
+
+type DiskStats struct {
+	Total        uint64  `json:"total"`
+	Used         uint64  `json:"used"`
+	Free         uint64  `json:"free"`
+	UsagePercent float64 `json:"usage_percent"`
+	MountPoint   string  `json:"mount_point"`
+}
+
+type LoadAverage struct {
+	Load1  float64 `json:"load1"`
+	Load5  float64 `json:"load5"`
+	Load15 float64 `json:"load15"`
+}
+
+var prevIdle, prevTotal uint64
+
+func GetSystemStats() (*SystemStats, error) {
+	stats := &SystemStats{}
+
+	cpu, err := getCPUStats()
+	if err == nil {
+		stats.CPU = *cpu
+	}
+
+	mem, err := getMemoryStats()
+	if err == nil {
+		stats.Memory = *mem
+	}
+
+	disk, err := getDiskStats("/")
+	if err == nil {
+		stats.Disk = *disk
+	}
+
+	uptime, err := getUptime()
+	if err == nil {
+		stats.Uptime = uptime
+	}
+
+	load, err := getLoadAverage()
+	if err == nil {
+		stats.LoadAvg = *load
+	}
+
+	return stats, nil
+}
+
+func getCPUStats() (*CPUStats, error) {
+	file, err := os.Open("/proc/stat")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	if scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "cpu ") {
+			fields := strings.Fields(line)
+			if len(fields) >= 5 {
+				var total, idle uint64
+				for i := 1; i < len(fields); i++ {
+					val, _ := strconv.ParseUint(fields[i], 10, 64)
+					total += val
+					if i == 4 {
+						idle = val
+					}
+				}
+
+				var cpuPercent float64
+				if prevTotal > 0 {
+					totalDelta := total - prevTotal
+					idleDelta := idle - prevIdle
+					if totalDelta > 0 {
+						cpuPercent = (1.0 - float64(idleDelta)/float64(totalDelta)) * 100
+					}
+				}
+
+				prevTotal = total
+				prevIdle = idle
+
+				cores := getCPUCores()
+				return &CPUStats{
+					UsagePercent: cpuPercent,
+					Cores:        cores,
+				}, nil
+			}
+		}
+	}
+
+	return &CPUStats{}, nil
+}
+
+func getCPUCores() int {
+	file, err := os.Open("/proc/cpuinfo")
+	if err != nil {
+		return 1
+	}
+	defer file.Close()
+
+	cores := 0
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		if strings.HasPrefix(scanner.Text(), "processor") {
+			cores++
+		}
+	}
+	if cores == 0 {
+		cores = 1
+	}
+	return cores
+}
+
+func getMemoryStats() (*MemoryStats, error) {
+	file, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	stats := &MemoryStats{}
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		key := strings.TrimSuffix(fields[0], ":")
+		value, _ := strconv.ParseUint(fields[1], 10, 64)
+		value *= 1024
+
+		switch key {
+		case "MemTotal":
+			stats.Total = value
+		case "MemFree":
+			stats.Free = value
+		case "MemAvailable":
+			stats.Available = value
+		}
+	}
+
+	stats.Used = stats.Total - stats.Available
+	if stats.Total > 0 {
+		stats.UsagePercent = float64(stats.Used) / float64(stats.Total) * 100
+	}
+
+	return stats, nil
+}
+
+func getDiskStats(path string) (*DiskStats, error) {
+	cmd := exec.Command("df", "-B1", path)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(string(output), "\n")
+	if len(lines) < 2 {
+		return &DiskStats{MountPoint: path}, nil
+	}
+
+	fields := strings.Fields(lines[1])
+	if len(fields) < 6 {
+		return &DiskStats{MountPoint: path}, nil
+	}
+
+	total, _ := strconv.ParseUint(fields[1], 10, 64)
+	used, _ := strconv.ParseUint(fields[2], 10, 64)
+	free, _ := strconv.ParseUint(fields[3], 10, 64)
+
+	var usagePercent float64
+	if total > 0 {
+		usagePercent = float64(used) / float64(total) * 100
+	}
+
+	return &DiskStats{
+		Total:        total,
+		Used:         used,
+		Free:         free,
+		UsagePercent: usagePercent,
+		MountPoint:   path,
+	}, nil
+}
+
+func getUptime() (int64, error) {
+	data, err := os.ReadFile("/proc/uptime")
+	if err != nil {
+		return 0, err
+	}
+
+	fields := strings.Fields(string(data))
+	if len(fields) < 1 {
+		return 0, nil
+	}
+
+	uptime, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return int64(uptime), nil
+}
+
+func getLoadAverage() (*LoadAverage, error) {
+	data, err := os.ReadFile("/proc/loadavg")
+	if err != nil {
+		return nil, err
+	}
+
+	fields := strings.Fields(string(data))
+	if len(fields) < 3 {
+		return &LoadAverage{}, nil
+	}
+
+	load1, _ := strconv.ParseFloat(fields[0], 64)
+	load5, _ := strconv.ParseFloat(fields[1], 64)
+	load15, _ := strconv.ParseFloat(fields[2], 64)
+
+	return &LoadAverage{
+		Load1:  load1,
+		Load5:  load5,
+		Load15: load15,
+	}, nil
+}
+
+func init() {
+	_, _ = getCPUStats()
+	time.Sleep(100 * time.Millisecond)
+}


### PR DESCRIPTION
- Add system stats package reading from /proc filesystem (CPU, memory, disk, uptime, load average)
- Add container stats API for deployment-level resource monitoring
- Use docker-compose project labels for reliable container discovery
- Include system stats in /stats endpoint response