### PR TITLE
fix: Certbot container webroot path and deployment cleanup

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -540,6 +540,8 @@ func (s *Server) updateDeploymentMetadata(c *gin.Context) {
 func (s *Server) deleteDeployment(c *gin.Context) {
 	name := c.Param("name")
 
+	_ = s.proxyOrchestrator.TeardownDeployment(name)
+
 	if err := s.manager.DeleteDeployment(name); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": err.Error(),

--- a/internal/ssl/manager.go
+++ b/internal/ssl/manager.go
@@ -16,10 +16,11 @@ import (
 )
 
 type Manager struct {
-	config    *config.CertbotConfig
-	certsPath string
-	webRoot   string
-	mu        sync.RWMutex
+	config           *config.CertbotConfig
+	certsPath        string
+	webRoot          string
+	containerWebRoot string
+	mu               sync.RWMutex
 }
 
 func NewManager(cfg *config.CertbotConfig, deploymentsPath string) *Manager {
@@ -33,10 +34,16 @@ func NewManager(cfg *config.CertbotConfig, deploymentsPath string) *Manager {
 		webRoot = filepath.Join(deploymentsPath, "nginx", "html")
 	}
 
+	containerWebRoot := cfg.ContainerWebrootPath
+	if containerWebRoot == "" {
+		containerWebRoot = "/var/www/certbot"
+	}
+
 	return &Manager{
-		config:    cfg,
-		certsPath: certsPath,
-		webRoot:   webRoot,
+		config:           cfg,
+		certsPath:        certsPath,
+		webRoot:          webRoot,
+		containerWebRoot: containerWebRoot,
 	}
 }
 
@@ -61,6 +68,12 @@ func (m *Manager) UpdateConfig(cfg *config.CertbotConfig, deploymentsPath string
 		webRoot = filepath.Join(deploymentsPath, "nginx", "html")
 	}
 	m.webRoot = webRoot
+
+	containerWebRoot := cfg.ContainerWebrootPath
+	if containerWebRoot == "" {
+		containerWebRoot = "/var/www/certbot"
+	}
+	m.containerWebRoot = containerWebRoot
 }
 
 func (m *Manager) RequestCertificate(domain string) (*CertificateResult, error) {
@@ -78,7 +91,7 @@ func (m *Manager) RequestCertificate(domain string) (*CertificateResult, error) 
 	certbotArgs := []string{
 		"certonly",
 		"--webroot",
-		"--webroot-path", m.webRoot,
+		"--webroot-path", m.containerWebRoot,
 		"--email", m.config.Email,
 		"--agree-tos",
 		"--no-eff-email",
@@ -115,7 +128,7 @@ func (m *Manager) getServiceExecConfig() *config.ServiceExecConfig {
 		RunOnRequest: true,
 		Volumes: []string{
 			certsDir + ":/etc/letsencrypt",
-			m.webRoot + ":/var/www/certbot",
+			m.webRoot + ":" + m.containerWebRoot,
 		},
 	}
 }

--- a/internal/ssl/manager_test.go
+++ b/internal/ssl/manager_test.go
@@ -80,31 +80,68 @@ func TestUpdateConfig_WebrootPath(t *testing.T) {
 	}
 }
 
-func TestGetServiceExecConfig_WebrootVolume(t *testing.T) {
+func TestContainerWebrootPath(t *testing.T) {
 	tests := []struct {
-		name            string
-		webrootPath     string
-		deploymentsPath string
-		expectedVolume  string
+		name                     string
+		containerWebrootPath     string
+		expectedContainerWebroot string
 	}{
 		{
-			name:            "configured webroot in volume mount",
-			webrootPath:     "/custom/webroot",
-			deploymentsPath: "/deployments",
-			expectedVolume:  "/custom/webroot:/var/www/certbot",
+			name:                     "uses configured container webroot",
+			containerWebrootPath:     "/custom/container/path",
+			expectedContainerWebroot: "/custom/container/path",
 		},
 		{
-			name:            "default webroot in volume mount",
-			webrootPath:     "",
-			deploymentsPath: "/deployments",
-			expectedVolume:  "/deployments/nginx/html:/var/www/certbot",
+			name:                     "uses default when not configured",
+			containerWebrootPath:     "",
+			expectedContainerWebroot: "/var/www/certbot",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.CertbotConfig{
-				WebrootPath: tt.webrootPath,
+				ContainerWebrootPath: tt.containerWebrootPath,
+			}
+
+			m := NewManager(cfg, "/deployments")
+
+			if m.containerWebRoot != tt.expectedContainerWebroot {
+				t.Errorf("containerWebRoot = %q, want %q", m.containerWebRoot, tt.expectedContainerWebroot)
+			}
+		})
+	}
+}
+
+func TestGetServiceExecConfig_WebrootVolume(t *testing.T) {
+	tests := []struct {
+		name                 string
+		webrootPath          string
+		containerWebrootPath string
+		deploymentsPath      string
+		expectedVolume       string
+	}{
+		{
+			name:                 "configured paths",
+			webrootPath:          "/custom/webroot",
+			containerWebrootPath: "/custom/container",
+			deploymentsPath:      "/deployments",
+			expectedVolume:       "/custom/webroot:/custom/container",
+		},
+		{
+			name:                 "default paths",
+			webrootPath:          "",
+			containerWebrootPath: "",
+			deploymentsPath:      "/deployments",
+			expectedVolume:       "/deployments/nginx/html:/var/www/certbot",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.CertbotConfig{
+				WebrootPath:          tt.webrootPath,
+				ContainerWebrootPath: tt.containerWebrootPath,
 			}
 
 			m := NewManager(cfg, tt.deploymentsPath)
@@ -112,7 +149,7 @@ func TestGetServiceExecConfig_WebrootVolume(t *testing.T) {
 
 			found := false
 			for _, vol := range execCfg.Volumes {
-				if strings.Contains(vol, ":/var/www/certbot") {
+				if strings.Contains(vol, m.containerWebRoot) {
 					if vol != tt.expectedVolume {
 						t.Errorf("volume = %q, want %q", vol, tt.expectedVolume)
 					}
@@ -122,7 +159,7 @@ func TestGetServiceExecConfig_WebrootVolume(t *testing.T) {
 			}
 
 			if !found {
-				t.Error("webroot volume mount not found in exec config")
+				t.Errorf("webroot volume mount not found, expected %q", tt.expectedVolume)
 			}
 		})
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,13 +50,14 @@ type NginxConfig struct {
 }
 
 type CertbotConfig struct {
-	Enabled     bool   `yaml:"enabled" json:"enabled"`
-	Image       string `yaml:"image" json:"image"`
-	Email       string `yaml:"email" json:"email"`
-	Staging     bool   `yaml:"staging" json:"staging"`
-	CertsPath   string `yaml:"certs_path" json:"certs_path"`
-	WebrootPath string `yaml:"webroot_path" json:"webroot_path"`
-	DNSProvider string `yaml:"dns_provider" json:"dns_provider"`
+	Enabled              bool   `yaml:"enabled" json:"enabled"`
+	Image                string `yaml:"image" json:"image"`
+	Email                string `yaml:"email" json:"email"`
+	Staging              bool   `yaml:"staging" json:"staging"`
+	CertsPath            string `yaml:"certs_path" json:"certs_path"`
+	WebrootPath          string `yaml:"webroot_path" json:"webroot_path"`
+	ContainerWebrootPath string `yaml:"container_webroot_path" json:"container_webroot_path"`
+	DNSProvider          string `yaml:"dns_provider" json:"dns_provider"`
 }
 
 type ServiceExecConfig struct {


### PR DESCRIPTION
- Add configurable container_webroot_path for certbot (default /var/www/certbot)
- Use container path for --webroot-path argument, not host path
- Delete virtual host config when deleting deployment
- Add tests for container webroot configuration