### PR TITLE
feat(docker): Improve compose file handling and add Nextcloud template

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -258,13 +258,14 @@ func (s *Server) getDeployment(c *gin.Context) {
 		return
 	}
 
-	composeContent, _ := s.manager.GetComposeFile(name)
+	composeContent, composeFilename, _ := s.manager.GetComposeFile(name)
 	proxyStatus := s.proxyOrchestrator.GetDeploymentProxyStatus(deployment)
 
 	c.JSON(http.StatusOK, gin.H{
-		"deployment":      deployment,
-		"compose_content": composeContent,
-		"proxy_status":    proxyStatus,
+		"deployment":       deployment,
+		"compose_content":  composeContent,
+		"compose_filename": composeFilename,
+		"proxy_status":     proxyStatus,
 	})
 }
 
@@ -671,7 +672,7 @@ func (s *Server) getDeploymentLogs(c *gin.Context) {
 func (s *Server) getDeploymentCompose(c *gin.Context) {
 	name := c.Param("name")
 
-	content, err := s.manager.GetComposeFile(name)
+	content, filename, err := s.manager.GetComposeFile(name)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{
 			"error": err.Error(),
@@ -680,8 +681,9 @@ func (s *Server) getDeploymentCompose(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"name":    name,
-		"content": content,
+		"name":     name,
+		"content":  content,
+		"filename": filename,
 	})
 }
 

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -41,8 +42,8 @@ func (c *ComposeExecutor) Stop(deploymentPath string) (string, error) {
 }
 
 func (c *ComposeExecutor) Restart(deploymentPath string) (string, error) {
-	// Stop then start to handle both existing and new containers
-	_, _ = c.runCompose(deploymentPath, "stop")
+	// Use down to properly remove containers before recreating
+	_, _ = c.runCompose(deploymentPath, "down", "--remove-orphans")
 	return c.runCompose(deploymentPath, "up", "-d", "--remove-orphans")
 }
 
@@ -82,27 +83,53 @@ func (c *ComposeExecutor) getProjectName(deploymentPath string) string {
 
 // readComposeProjectName reads the 'name:' attribute from the compose file
 func (c *ComposeExecutor) readComposeProjectName(deploymentPath string) string {
-	composeFiles := []string{
+	composePath := c.findComposeFile(deploymentPath)
+	if composePath == "" {
+		return ""
+	}
+
+	data, err := os.ReadFile(composePath)
+	if err != nil {
+		return ""
+	}
+
+	var compose struct {
+		Name string `yaml:"name"`
+	}
+	if err := yaml.Unmarshal(data, &compose); err == nil && compose.Name != "" {
+		return compose.Name
+	}
+	return ""
+}
+
+// findComposeFile finds any compose file in the deployment directory
+func (c *ComposeExecutor) findComposeFile(dirPath string) string {
+	standardNames := []string{
 		"docker-compose.yml",
 		"docker-compose.yaml",
 		"compose.yml",
 		"compose.yaml",
 	}
 
-	for _, filename := range composeFiles {
-		path := deploymentPath + "/" + filename
-		data, err := os.ReadFile(path)
-		if err != nil {
-			continue
-		}
-
-		var compose struct {
-			Name string `yaml:"name"`
-		}
-		if err := yaml.Unmarshal(data, &compose); err == nil && compose.Name != "" {
-			return compose.Name
+	for _, name := range standardNames {
+		path := dirPath + "/" + name
+		if _, err := os.Stat(path); err == nil {
+			return path
 		}
 	}
+
+	patterns := []string{
+		"*compose*.yml",
+		"*compose*.yaml",
+	}
+
+	for _, pattern := range patterns {
+		matches, _ := filepath.Glob(dirPath + "/" + pattern)
+		if len(matches) > 0 {
+			return matches[0]
+		}
+	}
+
 	return ""
 }
 
@@ -129,10 +156,15 @@ func (c *ComposeExecutor) runCompose(deploymentPath string, args ...string) (str
 		return "", fmt.Errorf("docker compose command not found")
 	}
 
+	composePath := c.findComposeFile(deploymentPath)
+	if composePath == "" {
+		return "", fmt.Errorf("no compose file found in %s", deploymentPath)
+	}
+
 	projectName := c.getProjectName(deploymentPath)
 
 	var baseArgs []string
-	baseArgs = append(baseArgs, "-p", projectName)
+	baseArgs = append(baseArgs, "-f", composePath, "-p", projectName)
 
 	envFile := deploymentPath + "/.env.flatrun"
 	if _, err := os.Stat(envFile); err == nil {

--- a/internal/docker/discovery.go
+++ b/internal/docker/discovery.go
@@ -137,17 +137,31 @@ func (d *Discovery) GetDeployment(name string) (*models.Deployment, error) {
 }
 
 func (d *Discovery) findComposeFile(dirPath string) string {
-	candidates := []string{
+	// First check exact standard names (preferred)
+	standardNames := []string{
 		"docker-compose.yml",
 		"docker-compose.yaml",
 		"compose.yml",
 		"compose.yaml",
 	}
 
-	for _, candidate := range candidates {
-		path := filepath.Join(dirPath, candidate)
+	for _, name := range standardNames {
+		path := filepath.Join(dirPath, name)
 		if _, err := os.Stat(path); err == nil {
 			return path
+		}
+	}
+
+	// Fallback to pattern matching for *compose*.yml/yaml files
+	patterns := []string{
+		"*compose*.yml",
+		"*compose*.yaml",
+	}
+
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(filepath.Join(dirPath, pattern))
+		if err == nil && len(matches) > 0 {
+			return matches[0]
 		}
 	}
 
@@ -263,20 +277,21 @@ func (d *Discovery) DeleteDeployment(name string) error {
 	return os.RemoveAll(dirPath)
 }
 
-func (d *Discovery) GetComposeFile(name string) (string, error) {
+func (d *Discovery) GetComposeFile(name string) (string, string, error) {
 	dirPath := filepath.Join(d.basePath, name)
 	composePath := d.findComposeFile(dirPath)
 
 	if composePath == "" {
-		return "", os.ErrNotExist
+		return "", "", os.ErrNotExist
 	}
 
 	data, err := os.ReadFile(composePath)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	return string(data), nil
+	filename := filepath.Base(composePath)
+	return string(data), filename, nil
 }
 
 func (d *Discovery) UpdateComposeFile(name string, content string) error {

--- a/internal/docker/manager.go
+++ b/internal/docker/manager.go
@@ -180,7 +180,7 @@ func (m *Manager) UpdateDeployment(name string, composeContent string) error {
 	return m.discovery.UpdateComposeFile(name, composeContent)
 }
 
-func (m *Manager) GetComposeFile(name string) (string, error) {
+func (m *Manager) GetComposeFile(name string) (string, string, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 

--- a/templates/astro/metadata.yml
+++ b/templates/astro/metadata.yml
@@ -1,7 +1,7 @@
 name: Astro
 description: The web framework for content-driven websites
 icon: pi pi-star
-logo: https://astro.build/assets/press/astro-icon-light-gradient.svg
+logo: https://cdn.simpleicons.org/astro
 category: framework
 priority: 50
 container_port: 4321

--- a/templates/ghost/metadata.yml
+++ b/templates/ghost/metadata.yml
@@ -1,7 +1,7 @@
 name: Ghost
 description: Professional publishing platform
 icon: pi pi-book
-logo: https://ghost.org/images/logos/ghost-logo-orb.png
+logo: https://cdn.simpleicons.org/ghost
 category: application
 priority: 70
 container_port: 2368

--- a/templates/infra/mariadb/metadata.yml
+++ b/templates/infra/mariadb/metadata.yml
@@ -1,7 +1,7 @@
 name: MariaDB
 description: Community-developed fork of MySQL
 icon: pi pi-database
-logo: https://mariadb.com/wp-content/uploads/2019/11/mariadb-logo_blue-transparent.png
+logo: https://cdn.simpleicons.org/mariadb
 category: database
 type: infrastructure
 priority: 85

--- a/templates/infra/mysql/metadata.yml
+++ b/templates/infra/mysql/metadata.yml
@@ -1,7 +1,7 @@
 name: MySQL
 description: Popular open-source relational database
 icon: pi pi-database
-logo: https://www.mysql.com/common/logos/logo-mysql-170x115.png
+logo: https://cdn.simpleicons.org/mysql
 category: database
 type: infrastructure
 priority: 90

--- a/templates/infra/nginx/metadata.yml
+++ b/templates/infra/nginx/metadata.yml
@@ -1,7 +1,7 @@
 name: Nginx
 description: High-performance HTTP server and reverse proxy
 icon: pi pi-server
-logo: https://nginx.org/nginx.png
+logo: https://cdn.simpleicons.org/nginx
 category: infrastructure
 type: infrastructure
 priority: 100

--- a/templates/infra/postgres/metadata.yml
+++ b/templates/infra/postgres/metadata.yml
@@ -1,7 +1,7 @@
 name: PostgreSQL
 description: Advanced open-source relational database
 icon: pi pi-database
-logo: https://www.postgresql.org/media/img/about/press/elephant.png
+logo: https://cdn.simpleicons.org/postgresql
 category: database
 type: infrastructure
 priority: 80

--- a/templates/infra/redis/metadata.yml
+++ b/templates/infra/redis/metadata.yml
@@ -1,7 +1,7 @@
 name: Redis
 description: In-memory data structure store
 icon: pi pi-bolt
-logo: https://redis.io/images/redis-white.png
+logo: https://cdn.simpleicons.org/redis
 category: infrastructure
 type: infrastructure
 priority: 75

--- a/templates/laravel/metadata.yml
+++ b/templates/laravel/metadata.yml
@@ -1,7 +1,7 @@
 name: Laravel
 description: PHP framework for web artisans
 icon: pi pi-code
-logo: https://laravel.com/img/logomark.min.svg
+logo: https://cdn.simpleicons.org/laravel
 category: framework
 priority: 80
 container_port: 8000

--- a/templates/nextcloud/docker-compose.yml
+++ b/templates/nextcloud/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  app:
+    image: nextcloud:latest
+    restart: unless-stopped
+    ports:
+      - "${PORT:-8080}:80"
+    volumes:
+      - nextcloud_data:/var/www/html/data
+      - nextcloud_config:/var/www/html/config
+      - nextcloud_apps:/var/www/html/custom_apps
+    environment:
+      - MYSQL_HOST=${DB_HOST:-db}
+      - MYSQL_DATABASE=${DB_DATABASE:-nextcloud}
+      - MYSQL_USER=${DB_USERNAME:-nextcloud}
+      - MYSQL_PASSWORD=${DB_PASSWORD:-nextcloud}
+      - NEXTCLOUD_ADMIN_USER=${ADMIN_USER:-admin}
+      - NEXTCLOUD_ADMIN_PASSWORD=${ADMIN_PASSWORD:-admin}
+      - NEXTCLOUD_TRUSTED_DOMAINS=${TRUSTED_DOMAINS:-localhost}
+    networks:
+      - default
+      - database
+
+volumes:
+  nextcloud_data:
+  nextcloud_config:
+  nextcloud_apps:
+
+networks:
+  database:
+    external: true

--- a/templates/nextcloud/metadata.yml
+++ b/templates/nextcloud/metadata.yml
@@ -1,0 +1,26 @@
+name: Nextcloud
+description: Self-hosted productivity platform
+icon: pi pi-cloud
+logo: https://cdn.simpleicons.org/nextcloud
+category: application
+priority: 85
+container_port: 80
+mounts:
+  - id: data
+    name: User Data
+    container_path: /var/www/html/data
+    description: User files and data storage
+    type: volume
+    required: true
+  - id: config
+    name: Configuration
+    container_path: /var/www/html/config
+    description: Nextcloud configuration files
+    type: volume
+    required: true
+  - id: apps
+    name: Custom Apps
+    container_path: /var/www/html/custom_apps
+    description: Custom Nextcloud applications
+    type: volume
+    required: false

--- a/templates/nextjs/metadata.yml
+++ b/templates/nextjs/metadata.yml
@@ -1,7 +1,7 @@
 name: Next.js
 description: React framework for production
 icon: pi pi-globe
-logo: https://assets.vercel.com/image/upload/v1662130559/nextjs/Icon_dark_background.png
+logo: https://cdn.simpleicons.org/nextdotjs
 category: framework
 priority: 60
 container_port: 3000

--- a/templates/node/metadata.yml
+++ b/templates/node/metadata.yml
@@ -1,7 +1,7 @@
 name: Node.js
 description: JavaScript runtime for web applications
 icon: pi pi-code
-logo: https://nodejs.org/static/logos/nodejsLight.svg
+logo: https://cdn.simpleicons.org/nodedotjs
 category: runtime
 priority: 40
 container_port: 3000

--- a/templates/php/metadata.yml
+++ b/templates/php/metadata.yml
@@ -1,7 +1,7 @@
 name: PHP
 description: PHP with Apache web server
 icon: pi pi-code
-logo: https://www.php.net/images/logos/new-php-logo.svg
+logo: https://cdn.simpleicons.org/php
 category: runtime
 priority: 30
 container_port: 80

--- a/templates/static/metadata.yml
+++ b/templates/static/metadata.yml
@@ -1,7 +1,7 @@
 name: Static Site
 description: Simple static HTML/CSS/JS site
 icon: pi pi-file
-logo: https://cdn-icons-png.flaticon.com/512/888/888859.png
+logo: https://cdn.simpleicons.org/html5
 category: basic
 priority: 100
 container_port: 80

--- a/templates/wordpress/metadata.yml
+++ b/templates/wordpress/metadata.yml
@@ -1,7 +1,7 @@
 name: WordPress
 description: Popular content management system
 icon: pi pi-globe
-logo: https://s.w.org/style/images/about/WordPress-logotype-wmark.png
+logo: https://cdn.simpleicons.org/wordpress
 category: application
 priority: 100
 container_port: 80


### PR DESCRIPTION
Compose file detection:
- Add flexible pattern matching (*compose*.yml/yaml)
- Explicitly pass compose file with -f flag for non-standard names
- Return compose filename in API response for UI display

Fixes:
- Use down instead of stop in restart to avoid container name conflicts

Templates:
- Add Nextcloud template with docker-compose and metadata
- Update all template logos to use Simple Icons CDN