### PR TITLE
feat: Implement mount injection for stateless deployments

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1435,14 +1435,14 @@ func (s *Server) generateComposeWithOptions(templateID string, opts *ComposeGene
 	content = strings.ReplaceAll(content, "${PROXY_NETWORK}", networkName)
 	content = replaceHardcodedNetwork(content, "proxy", networkName)
 
-	if opts.MapPorts && opts.HostPort != "" {
-		var metadata TemplateMetadata
-		metadataPath := filepath.Join(templatesDir, templateID, "metadata.yml")
-		metadataContent, err := os.ReadFile(metadataPath)
-		if err == nil {
-			_ = yaml.Unmarshal(metadataContent, &metadata)
-		}
+	var metadata TemplateMetadata
+	metadataPath := filepath.Join(templatesDir, templateID, "metadata.yml")
+	metadataContent, err := os.ReadFile(metadataPath)
+	if err == nil {
+		_ = yaml.Unmarshal(metadataContent, &metadata)
+	}
 
+	if opts.MapPorts && opts.HostPort != "" {
 		containerPort := opts.ContainerPort
 		if containerPort == 0 && metadata.ContainerPort > 0 {
 			containerPort = metadata.ContainerPort
@@ -1457,7 +1457,89 @@ func (s *Server) generateComposeWithOptions(templateID string, opts *ComposeGene
 		content = re.ReplaceAllString(content, portMapping)
 	}
 
+	if len(opts.Mounts) > 0 && len(metadata.Mounts) > 0 {
+		content = s.injectMounts(content, opts.Mounts, metadata.Mounts)
+	}
+
 	return content, nil
+}
+
+func (s *Server) injectMounts(content string, selections []MountSelection, available []TemplateMount) string {
+	mountMap := make(map[string]TemplateMount)
+	for _, m := range available {
+		mountMap[m.ID] = m
+	}
+
+	var newVolumes []string
+	for _, sel := range selections {
+		if !sel.Enabled {
+			continue
+		}
+		mount, ok := mountMap[sel.ID]
+		if !ok {
+			continue
+		}
+
+		var hostPath string
+		if sel.Type == "volume" {
+			hostPath = sel.ID + "_data"
+		} else {
+			hostPath = "./" + sel.ID
+		}
+		newVolumes = append(newVolumes, fmt.Sprintf("%s:%s", hostPath, mount.ContainerPath))
+	}
+
+	if len(newVolumes) == 0 {
+		return content
+	}
+
+	var compose map[string]interface{}
+	if err := yaml.Unmarshal([]byte(content), &compose); err != nil {
+		return content
+	}
+
+	services, ok := compose["services"].(map[string]interface{})
+	if !ok {
+		return content
+	}
+
+	for serviceName, serviceData := range services {
+		service, ok := serviceData.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		existingVolumes := make(map[string]bool)
+		var volumesList []string
+
+		if v, ok := service["volumes"].([]interface{}); ok {
+			for _, vol := range v {
+				if vs, ok := vol.(string); ok {
+					existingVolumes[vs] = true
+					volumesList = append(volumesList, vs)
+				}
+			}
+		}
+
+		for _, vol := range newVolumes {
+			if !existingVolumes[vol] {
+				volumesList = append(volumesList, vol)
+			}
+		}
+
+		service["volumes"] = volumesList
+		services[serviceName] = service
+		break
+	}
+
+	compose["services"] = services
+
+	result, err := yaml.Marshal(compose)
+	if err != nil {
+		return content
+	}
+
+	return string(result)
 }
 
 func (s *Server) generateCustomCompose(opts *ComposeGenerateRequest) (string, error) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -369,3 +369,403 @@ func TestGenerateComposeWithOptionsCustomTemplate(t *testing.T) {
 		t.Error("Result should contain deployment name")
 	}
 }
+
+func TestInjectMounts(t *testing.T) {
+	cfg := &config.Config{}
+	s := &Server{config: cfg}
+
+	availableMounts := []TemplateMount{
+		{ID: "app", Name: "Application", ContainerPath: "/app", Type: "file"},
+		{ID: "data", Name: "Data", ContainerPath: "/var/data", Type: "volume"},
+		{ID: "config", Name: "Config", ContainerPath: "/etc/config", Type: "file"},
+	}
+
+	tests := []struct {
+		name           string
+		composeContent string
+		selections     []MountSelection
+		wantVolumes    []string
+		dontWant       []string
+	}{
+		{
+			name: "injects single bind mount",
+			composeContent: `name: test
+services:
+  app:
+    image: nginx
+    expose:
+      - "80"
+`,
+			selections: []MountSelection{
+				{ID: "app", Enabled: true, Type: "file"},
+			},
+			wantVolumes: []string{"./app:/app"},
+		},
+		{
+			name: "injects named volume",
+			composeContent: `name: test
+services:
+  app:
+    image: nginx
+`,
+			selections: []MountSelection{
+				{ID: "data", Enabled: true, Type: "volume"},
+			},
+			wantVolumes: []string{"data_data:/var/data"},
+		},
+		{
+			name: "injects multiple mounts",
+			composeContent: `name: test
+services:
+  app:
+    image: nginx
+`,
+			selections: []MountSelection{
+				{ID: "app", Enabled: true, Type: "file"},
+				{ID: "config", Enabled: true, Type: "file"},
+			},
+			wantVolumes: []string{"./app:/app", "./config:/etc/config"},
+		},
+		{
+			name: "skips disabled mounts",
+			composeContent: `name: test
+services:
+  app:
+    image: nginx
+`,
+			selections: []MountSelection{
+				{ID: "app", Enabled: true, Type: "file"},
+				{ID: "data", Enabled: false, Type: "volume"},
+			},
+			wantVolumes: []string{"./app:/app"},
+			dontWant:    []string{"data_data:/var/data"},
+		},
+		{
+			name: "preserves existing volumes and adds new ones",
+			composeContent: `name: test
+services:
+  app:
+    image: nginx
+    volumes:
+      - ./existing:/existing
+`,
+			selections: []MountSelection{
+				{ID: "app", Enabled: true, Type: "file"},
+			},
+			wantVolumes: []string{"./existing:/existing", "./app:/app"},
+		},
+		{
+			name: "no injection when all mounts disabled",
+			composeContent: `name: test
+services:
+  app:
+    image: nginx
+    volumes:
+      - ./existing:/existing
+`,
+			selections: []MountSelection{
+				{ID: "app", Enabled: false, Type: "file"},
+				{ID: "data", Enabled: false, Type: "volume"},
+			},
+			wantVolumes: []string{"./existing:/existing"},
+			dontWant:    []string{"./app:/app", "data_data:/var/data"},
+		},
+		{
+			name: "handles unknown mount ID gracefully",
+			composeContent: `name: test
+services:
+  app:
+    image: nginx
+`,
+			selections: []MountSelection{
+				{ID: "unknown", Enabled: true, Type: "file"},
+				{ID: "app", Enabled: true, Type: "file"},
+			},
+			wantVolumes: []string{"./app:/app"},
+			dontWant:    []string{"unknown"},
+		},
+		{
+			name: "empty selections returns original content",
+			composeContent: `name: test
+services:
+  app:
+    image: nginx
+`,
+			selections:  []MountSelection{},
+			wantVolumes: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.injectMounts(tt.composeContent, tt.selections, availableMounts)
+
+			for _, want := range tt.wantVolumes {
+				if !strings.Contains(result, want) {
+					t.Errorf("expected volume %q in result:\n%s", want, result)
+				}
+			}
+
+			for _, dontWant := range tt.dontWant {
+				if strings.Contains(result, dontWant) {
+					t.Errorf("unexpected volume %q in result:\n%s", dontWant, result)
+				}
+			}
+		})
+	}
+}
+
+func TestInjectMountsNoDuplicates(t *testing.T) {
+	cfg := &config.Config{}
+	s := &Server{config: cfg}
+
+	availableMounts := []TemplateMount{
+		{ID: "app", Name: "Application", ContainerPath: "/app", Type: "file"},
+	}
+
+	composeContent := `name: test
+services:
+  app:
+    image: nginx
+    volumes:
+      - ./app:/app
+`
+	selections := []MountSelection{
+		{ID: "app", Enabled: true, Type: "file"},
+	}
+
+	result := s.injectMounts(composeContent, selections, availableMounts)
+
+	count := strings.Count(result, "./app:/app")
+	if count > 1 {
+		t.Errorf("expected no duplicate mounts, found %d occurrences of './app:/app':\n%s", count, result)
+	}
+}
+
+func TestInjectMountsPreservesYAMLStructure(t *testing.T) {
+	cfg := &config.Config{}
+	s := &Server{config: cfg}
+
+	availableMounts := []TemplateMount{
+		{ID: "app", Name: "Application", ContainerPath: "/app", Type: "file"},
+	}
+
+	composeContent := `name: test
+services:
+  app:
+    image: nginx
+    environment:
+      - FOO=bar
+    expose:
+      - "80"
+    networks:
+      - proxy
+networks:
+  proxy:
+    external: true
+`
+	selections := []MountSelection{
+		{ID: "app", Enabled: true, Type: "file"},
+	}
+
+	result := s.injectMounts(composeContent, selections, availableMounts)
+
+	if !strings.Contains(result, "environment") {
+		t.Error("environment section should be preserved")
+	}
+	if !strings.Contains(result, "FOO") {
+		t.Error("environment variables should be preserved")
+	}
+	if !strings.Contains(result, "networks") {
+		t.Error("networks section should be preserved")
+	}
+	if !strings.Contains(result, "external: true") {
+		t.Error("network external flag should be preserved")
+	}
+	if !strings.Contains(result, "./app:/app") {
+		t.Error("volume should be injected")
+	}
+}
+
+func TestInjectMountsInvalidYAML(t *testing.T) {
+	cfg := &config.Config{}
+	s := &Server{config: cfg}
+
+	availableMounts := []TemplateMount{
+		{ID: "app", Name: "Application", ContainerPath: "/app", Type: "file"},
+	}
+
+	invalidContent := `this is not valid yaml: {{{`
+	selections := []MountSelection{
+		{ID: "app", Enabled: true, Type: "file"},
+	}
+
+	result := s.injectMounts(invalidContent, selections, availableMounts)
+
+	if result != invalidContent {
+		t.Error("invalid YAML should return original content unchanged")
+	}
+}
+
+func TestInjectMountsNoServicesSection(t *testing.T) {
+	cfg := &config.Config{}
+	s := &Server{config: cfg}
+
+	availableMounts := []TemplateMount{
+		{ID: "app", Name: "Application", ContainerPath: "/app", Type: "file"},
+	}
+
+	contentWithoutServices := `name: test
+networks:
+  proxy:
+    external: true
+`
+	selections := []MountSelection{
+		{ID: "app", Enabled: true, Type: "file"},
+	}
+
+	result := s.injectMounts(contentWithoutServices, selections, availableMounts)
+
+	if result != contentWithoutServices {
+		t.Error("content without services should return original content unchanged")
+	}
+}
+
+func TestGenerateComposeWithMountInjection(t *testing.T) {
+	cfg := &config.Config{
+		DeploymentsPath: t.TempDir(),
+		Infrastructure: config.InfrastructureConfig{
+			DefaultProxyNetwork: "proxy",
+		},
+	}
+	s := &Server{config: cfg}
+
+	templateDir := cfg.DeploymentsPath + "/.flatrun/templates/test-app"
+	if err := createDir(templateDir); err != nil {
+		t.Fatalf("failed to create template dir: %v", err)
+	}
+
+	composeContent := `name: ${NAME}
+services:
+  app:
+    image: node:20-alpine
+    container_name: ${NAME}
+    expose:
+      - "3000"
+    networks:
+      - proxy
+
+networks:
+  proxy:
+    external: true
+`
+	if err := writeFile(templateDir+"/docker-compose.yml", composeContent); err != nil {
+		t.Fatalf("failed to write compose: %v", err)
+	}
+
+	metadata := `name: Test App
+container_port: 3000
+mounts:
+  - id: app
+    name: Application
+    container_path: /app
+    type: file
+  - id: data
+    name: Data Storage
+    container_path: /var/data
+    type: volume
+`
+	if err := writeFile(templateDir+"/metadata.yml", metadata); err != nil {
+		t.Fatalf("failed to write metadata: %v", err)
+	}
+
+	opts := &ComposeGenerateRequest{
+		Name:          "my-node-app",
+		ContainerPort: 3000,
+		Mounts: []MountSelection{
+			{ID: "app", Enabled: true, Type: "file"},
+			{ID: "data", Enabled: true, Type: "volume"},
+		},
+	}
+
+	result, err := s.generateComposeWithOptions("test-app", opts)
+	if err != nil {
+		t.Fatalf("generateComposeWithOptions failed: %v", err)
+	}
+
+	if !strings.Contains(result, "my-node-app") {
+		t.Error("Result should contain deployment name")
+	}
+	if !strings.Contains(result, "./app:/app") {
+		t.Error("Result should contain bind mount for app")
+	}
+	if !strings.Contains(result, "data_data:/var/data") {
+		t.Error("Result should contain named volume for data")
+	}
+}
+
+func TestGenerateComposeWithNoMountsSelected(t *testing.T) {
+	cfg := &config.Config{
+		DeploymentsPath: t.TempDir(),
+		Infrastructure: config.InfrastructureConfig{
+			DefaultProxyNetwork: "proxy",
+		},
+	}
+	s := &Server{config: cfg}
+
+	templateDir := cfg.DeploymentsPath + "/.flatrun/templates/stateless-app"
+	if err := createDir(templateDir); err != nil {
+		t.Fatalf("failed to create template dir: %v", err)
+	}
+
+	composeContent := `name: ${NAME}
+services:
+  app:
+    image: nginx:alpine
+    container_name: ${NAME}
+    expose:
+      - "80"
+    networks:
+      - proxy
+
+networks:
+  proxy:
+    external: true
+`
+	if err := writeFile(templateDir+"/docker-compose.yml", composeContent); err != nil {
+		t.Fatalf("failed to write compose: %v", err)
+	}
+
+	metadata := `name: Stateless App
+container_port: 80
+mounts:
+  - id: html
+    name: HTML Content
+    container_path: /usr/share/nginx/html
+    type: file
+    required: false
+`
+	if err := writeFile(templateDir+"/metadata.yml", metadata); err != nil {
+		t.Fatalf("failed to write metadata: %v", err)
+	}
+
+	opts := &ComposeGenerateRequest{
+		Name:          "my-stateless-app",
+		ContainerPort: 80,
+		Mounts: []MountSelection{
+			{ID: "html", Enabled: false, Type: "file"},
+		},
+	}
+
+	result, err := s.generateComposeWithOptions("stateless-app", opts)
+	if err != nil {
+		t.Fatalf("generateComposeWithOptions failed: %v", err)
+	}
+
+	if strings.Contains(result, "volumes:") {
+		t.Error("Result should not contain volumes section when all mounts disabled")
+	}
+	if strings.Contains(result, "./html") {
+		t.Error("Result should not contain disabled mount")
+	}
+}

--- a/templates/astro/docker-compose.yml
+++ b/templates/astro/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: node:20-alpine
     container_name: ${NAME}
     working_dir: /app
-    volumes:
-      - ./app:/app
     expose:
       - "4321"
     command: sh -c "npm install && npm run build && npm run preview -- --host"

--- a/templates/laravel/docker-compose.yml
+++ b/templates/laravel/docker-compose.yml
@@ -3,8 +3,6 @@ services:
   app:
     image: bitnami/laravel:latest
     container_name: ${NAME}
-    volumes:
-      - ./app:/app
     expose:
       - "8000"
     networks:

--- a/templates/nextjs/docker-compose.yml
+++ b/templates/nextjs/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: node:20-alpine
     container_name: ${NAME}
     working_dir: /app
-    volumes:
-      - ./app:/app
     expose:
       - "3000"
     command: sh -c "npm install && npm run build && npm start"

--- a/templates/node/docker-compose.yml
+++ b/templates/node/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     image: node:20-alpine
     container_name: ${NAME}
     working_dir: /app
-    volumes:
-      - ./app:/app
     expose:
       - "3000"
     command: npm start

--- a/templates/php/docker-compose.yml
+++ b/templates/php/docker-compose.yml
@@ -3,8 +3,6 @@ services:
   app:
     image: php:8.3-apache
     container_name: ${NAME}
-    volumes:
-      - ./html:/var/www/html
     expose:
       - "80"
     networks:


### PR DESCRIPTION
- Add injectMounts function to merge selected mounts into compose
- Update generateComposeWithOptions to apply mount selections
- Remove hardcoded volumes from source-code templates
- Keep essential volumes for stateful apps (ghost, nextcloud, wordpress)
- Add comprehensive tests for mount injection edge cases
- Prevent duplicate mounts when compose already has the volume