### PR TITLE
feat: Add compose YAML marshaler with natural key ordering

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -276,13 +278,14 @@ func (s *Server) getDeployment(c *gin.Context) {
 
 func (s *Server) createDeployment(c *gin.Context) {
 	var req struct {
-		Name              string                  `json:"name" binding:"required"`
-		ComposeContent    string                  `json:"compose_content"`
-		TemplateID        string                  `json:"template_id,omitempty"`
-		Metadata          *models.ServiceMetadata `json:"metadata,omitempty"`
-		EnvVars           []EnvVar                `json:"env_vars,omitempty"`
-		AutoStart         bool                    `json:"auto_start"`
-		UseSharedDatabase bool                    `json:"use_shared_database"`
+		Name                      string                  `json:"name" binding:"required"`
+		ComposeContent            string                  `json:"compose_content"`
+		TemplateID                string                  `json:"template_id,omitempty"`
+		Metadata                  *models.ServiceMetadata `json:"metadata,omitempty"`
+		EnvVars                   []EnvVar                `json:"env_vars,omitempty"`
+		AutoStart                 bool                    `json:"auto_start"`
+		UseSharedDatabase         bool                    `json:"use_shared_database"`
+		ExistingDatabaseContainer string                  `json:"existing_database_container,omitempty"`
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -310,7 +313,22 @@ func (s *Server) createDeployment(c *gin.Context) {
 		return
 	}
 
-	// Add database network to compose if using shared database
+	// Add proxy network if expose is enabled
+	proxyNetworkName := s.config.Infrastructure.DefaultProxyNetwork
+	if req.Metadata != nil && req.Metadata.Networking.Expose && proxyNetworkName != "" {
+		if err := s.networksManager.EnsureNetwork(proxyNetworkName); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to ensure proxy network exists: " + err.Error(),
+			})
+			return
+		}
+		req.ComposeContent = s.addProxyNetwork(req.ComposeContent)
+		if err := s.networksManager.EnsureContainerOnNetwork(proxyNetworkName, s.config.Nginx.ContainerName); err != nil {
+			log.Printf("Warning: failed to ensure nginx on network %s: %v", proxyNetworkName, err)
+		}
+	}
+
+	// Add shared database network if using shared database
 	if req.UseSharedDatabase && s.config.Infrastructure.Database.Enabled {
 		dbNetworkName := s.config.Infrastructure.DefaultDatabaseNetwork
 		if dbNetworkName == "" {
@@ -325,18 +343,9 @@ func (s *Server) createDeployment(c *gin.Context) {
 		req.ComposeContent = s.addDatabaseNetwork(req.ComposeContent)
 	}
 
-	networkName := s.config.Infrastructure.DefaultProxyNetwork
-	if err := s.networksManager.EnsureNetwork(networkName); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": "Failed to ensure network exists: " + err.Error(),
-		})
-		return
-	}
-
-	if req.Metadata != nil && req.Metadata.Networking.Expose {
-		if err := s.networksManager.EnsureContainerOnNetwork(networkName, s.config.Nginx.ContainerName); err != nil {
-			log.Printf("Warning: failed to ensure nginx on network %s: %v", networkName, err)
-		}
+	// Add existing database container's network
+	if req.ExistingDatabaseContainer != "" {
+		req.ComposeContent = s.addContainerNetwork(req.ComposeContent, req.ExistingDatabaseContainer)
 	}
 
 	if err := s.manager.CreateDeployment(req.Name, req.ComposeContent); err != nil {
@@ -1835,81 +1844,69 @@ func replaceHardcodedNetwork(content, oldNetwork, newNetwork string) string {
 	return strings.Join(result, "\n")
 }
 
-// addDatabaseNetwork adds the database network to a compose file so containers
-// can communicate with the shared database infrastructure
+// getContainerNetworks returns the networks a container is connected to
+func (s *Server) getContainerNetworks(containerName string) ([]string, error) {
+	cmd := exec.Command("docker", "inspect", "--format", "{{json .NetworkSettings.Networks}}", containerName)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var networks map[string]interface{}
+	if err := json.Unmarshal(output, &networks); err != nil {
+		return nil, err
+	}
+
+	var result []string
+	for name := range networks {
+		result = append(result, name)
+	}
+	return result, nil
+}
+
+// addDatabaseNetwork adds the configured shared database network to a compose file
 func (s *Server) addDatabaseNetwork(content string) string {
 	dbNetworkName := s.config.Infrastructure.DefaultDatabaseNetwork
 	if dbNetworkName == "" {
 		dbNetworkName = "database"
 	}
-
-	var compose map[string]interface{}
-	if err := yaml.Unmarshal([]byte(content), &compose); err != nil {
-		return content
-	}
-
-	// Get or create top-level networks section
-	networks, ok := compose["networks"].(map[string]interface{})
-	if !ok {
-		networks = make(map[string]interface{})
-		compose["networks"] = networks
-	}
-
-	// Add database network as external if not already present
-	if _, exists := networks[dbNetworkName]; !exists {
-		networks[dbNetworkName] = map[string]interface{}{
-			"external": true,
-		}
-	}
-
-	// Add database network to each service
-	services, ok := compose["services"].(map[string]interface{})
-	if ok {
-		for serviceName, serviceData := range services {
-			service, ok := serviceData.(map[string]interface{})
-			if !ok {
-				continue
-			}
-
-			// Get or create service networks
-			var serviceNetworks []interface{}
-			switch n := service["networks"].(type) {
-			case []interface{}:
-				serviceNetworks = n
-			case map[string]interface{}:
-				// Convert map format to list format
-				for netName := range n {
-					serviceNetworks = append(serviceNetworks, netName)
-				}
-			default:
-				serviceNetworks = []interface{}{}
-			}
-
-			// Check if database network already exists
-			hasDbNetwork := false
-			for _, net := range serviceNetworks {
-				if netStr, ok := net.(string); ok && netStr == dbNetworkName {
-					hasDbNetwork = true
-					break
-				}
-			}
-
-			// Add database network if not present
-			if !hasDbNetwork {
-				serviceNetworks = append(serviceNetworks, dbNetworkName)
-				service["networks"] = serviceNetworks
-				services[serviceName] = service
-			}
-		}
-	}
-
-	// Re-marshal
-	data, err := yaml.Marshal(compose)
+	result, err := docker.AddNetworkToCompose(content, dbNetworkName)
 	if err != nil {
 		return content
 	}
+	return result
+}
 
-	return string(data)
+// addProxyNetwork adds the configured proxy network to a compose file
+func (s *Server) addProxyNetwork(content string) string {
+	result, err := docker.AddNetworkToCompose(content, s.config.Infrastructure.DefaultProxyNetwork)
+	if err != nil {
+		return content
+	}
+	return result
+}
+
+// addContainerNetwork finds and adds the network of a specific container to a compose file
+func (s *Server) addContainerNetwork(content string, containerName string) string {
+	networks, err := s.getContainerNetworks(containerName)
+	if err != nil || len(networks) == 0 {
+		return content
+	}
+	// Add the first non-bridge network, or first network if all are bridge
+	for _, net := range networks {
+		if net != "bridge" && net != "host" && net != "none" {
+			result, err := docker.AddNetworkToCompose(content, net)
+			if err != nil {
+				return content
+			}
+			return result
+		}
+	}
+	result, err := docker.AddNetworkToCompose(content, networks[0])
+	if err != nil {
+		return content
+	}
+	return result
 }
 
 func (s *Server) processTemplateFiles(deploymentName, templateID string, envVars []EnvVar) {

--- a/internal/docker/compose_yaml.go
+++ b/internal/docker/compose_yaml.go
@@ -1,0 +1,239 @@
+package docker
+
+import (
+	"bytes"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var topLevelKeyOrder = []string{
+	"name",
+	"version",
+	"services",
+	"networks",
+	"volumes",
+	"configs",
+	"secrets",
+}
+
+var serviceKeyOrder = []string{
+	"image",
+	"build",
+	"container_name",
+	"command",
+	"entrypoint",
+	"working_dir",
+	"user",
+	"environment",
+	"env_file",
+	"ports",
+	"expose",
+	"volumes",
+	"networks",
+	"depends_on",
+	"links",
+	"healthcheck",
+	"restart",
+	"deploy",
+	"labels",
+	"logging",
+	"extra_hosts",
+	"dns",
+	"cap_add",
+	"cap_drop",
+	"privileged",
+	"security_opt",
+	"sysctls",
+	"ulimits",
+	"devices",
+	"tmpfs",
+	"tty",
+	"stdin_open",
+	"stop_signal",
+	"stop_grace_period",
+	"platform",
+	"pull_policy",
+	"profiles",
+	"extends",
+}
+
+func MarshalComposeYAML(compose map[string]interface{}) ([]byte, error) {
+	root := &yaml.Node{Kind: yaml.DocumentNode}
+	content := &yaml.Node{Kind: yaml.MappingNode}
+	root.Content = append(root.Content, content)
+
+	for _, key := range topLevelKeyOrder {
+		if val, exists := compose[key]; exists {
+			if key == "services" {
+				if services, ok := val.(map[string]interface{}); ok {
+					addServicesNode(content, services)
+					continue
+				}
+			}
+			addKeyValue(content, key, val)
+		}
+	}
+
+	for key, val := range compose {
+		if !contains(topLevelKeyOrder, key) {
+			addKeyValue(content, key, val)
+		}
+	}
+
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(root); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func addServicesNode(parent *yaml.Node, services map[string]interface{}) {
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: "services"}
+	valueNode := &yaml.Node{Kind: yaml.MappingNode}
+
+	var serviceNames []string
+	for name := range services {
+		serviceNames = append(serviceNames, name)
+	}
+
+	for _, name := range serviceNames {
+		serviceData := services[name]
+		service, ok := serviceData.(map[string]interface{})
+		if !ok {
+			addKeyValue(valueNode, name, serviceData)
+			continue
+		}
+
+		serviceKeyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: name}
+		serviceValueNode := &yaml.Node{Kind: yaml.MappingNode}
+
+		for _, key := range serviceKeyOrder {
+			if val, exists := service[key]; exists {
+				addKeyValue(serviceValueNode, key, val)
+			}
+		}
+
+		for key, val := range service {
+			if !contains(serviceKeyOrder, key) {
+				addKeyValue(serviceValueNode, key, val)
+			}
+		}
+
+		valueNode.Content = append(valueNode.Content, serviceKeyNode, serviceValueNode)
+	}
+
+	parent.Content = append(parent.Content, keyNode, valueNode)
+}
+
+func addKeyValue(parent *yaml.Node, key string, value interface{}) {
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: key}
+
+	var valueNode yaml.Node
+	if err := valueNode.Encode(value); err != nil {
+		return
+	}
+
+	parent.Content = append(parent.Content, keyNode, &valueNode)
+}
+
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+func ParseComposeYAML(content string) (map[string]interface{}, error) {
+	var compose map[string]interface{}
+	if err := yaml.Unmarshal([]byte(content), &compose); err != nil {
+		return nil, err
+	}
+	return compose, nil
+}
+
+func AddNetworkToCompose(content string, networkName string) (string, error) {
+	if networkName == "" {
+		return content, nil
+	}
+
+	compose, err := ParseComposeYAML(content)
+	if err != nil {
+		return content, err
+	}
+
+	networks, ok := compose["networks"].(map[string]interface{})
+	if !ok {
+		networks = make(map[string]interface{})
+		compose["networks"] = networks
+	}
+
+	referencedNetworks := make(map[string]bool)
+
+	services, ok := compose["services"].(map[string]interface{})
+	if ok {
+		for serviceName, serviceData := range services {
+			service, ok := serviceData.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			var serviceNetworks []string
+			switch n := service["networks"].(type) {
+			case []interface{}:
+				for _, net := range n {
+					if netStr, ok := net.(string); ok {
+						serviceNetworks = append(serviceNetworks, netStr)
+						referencedNetworks[netStr] = true
+					}
+				}
+			case map[string]interface{}:
+				for netName := range n {
+					serviceNetworks = append(serviceNetworks, netName)
+					referencedNetworks[netName] = true
+				}
+			}
+
+			hasNetwork := false
+			for _, net := range serviceNetworks {
+				if net == networkName {
+					hasNetwork = true
+					break
+				}
+			}
+
+			if !hasNetwork {
+				serviceNetworks = append(serviceNetworks, networkName)
+				networksList := make([]interface{}, len(serviceNetworks))
+				for i, n := range serviceNetworks {
+					networksList[i] = n
+				}
+				service["networks"] = networksList
+				services[serviceName] = service
+			}
+		}
+	}
+
+	if _, exists := networks[networkName]; !exists {
+		networks[networkName] = map[string]interface{}{
+			"external": true,
+		}
+	}
+
+	for netName := range referencedNetworks {
+		if _, exists := networks[netName]; !exists {
+			networks[netName] = map[string]interface{}{}
+		}
+	}
+
+	result, err := MarshalComposeYAML(compose)
+	if err != nil {
+		return content, err
+	}
+
+	return strings.TrimSpace(string(result)), nil
+}

--- a/internal/docker/compose_yaml_test.go
+++ b/internal/docker/compose_yaml_test.go
@@ -1,0 +1,505 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMarshalComposeYAML_KeyOrder(t *testing.T) {
+	compose := map[string]interface{}{
+		"volumes": map[string]interface{}{
+			"data": map[string]interface{}{},
+		},
+		"networks": map[string]interface{}{
+			"web": map[string]interface{}{},
+		},
+		"services": map[string]interface{}{
+			"app": map[string]interface{}{
+				"image": "nginx",
+			},
+		},
+		"name": "myproject",
+	}
+
+	result, err := MarshalComposeYAML(compose)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(result)
+
+	nameIdx := strings.Index(output, "name:")
+	servicesIdx := strings.Index(output, "services:")
+	networksIdx := strings.Index(output, "networks:")
+	volumesIdx := strings.Index(output, "volumes:")
+
+	if nameIdx == -1 || servicesIdx == -1 || networksIdx == -1 || volumesIdx == -1 {
+		t.Fatalf("missing expected keys in output:\n%s", output)
+	}
+
+	if nameIdx > servicesIdx {
+		t.Errorf("name should come before services")
+	}
+	if servicesIdx > networksIdx {
+		t.Errorf("services should come before networks")
+	}
+	if networksIdx > volumesIdx {
+		t.Errorf("networks should come before volumes")
+	}
+}
+
+func TestMarshalComposeYAML_ServiceKeyOrder(t *testing.T) {
+	compose := map[string]interface{}{
+		"services": map[string]interface{}{
+			"app": map[string]interface{}{
+				"networks":    []interface{}{"web"},
+				"volumes":     []interface{}{"/data:/data"},
+				"ports":       []interface{}{"80:80"},
+				"environment": map[string]interface{}{"FOO": "bar"},
+				"image":       "nginx",
+				"restart":     "always",
+			},
+		},
+	}
+
+	result, err := MarshalComposeYAML(compose)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(result)
+
+	imageIdx := strings.Index(output, "image:")
+	envIdx := strings.Index(output, "environment:")
+	portsIdx := strings.Index(output, "ports:")
+	volumesIdx := strings.Index(output, "volumes:")
+	networksIdx := strings.Index(output, "networks:")
+	restartIdx := strings.Index(output, "restart:")
+
+	if imageIdx > envIdx {
+		t.Errorf("image should come before environment")
+	}
+	if envIdx > portsIdx {
+		t.Errorf("environment should come before ports")
+	}
+	if portsIdx > volumesIdx {
+		t.Errorf("ports should come before volumes")
+	}
+	if volumesIdx > networksIdx {
+		t.Errorf("volumes should come before networks")
+	}
+	if networksIdx > restartIdx {
+		t.Errorf("networks should come before restart")
+	}
+}
+
+func TestMarshalComposeYAML_PreservesVersion(t *testing.T) {
+	compose := map[string]interface{}{
+		"version": "3.8",
+		"services": map[string]interface{}{
+			"app": map[string]interface{}{
+				"image": "nginx",
+			},
+		},
+	}
+
+	result, err := MarshalComposeYAML(compose)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(result)
+	if !strings.Contains(output, "version:") {
+		t.Errorf("version should be preserved if provided")
+	}
+
+	versionIdx := strings.Index(output, "version:")
+	servicesIdx := strings.Index(output, "services:")
+	if versionIdx > servicesIdx {
+		t.Errorf("version should come before services")
+	}
+}
+
+func TestAddNetworkToCompose_AddsNetwork(t *testing.T) {
+	input := `name: myapp
+services:
+  app:
+    image: nginx
+`
+	result, err := AddNetworkToCompose(input, "proxy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "networks:") {
+		t.Errorf("should add networks section")
+	}
+	if !strings.Contains(result, "proxy") {
+		t.Errorf("should add proxy network")
+	}
+	if !strings.Contains(result, "external: true") {
+		t.Errorf("should mark network as external")
+	}
+}
+
+func TestAddNetworkToCompose_NoDuplicates(t *testing.T) {
+	input := `name: myapp
+services:
+  app:
+    image: nginx
+    networks:
+      - proxy
+networks:
+  proxy:
+    external: true
+`
+	result, err := AddNetworkToCompose(input, "proxy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	count := strings.Count(result, "proxy")
+	if count != 2 {
+		t.Errorf("expected proxy to appear exactly 2 times (service + network definition), got %d", count)
+	}
+}
+
+func TestAddNetworkToCompose_PreservesUserNetworks(t *testing.T) {
+	input := `name: myapp
+services:
+  app:
+    image: nginx
+    networks:
+      - web
+networks:
+  web: {}
+`
+	result, err := AddNetworkToCompose(input, "proxy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "web") {
+		t.Errorf("should preserve user's web network")
+	}
+	if !strings.Contains(result, "proxy") {
+		t.Errorf("should add proxy network")
+	}
+}
+
+func TestAddNetworkToCompose_MultipleServices(t *testing.T) {
+	input := `name: myapp
+services:
+  app:
+    image: nginx
+  db:
+    image: mysql
+`
+	result, err := AddNetworkToCompose(input, "proxy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	proxyCount := strings.Count(result, "proxy")
+	if proxyCount < 3 {
+		t.Errorf("expected proxy to appear at least 3 times (2 services + 1 definition), got %d", proxyCount)
+	}
+}
+
+func TestAddNetworkToCompose_EmptyNetworkName(t *testing.T) {
+	input := `name: myapp
+services:
+  app:
+    image: nginx
+`
+	result, err := AddNetworkToCompose(input, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result != input {
+		t.Errorf("empty network name should return original content")
+	}
+}
+
+func TestAddNetworkToCompose_DefinesReferencedNetworks(t *testing.T) {
+	input := `name: myapp
+services:
+  app:
+    image: nginx
+    networks:
+      - custom
+`
+	result, err := AddNetworkToCompose(input, "proxy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "custom") {
+		t.Errorf("should preserve custom network reference")
+	}
+	if !strings.Contains(result, "proxy") {
+		t.Errorf("should add proxy network")
+	}
+}
+
+func TestAddNetworkToCompose_KeyOrder(t *testing.T) {
+	input := `name: myapp
+services:
+  app:
+    image: nginx
+`
+	result, err := AddNetworkToCompose(input, "proxy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	nameIdx := strings.Index(result, "name:")
+	servicesIdx := strings.Index(result, "services:")
+	networksIdx := strings.Index(result, "networks:")
+
+	if nameIdx == -1 || servicesIdx == -1 || networksIdx == -1 {
+		t.Fatalf("missing expected keys in output:\n%s", result)
+	}
+
+	if nameIdx > servicesIdx {
+		t.Errorf("name should come before services")
+	}
+	if servicesIdx > networksIdx {
+		t.Errorf("services should come before networks")
+	}
+}
+
+func TestAddNetworkToCompose_ComplexStructure(t *testing.T) {
+	input := `name: wordpress
+services:
+  app:
+    image: wordpress
+    environment:
+      DB_HOST: db
+    ports:
+      - "8080:80"
+    volumes:
+      - wp_data:/var/www/html
+    depends_on:
+      - db
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+    volumes:
+      - db_data:/var/lib/mysql
+volumes:
+  wp_data: {}
+  db_data: {}
+`
+	result, err := AddNetworkToCompose(input, "proxy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	requiredStrings := []string{
+		"name:",
+		"services:",
+		"app:",
+		"db:",
+		"image:",
+		"environment:",
+		"ports:",
+		"volumes:",
+		"depends_on:",
+		"networks:",
+		"proxy",
+		"wp_data:",
+		"db_data:",
+	}
+
+	for _, s := range requiredStrings {
+		if !strings.Contains(result, s) {
+			t.Errorf("missing required string %q in output:\n%s", s, result)
+		}
+	}
+}
+
+func TestParseComposeYAML(t *testing.T) {
+	input := `name: test
+services:
+  app:
+    image: nginx
+`
+	compose, err := ParseComposeYAML(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if compose["name"] != "test" {
+		t.Errorf("expected name to be 'test', got %v", compose["name"])
+	}
+
+	services, ok := compose["services"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected services to be a map")
+	}
+
+	app, ok := services["app"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected app to be a map")
+	}
+
+	if app["image"] != "nginx" {
+		t.Errorf("expected image to be 'nginx', got %v", app["image"])
+	}
+}
+
+func TestMarshalComposeYAML_NoVersion(t *testing.T) {
+	compose := map[string]interface{}{
+		"name": "myapp",
+		"services": map[string]interface{}{
+			"app": map[string]interface{}{
+				"image": "nginx",
+			},
+		},
+	}
+
+	result, err := MarshalComposeYAML(compose)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(result)
+	if strings.Contains(output, "version:") {
+		t.Errorf("should not add version if not provided")
+	}
+}
+
+func TestAddNetworkToCompose_MapStyleNetworks(t *testing.T) {
+	input := `name: myapp
+services:
+  app:
+    image: nginx
+    networks:
+      web:
+        aliases:
+          - myalias
+`
+	result, err := AddNetworkToCompose(input, "proxy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "proxy") {
+		t.Errorf("should add proxy network")
+	}
+	if !strings.Contains(result, "web") {
+		t.Errorf("should preserve web network")
+	}
+}
+
+func TestMarshalComposeYAML_WithSecrets(t *testing.T) {
+	compose := map[string]interface{}{
+		"name": "myapp",
+		"services": map[string]interface{}{
+			"app": map[string]interface{}{
+				"image": "nginx",
+			},
+		},
+		"secrets": map[string]interface{}{
+			"db_password": map[string]interface{}{
+				"file": "./secrets/db_password.txt",
+			},
+		},
+	}
+
+	result, err := MarshalComposeYAML(compose)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(result)
+	if !strings.Contains(output, "secrets:") {
+		t.Errorf("should preserve secrets section")
+	}
+
+	servicesIdx := strings.Index(output, "services:")
+	secretsIdx := strings.Index(output, "secrets:")
+	if servicesIdx > secretsIdx {
+		t.Errorf("services should come before secrets")
+	}
+}
+
+func TestMarshalComposeYAML_WithConfigs(t *testing.T) {
+	compose := map[string]interface{}{
+		"name": "myapp",
+		"services": map[string]interface{}{
+			"app": map[string]interface{}{
+				"image": "nginx",
+			},
+		},
+		"configs": map[string]interface{}{
+			"nginx_config": map[string]interface{}{
+				"file": "./nginx.conf",
+			},
+		},
+	}
+
+	result, err := MarshalComposeYAML(compose)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(result)
+	if !strings.Contains(output, "configs:") {
+		t.Errorf("should preserve configs section")
+	}
+
+	servicesIdx := strings.Index(output, "services:")
+	configsIdx := strings.Index(output, "configs:")
+	if servicesIdx > configsIdx {
+		t.Errorf("services should come before configs")
+	}
+}
+
+func TestMarshalComposeYAML_UnknownTopLevelKeys(t *testing.T) {
+	compose := map[string]interface{}{
+		"name": "myapp",
+		"services": map[string]interface{}{
+			"app": map[string]interface{}{
+				"image": "nginx",
+			},
+		},
+		"x-custom": map[string]interface{}{
+			"key": "value",
+		},
+	}
+
+	result, err := MarshalComposeYAML(compose)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(result)
+	if !strings.Contains(output, "x-custom:") {
+		t.Errorf("should preserve custom extension fields")
+	}
+}
+
+func TestMarshalComposeYAML_UnknownServiceKeys(t *testing.T) {
+	compose := map[string]interface{}{
+		"services": map[string]interface{}{
+			"app": map[string]interface{}{
+				"image":      "nginx",
+				"x-priority": 10,
+			},
+		},
+	}
+
+	result, err := MarshalComposeYAML(compose)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(result)
+	if !strings.Contains(output, "x-priority:") {
+		t.Errorf("should preserve custom service extension fields")
+	}
+}


### PR DESCRIPTION
- Create compose_yaml.go with MarshalComposeYAML for predictable output
- Maintain natural key order: name, services, networks, volumes, etc.
- Preserve service key ordering: image, environment, ports, volumes, etc.
- Move network injection logic to docker package
- Add comprehensive tests for compose structure and network handling