### PR TITLE
feat: Add SSL certificate deletion protection

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -138,6 +138,7 @@ func (s *Server) setupRoutes() {
 			protected.DELETE("/proxy/:name", s.teardownProxy)
 			protected.GET("/proxy/vhosts", s.listVirtualHosts)
 			protected.POST("/proxy/sync", s.syncAllProxies)
+			protected.POST("/deployments/:name/ssl/disable", s.disableSSL)
 
 			protected.GET("/settings", s.getSettings)
 			protected.PUT("/settings", s.updateSettings)
@@ -2005,6 +2006,17 @@ func (s *Server) renewCertificates(c *gin.Context) {
 
 func (s *Server) deleteCertificate(c *gin.Context) {
 	domain := c.Param("domain")
+	force := c.DefaultQuery("force", "false") == "true"
+
+	vhosts := s.proxyOrchestrator.NginxManager().GetVhostsUsingSSLDomain(domain)
+	if len(vhosts) > 0 && !force {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":  "Certificate is in use by virtual hosts",
+			"vhosts": vhosts,
+			"hint":   "Disable SSL for these deployments first, or use ?force=true to delete anyway",
+		})
+		return
+	}
 
 	if err := s.proxyOrchestrator.SSLManager().DeleteCertificate(domain); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -2074,6 +2086,58 @@ func (s *Server) teardownProxy(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"message": "Proxy removed",
+		"name":    name,
+	})
+}
+
+func (s *Server) disableSSL(c *gin.Context) {
+	name := c.Param("name")
+
+	deployment, err := s.manager.GetDeployment(name)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "Deployment not found",
+		})
+		return
+	}
+
+	if deployment.Metadata == nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Deployment has no metadata configured",
+		})
+		return
+	}
+
+	deployment.Metadata.SSL.Enabled = false
+	deployment.Metadata.SSL.AutoCert = false
+
+	if err := s.manager.SaveMetadata(name, deployment.Metadata); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to save metadata: " + err.Error(),
+		})
+		return
+	}
+
+	if err := s.proxyOrchestrator.NginxManager().UpdateVirtualHost(deployment); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to update virtual host: " + err.Error(),
+		})
+		return
+	}
+
+	if err := s.proxyOrchestrator.NginxManager().TestConfig(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Nginx config test failed: " + err.Error(),
+		})
+		return
+	}
+
+	if err := s.proxyOrchestrator.NginxManager().Reload(); err != nil {
+		log.Printf("Warning: failed to reload nginx: %v", err)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "SSL disabled for deployment",
 		"name":    name,
 	})
 }

--- a/internal/api/ssl_deletion_test.go
+++ b/internal/api/ssl_deletion_test.go
@@ -1,0 +1,191 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/flatrun/agent/internal/nginx"
+	"github.com/flatrun/agent/internal/proxy"
+	"github.com/flatrun/agent/internal/ssl"
+	"github.com/flatrun/agent/pkg/config"
+	"github.com/gin-gonic/gin"
+)
+
+func TestDeleteCertificate_BlockedWhenInUse(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "ssl-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	confDir := filepath.Join(tmpDir, "nginx", "conf.d")
+	if err := os.MkdirAll(confDir, 0755); err != nil {
+		t.Fatalf("failed to create conf.d: %v", err)
+	}
+
+	certsDir := filepath.Join(tmpDir, "certs", "live", "example.com")
+	if err := os.MkdirAll(certsDir, 0755); err != nil {
+		t.Fatalf("failed to create certs dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(certsDir, "cert.pem"), []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to create cert file: %v", err)
+	}
+
+	sslConfig := `server {
+    listen 443 ssl;
+    server_name example.com;
+    ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+}`
+	if err := os.WriteFile(filepath.Join(confDir, "my-app.conf"), []byte(sslConfig), 0644); err != nil {
+		t.Fatalf("failed to create ssl config: %v", err)
+	}
+
+	cfg := &config.Config{
+		DeploymentsPath: tmpDir,
+		Nginx:           config.NginxConfig{},
+		Certbot: config.CertbotConfig{
+			CertsPath: filepath.Join(tmpDir, "certs", "live"),
+		},
+	}
+
+	nginxMgr := nginx.NewManager(&cfg.Nginx, tmpDir, "")
+	sslMgr := ssl.NewManager(&cfg.Certbot, tmpDir)
+
+	orchestrator := proxy.NewOrchestratorWithManagers(nginxMgr, sslMgr)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	server := &Server{
+		config:            cfg,
+		proxyOrchestrator: orchestrator,
+	}
+
+	router.DELETE("/certificates/:domain", server.deleteCertificate)
+
+	req := httptest.NewRequest(http.MethodDelete, "/certificates/example.com", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected status 409, got %d", w.Code)
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+
+	if response["error"] != "Certificate is in use by virtual hosts" {
+		t.Errorf("unexpected error message: %v", response["error"])
+	}
+
+	vhosts, ok := response["vhosts"].([]interface{})
+	if !ok {
+		t.Fatalf("expected vhosts array in response")
+	}
+	if len(vhosts) != 1 {
+		t.Errorf("expected 1 vhost, got %d", len(vhosts))
+	}
+	if vhosts[0] != "my-app" {
+		t.Errorf("expected vhost 'my-app', got %v", vhosts[0])
+	}
+}
+
+func TestDeleteCertificate_NotBlockedWhenNotInUse(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "ssl-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	confDir := filepath.Join(tmpDir, "nginx", "conf.d")
+	if err := os.MkdirAll(confDir, 0755); err != nil {
+		t.Fatalf("failed to create conf.d: %v", err)
+	}
+
+	certsDir := filepath.Join(tmpDir, "certs", "live", "unused.com")
+	if err := os.MkdirAll(certsDir, 0755); err != nil {
+		t.Fatalf("failed to create certs dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(certsDir, "cert.pem"), []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to create cert file: %v", err)
+	}
+
+	httpConfig := `server {
+    listen 80;
+    server_name other.com;
+}`
+	if err := os.WriteFile(filepath.Join(confDir, "http-app.conf"), []byte(httpConfig), 0644); err != nil {
+		t.Fatalf("failed to create http config: %v", err)
+	}
+
+	cfg := &config.Config{
+		DeploymentsPath: tmpDir,
+		Nginx:           config.NginxConfig{},
+		Certbot: config.CertbotConfig{
+			CertsPath: filepath.Join(tmpDir, "certs", "live"),
+		},
+	}
+
+	nginxMgr := nginx.NewManager(&cfg.Nginx, tmpDir, "")
+
+	vhosts := nginxMgr.GetVhostsUsingSSLDomain("unused.com")
+	if len(vhosts) != 0 {
+		t.Errorf("expected no vhosts using unused.com, got %v", vhosts)
+	}
+}
+
+func TestDeleteCertificate_DetectsUsage(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "ssl-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	confDir := filepath.Join(tmpDir, "nginx", "conf.d")
+	if err := os.MkdirAll(confDir, 0755); err != nil {
+		t.Fatalf("failed to create conf.d: %v", err)
+	}
+
+	certsDir := filepath.Join(tmpDir, "certs", "live", "used.com")
+	if err := os.MkdirAll(certsDir, 0755); err != nil {
+		t.Fatalf("failed to create certs dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(certsDir, "cert.pem"), []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to create cert file: %v", err)
+	}
+
+	sslConfig := `server {
+    listen 443 ssl;
+    server_name used.com;
+    ssl_certificate /etc/letsencrypt/live/used.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/used.com/privkey.pem;
+}`
+	if err := os.WriteFile(filepath.Join(confDir, "ssl-app.conf"), []byte(sslConfig), 0644); err != nil {
+		t.Fatalf("failed to create ssl config: %v", err)
+	}
+
+	cfg := &config.Config{
+		DeploymentsPath: tmpDir,
+		Nginx:           config.NginxConfig{},
+		Certbot: config.CertbotConfig{
+			CertsPath: filepath.Join(tmpDir, "certs", "live"),
+		},
+	}
+
+	nginxMgr := nginx.NewManager(&cfg.Nginx, tmpDir, "")
+
+	vhosts := nginxMgr.GetVhostsUsingSSLDomain("used.com")
+	if len(vhosts) != 1 {
+		t.Errorf("expected 1 vhost using used.com, got %d", len(vhosts))
+	}
+	if len(vhosts) > 0 && vhosts[0] != "ssl-app" {
+		t.Errorf("expected vhost 'ssl-app', got %v", vhosts[0])
+	}
+}

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -177,6 +177,38 @@ func (m *Manager) ListVirtualHosts() ([]VirtualHostInfo, error) {
 	return hosts, nil
 }
 
+func (m *Manager) GetVhostsUsingSSLDomain(domain string) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var vhosts []string
+
+	entries, err := os.ReadDir(m.configPath)
+	if err != nil {
+		return vhosts
+	}
+
+	certPath := fmt.Sprintf("/etc/letsencrypt/live/%s/", domain)
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".conf") {
+			continue
+		}
+
+		configPath := filepath.Join(m.configPath, entry.Name())
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			continue
+		}
+
+		if strings.Contains(string(content), certPath) {
+			vhosts = append(vhosts, strings.TrimSuffix(entry.Name(), ".conf"))
+		}
+	}
+
+	return vhosts
+}
+
 func (m *Manager) Reload() error {
 	if m.config.ContainerName == "" {
 		return fmt.Errorf("nginx container name not configured")

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -373,3 +373,127 @@ func TestVirtualHostExists(t *testing.T) {
 		t.Error("VirtualHostExists should return false for non-existing config")
 	}
 }
+
+func TestGetVhostsUsingSSLDomain(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "nginx-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	confDir := filepath.Join(tmpDir, "nginx", "conf.d")
+	if err := os.MkdirAll(confDir, 0755); err != nil {
+		t.Fatalf("failed to create conf.d: %v", err)
+	}
+
+	sslConfig := `server {
+    listen 443 ssl;
+    server_name example.com;
+    ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+}`
+	if err := os.WriteFile(filepath.Join(confDir, "ssl-app.conf"), []byte(sslConfig), 0644); err != nil {
+		t.Fatalf("failed to create ssl config: %v", err)
+	}
+
+	httpConfig := `server {
+    listen 80;
+    server_name other.com;
+}`
+	if err := os.WriteFile(filepath.Join(confDir, "http-app.conf"), []byte(httpConfig), 0644); err != nil {
+		t.Fatalf("failed to create http config: %v", err)
+	}
+
+	cfg := &config.NginxConfig{}
+	m := NewManager(cfg, tmpDir, "")
+
+	vhosts := m.GetVhostsUsingSSLDomain("example.com")
+	if len(vhosts) != 1 {
+		t.Errorf("expected 1 vhost using example.com SSL, got %d", len(vhosts))
+	}
+	if len(vhosts) > 0 && vhosts[0] != "ssl-app" {
+		t.Errorf("expected vhost 'ssl-app', got %q", vhosts[0])
+	}
+
+	vhosts = m.GetVhostsUsingSSLDomain("other.com")
+	if len(vhosts) != 0 {
+		t.Errorf("expected 0 vhosts using other.com SSL, got %d", len(vhosts))
+	}
+
+	vhosts = m.GetVhostsUsingSSLDomain("nonexistent.com")
+	if len(vhosts) != 0 {
+		t.Errorf("expected 0 vhosts for nonexistent domain, got %d", len(vhosts))
+	}
+}
+
+func TestGetVhostsUsingSSLDomain_MultipleVhosts(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "nginx-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	confDir := filepath.Join(tmpDir, "nginx", "conf.d")
+	if err := os.MkdirAll(confDir, 0755); err != nil {
+		t.Fatalf("failed to create conf.d: %v", err)
+	}
+
+	sslConfig1 := `server {
+    listen 443 ssl;
+    server_name app1.example.com;
+    ssl_certificate /etc/letsencrypt/live/wildcard.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/wildcard.example.com/privkey.pem;
+}`
+	if err := os.WriteFile(filepath.Join(confDir, "app1.conf"), []byte(sslConfig1), 0644); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	sslConfig2 := `server {
+    listen 443 ssl;
+    server_name app2.example.com;
+    ssl_certificate /etc/letsencrypt/live/wildcard.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/wildcard.example.com/privkey.pem;
+}`
+	if err := os.WriteFile(filepath.Join(confDir, "app2.conf"), []byte(sslConfig2), 0644); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	cfg := &config.NginxConfig{}
+	m := NewManager(cfg, tmpDir, "")
+
+	vhosts := m.GetVhostsUsingSSLDomain("wildcard.example.com")
+	if len(vhosts) != 2 {
+		t.Errorf("expected 2 vhosts using wildcard cert, got %d", len(vhosts))
+	}
+}
+
+func TestGetVhostsUsingSSLDomain_EmptyDirectory(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "nginx-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	confDir := filepath.Join(tmpDir, "nginx", "conf.d")
+	if err := os.MkdirAll(confDir, 0755); err != nil {
+		t.Fatalf("failed to create conf.d: %v", err)
+	}
+
+	cfg := &config.NginxConfig{}
+	m := NewManager(cfg, tmpDir, "")
+
+	vhosts := m.GetVhostsUsingSSLDomain("example.com")
+	if len(vhosts) != 0 {
+		t.Errorf("expected 0 vhosts for empty directory, got %d", len(vhosts))
+	}
+}
+
+func TestGetVhostsUsingSSLDomain_NonExistentDirectory(t *testing.T) {
+	cfg := &config.NginxConfig{}
+	m := NewManager(cfg, "/nonexistent/path", "")
+
+	vhosts := m.GetVhostsUsingSSLDomain("example.com")
+	if len(vhosts) != 0 {
+		t.Errorf("expected 0 vhosts for nonexistent directory, got %d", len(vhosts))
+	}
+}

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -22,6 +22,13 @@ func NewOrchestrator(cfg *config.Config) *Orchestrator {
 	}
 }
 
+func NewOrchestratorWithManagers(nginxMgr *nginx.Manager, sslMgr *ssl.Manager) *Orchestrator {
+	return &Orchestrator{
+		nginx: nginxMgr,
+		ssl:   sslMgr,
+	}
+}
+
 func (o *Orchestrator) NginxManager() *nginx.Manager {
 	return o.nginx
 }


### PR DESCRIPTION
Prevent deletion of SSL certificates that are in use by nginx vhosts. Returns 409 Conflict with list of affected vhosts. Adds disable SSL endpoint for deployments and force deletion option as bypass.