### PR TITLE
feat(traffic): add deployment context to PathStats

### DIFF
--- a/internal/traffic/db.go
+++ b/internal/traffic/db.go
@@ -284,20 +284,20 @@ func (db *DB) GetStats(deploymentName string, since time.Duration) (*TrafficStat
 		}
 	}
 
-	// Top paths
+	// Top paths with deployment context
 	rows, err = db.conn.Query(`
-		SELECT request_path, COUNT(*) as cnt, AVG(response_time_ms) as avg_time,
+		SELECT deployment_name, request_path, COUNT(*) as cnt, AVG(response_time_ms) as avg_time,
 			SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END) as errors
 		FROM traffic_logs
 		WHERE created_at >= ?`+deploymentFilter+`
-		GROUP BY request_path
-		ORDER BY cnt DESC
+		GROUP BY deployment_name, request_path
+		ORDER BY avg_time DESC
 		LIMIT 10`, args...)
 	if err == nil {
 		defer rows.Close()
 		for rows.Next() {
 			var p PathStats
-			if err := rows.Scan(&p.Path, &p.RequestCount, &p.AvgTimeMs, &p.ErrorCount); err == nil {
+			if err := rows.Scan(&p.Deployment, &p.Path, &p.RequestCount, &p.AvgTimeMs, &p.ErrorCount); err == nil {
 				stats.TopPaths = append(stats.TopPaths, p)
 			}
 		}

--- a/internal/traffic/models.go
+++ b/internal/traffic/models.go
@@ -44,6 +44,7 @@ type TrafficStats struct {
 
 type PathStats struct {
 	Path         string  `json:"path"`
+	Deployment   string  `json:"deployment"`
 	RequestCount int64   `json:"request_count"`
 	AvgTimeMs    float64 `json:"avg_time_ms"`
 	ErrorCount   int64   `json:"error_count"`


### PR DESCRIPTION
Add deployment field to PathStats struct and update top_paths query to group by both deployment and path. This enables the UI to show which deployment each slow endpoint belongs to.