### PR TITLE
fix(nginx): Increase server_names_hash_bucket_size to 128

### DIFF
--- a/templates/infra/nginx/nginx.conf
+++ b/templates/infra/nginx/nginx.conf
@@ -21,6 +21,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     types_hash_max_size 2048;
+    server_names_hash_bucket_size 128;
 
     # Gzip compression
     gzip on;

--- a/test/e2e/nginx/lua/nginx.conf
+++ b/test/e2e/nginx/lua/nginx.conf
@@ -18,6 +18,7 @@ http {
 
     sendfile on;
     keepalive_timeout 65;
+    server_names_hash_bucket_size 128;
 
     # Lua package path
     lua_package_path "/etc/nginx/lua/?.lua;;";

--- a/test/e2e/nginx/nginx.conf
+++ b/test/e2e/nginx/nginx.conf
@@ -19,6 +19,7 @@ http {
 
     sendfile on;
     keepalive_timeout 65;
+    server_names_hash_bucket_size 128;
 
     # Docker DNS resolver
     resolver 127.0.0.11 valid=10s ipv6=off;

--- a/test/e2e/nginx/security/nginx.conf
+++ b/test/e2e/nginx/security/nginx.conf
@@ -19,6 +19,7 @@ http {
 
     sendfile on;
     keepalive_timeout 65;
+    server_names_hash_bucket_size 128;
 
     # Docker DNS resolver
     resolver 127.0.0.11 valid=10s ipv6=off;


### PR DESCRIPTION
Long domain names (e.g., auto-generated subdomains) can exceed the default bucket size of 64, causing nginx config test to fail with:

  [emerg] could not build server_names_hash, you should increase
  server_names_hash_bucket_size: 64

Increasing to 128 accommodates longer domain names.