### PR TITLE
fix(credentials): Persist credential selection

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -987,7 +987,10 @@ func (s *Server) createDeployment(c *gin.Context) {
 
 	}
 
-	if req.Metadata != nil && (credentialID != "" || len(req.ServiceCredentials) > 0) {
+	if credentialID != "" || len(req.ServiceCredentials) > 0 {
+		if req.Metadata == nil {
+			req.Metadata = &models.ServiceMetadata{Name: req.Name}
+		}
 		if credentialID != "" {
 			req.Metadata.CredentialID = credentialID
 		}


### PR DESCRIPTION
Deployments created with a registry credential but no networking or SSL metadata (for example, internal services without an exposed domain) were silently dropped by the agent, so the detail view later showed them as "Public" and subsequent pulls reverted to Docker Hub.

The agent now persists registry credential selections unconditionally when one is present, ensuring the association survives across restarts and rebuilds regardless of whether other metadata fields were provided.