### PR TITLE
feat(agent): Improve nginx vhost generation, CLI help, and service discovery

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -16,42 +17,112 @@ import (
 	"github.com/flatrun/agent/pkg/updater"
 	"github.com/flatrun/agent/pkg/version"
 	"github.com/moby/moby/client"
+	"github.com/spf13/cobra"
 )
 
 func main() {
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case "update":
-			handleUpdate(os.Args[2:])
-			return
-		case "setup":
-			handleSetup(os.Args[2:])
-			return
-		case "version":
-			printVersion()
-			return
+	root := newRootCmd()
+	root.SetArgs(normalizeLegacyFlags(os.Args[1:]))
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+// normalizeLegacyFlags keeps the single-dash long forms the previous flag-based
+// CLI accepted (-config, -version) working under pflag, which otherwise reads a
+// single dash as a cluster of shorthand flags. This preserves existing launch
+// commands such as `flatrun-agent -config /etc/flatrun/config.yml`.
+func normalizeLegacyFlags(args []string) []string {
+	out := make([]string, 0, len(args))
+	for _, a := range args {
+		if a == "-config" || a == "-version" ||
+			strings.HasPrefix(a, "-config=") || strings.HasPrefix(a, "-version=") {
+			a = "-" + a
 		}
+		out = append(out, a)
+	}
+	return out
+}
+
+func newRootCmd() *cobra.Command {
+	var configPath string
+	var showVersion bool
+
+	root := &cobra.Command{
+		Use:          "flatrun-agent",
+		Short:        "Flatrun Agent - flat-file container orchestration",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if showVersion {
+				printVersion()
+				return nil
+			}
+			// A bare invocation is most likely someone looking for guidance,
+			// not an attempt to start the daemon: the service is always launched
+			// with --config. Show help rather than failing on a missing default
+			// config. Pass --config (or use `serve`) to actually start.
+			if !cmd.Flags().Changed("config") {
+				return cmd.Help()
+			}
+			return runServer(configPath)
+		},
+	}
+	root.CompletionOptions.DisableDefaultCmd = true
+	root.PersistentFlags().StringVar(&configPath, "config", "", "Path to configuration file")
+	root.Flags().BoolVar(&showVersion, "version", false, "Print version information")
+
+	serve := &cobra.Command{
+		Use:          "serve",
+		Short:        "Start the agent server",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runServer(configPath)
+		},
 	}
 
-	configPath := flag.String("config", "", "Path to configuration file")
-	showVersion := flag.Bool("version", false, "Print version information")
-	flag.Parse()
-
-	if *showVersion {
-		printVersion()
-		return
+	setup := &cobra.Command{
+		Use:                "setup <target> <service> [options]",
+		Short:              "Deploy an infrastructure service from embedded templates",
+		DisableFlagParsing: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			handleSetup(args)
+		},
 	}
 
-	resolvedConfigPath := config.FindConfigPath(*configPath)
+	update := &cobra.Command{
+		Use:                "update [options]",
+		Short:              "Update the agent to the latest version",
+		DisableFlagParsing: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			handleUpdate(args)
+		},
+	}
+
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		Run: func(cmd *cobra.Command, args []string) {
+			printVersion()
+		},
+	}
+
+	root.AddCommand(serve, setup, update, versionCmd)
+	return root
+}
+
+func runServer(configPath string) error {
+	resolvedConfigPath := config.FindConfigPath(configPath)
 	cfg, err := config.Load(resolvedConfigPath)
 	if err != nil {
-		log.Fatalf("Failed to load config from %s: %v", resolvedConfigPath, err)
+		return fmt.Errorf("failed to load config from %s: %w", resolvedConfigPath, err)
 	}
 
-	ensureDockerReachable(cfg.DockerSocket)
+	if err := ensureDockerReachable(cfg.DockerSocket); err != nil {
+		return err
+	}
 
 	if err := os.MkdirAll(cfg.DeploymentsPath, 0755); err != nil {
-		log.Fatalf("Failed to create deployments directory '%s': %v", cfg.DeploymentsPath, err)
+		return fmt.Errorf("failed to create deployments directory %q: %w", cfg.DeploymentsPath, err)
 	}
 
 	log.Printf("Starting Flatrun Agent v%s", version.Version)
@@ -61,7 +132,7 @@ func main() {
 
 	fileWatcher, err := watcher.New(cfg.DeploymentsPath)
 	if err != nil {
-		log.Fatalf("Failed to create file watcher: %v", err)
+		return fmt.Errorf("failed to create file watcher: %w", err)
 	}
 	defer fileWatcher.Close()
 
@@ -80,9 +151,10 @@ func main() {
 
 	log.Println("Shutting down Flatrun Agent...")
 	_ = apiServer.Stop()
+	return nil
 }
 
-func ensureDockerReachable(dockerHost string) {
+func ensureDockerReachable(dockerHost string) error {
 	log.Println("Checking if Docker is reachable...")
 
 	opts := []client.Opt{client.FromEnv}
@@ -92,7 +164,7 @@ func ensureDockerReachable(dockerHost string) {
 
 	cli, err := client.New(opts...)
 	if err != nil {
-		log.Fatalf("Failed to create Docker client: %v", err)
+		return fmt.Errorf("failed to create Docker client: %w", err)
 	}
 	defer cli.Close()
 
@@ -100,11 +172,10 @@ func ensureDockerReachable(dockerHost string) {
 	defer cancel()
 
 	if _, err := cli.Ping(ctx, client.PingOptions{}); err != nil {
-		log.Fatalf("Docker is not reachable: %v. "+
-			"Ensure the Docker daemon is running and the socket "+
-			"in config is correct.", err)
+		return fmt.Errorf("docker is not reachable: %w. Ensure the Docker daemon is running and the socket in config is correct", err)
 	}
 	log.Println("Docker is reachable")
+	return nil
 }
 
 func printVersion() {

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRootCmd_BareShowsHelp(t *testing.T) {
+	cmd := newRootCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("bare invocation should not error, got: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{"serve", "setup", "update", "version"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("help output missing %q command, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestNormalizeLegacyFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"single-dash config", []string{"-config", "/etc/x.yml"}, []string{"--config", "/etc/x.yml"}},
+		{"single-dash config equals", []string{"-config=/etc/x.yml"}, []string{"--config=/etc/x.yml"}},
+		{"single-dash version", []string{"-version"}, []string{"--version"}},
+		{"double-dash untouched", []string{"--config", "/etc/x.yml"}, []string{"--config", "/etc/x.yml"}},
+		{"subcommand untouched", []string{"setup", "infra", "nginx"}, []string{"setup", "infra", "nginx"}},
+		{"unrelated short flag untouched", []string{"update", "-check"}, []string{"update", "-check"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeLegacyFlags(tt.in)
+			if strings.Join(got, " ") != strings.Join(tt.want, " ") {
+				t.Errorf("normalizeLegacyFlags(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRootCmd_RegistersSubcommands(t *testing.T) {
+	cmd := newRootCmd()
+	for _, name := range []string{"serve", "setup", "update", "version"} {
+		sub, _, err := cmd.Find([]string{name})
+		if err != nil || sub.Name() != name {
+			t.Errorf("expected subcommand %q to be registered, got %v (err %v)", name, sub, err)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/moby/moby/client v0.2.2
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/spf13/cobra v1.10.2
 	github.com/testcontainers/testcontainers-go v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.41.0
 	golang.org/x/crypto v0.48.0
@@ -152,7 +153,6 @@ require (
 	github.com/sigstore/sigstore-go v1.1.4-0.20251124094504-b5fe07a5a7d7 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tilt-dev/fsnotify v1.4.8-0.20220602155310-fff9c274a375 // indirect

--- a/internal/docker/discovery.go
+++ b/internal/docker/discovery.go
@@ -667,10 +667,17 @@ func (d *Discovery) generateMetadataFromCompose(composePath, name string) *model
 
 // pickPrimaryService selects the service to use for networking metadata.
 // For single-service composes, returns that service. For multi-service,
-// returns the first service with exposed ports.
+// it prefers a service named "app" or "web" that exposes ports, then falls
+// back to the first service with exposed ports. The preference keeps the
+// selection deterministic, since Go map iteration order is random.
 func (d *Discovery) pickPrimaryService(services map[string]composeService) (string, composeService) {
 	if len(services) == 1 {
 		for name, svc := range services {
+			return name, svc
+		}
+	}
+	for name, svc := range services {
+		if (name == "app" || name == "web") && (len(svc.Ports) > 0 || len(svc.Expose) > 0) {
 			return name, svc
 		}
 	}

--- a/internal/docker/discovery.go
+++ b/internal/docker/discovery.go
@@ -582,7 +582,9 @@ func (d *Discovery) UpdateComposeFile(name string, content string) error {
 				if newMeta.Networking.Service != "" {
 					existing.Networking.Service = newMeta.Networking.Service
 				}
-				d.SaveMetadata(name, existing)
+				if err := d.SaveMetadata(name, existing); err != nil {
+					return fmt.Errorf("failed to sync service metadata: %w", err)
+				}
 			}
 		}
 	}

--- a/internal/docker/discovery_test.go
+++ b/internal/docker/discovery_test.go
@@ -498,6 +498,26 @@ func TestGenerateMetadataFromCompose_ServiceName(t *testing.T) {
 	}
 }
 
+func TestPickPrimaryService_PrefersAppOrWeb(t *testing.T) {
+	d := NewDiscovery(t.TempDir())
+
+	withPorts := composeService{Ports: []interface{}{"80:80"}}
+	services := map[string]composeService{
+		"queue": withPorts,
+		"app":   withPorts,
+		"redis": withPorts,
+	}
+
+	// Map iteration order is random, so a service with ports could be returned
+	// in any order. Repeat to confirm "app" is selected deterministically.
+	for i := 0; i < 100; i++ {
+		name, _ := d.pickPrimaryService(services)
+		if name != "app" {
+			t.Fatalf("pickPrimaryService = %q, want \"app\"", name)
+		}
+	}
+}
+
 func TestGenerateMetadataFromCompose_Expose(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -355,6 +355,9 @@ func (m *Manager) generateConfig(deployment *models.Deployment) (string, error) 
 	if data.ProxyType == "" {
 		data.ProxyType = "http"
 	}
+	if data.ProxyTimeout == 0 {
+		data.ProxyTimeout = defaultProxyTimeout
+	}
 
 	var tmpl *template.Template
 	var err error
@@ -495,6 +498,11 @@ func (m *Manager) groupDomainsByHost(domains []models.DomainConfig, deploymentNa
 				port = 80
 			}
 
+			timeout := d.ProxyTimeout
+			if timeout == 0 {
+				timeout = defaultProxyTimeout
+			}
+
 			locations = append(locations, locationData{
 				Path:          path,
 				Service:       service,
@@ -502,6 +510,7 @@ func (m *Manager) groupDomainsByHost(domains []models.DomainConfig, deploymentNa
 				Protocol:      "http",
 				StripPrefix:   d.StripPrefix,
 				OriginalPath:  d.PathPrefix,
+				ProxyTimeout:  timeout,
 			})
 
 			if d.SSL.Enabled {
@@ -574,6 +583,10 @@ type VirtualHostInfo struct {
 	ModifiedAt int64  `json:"modified_at"`
 }
 
+// defaultProxyTimeout is the proxy read/send timeout in seconds applied when a
+// domain does not set one explicitly.
+const defaultProxyTimeout = 60
+
 type templateData struct {
 	DeploymentName       string
 	Domain               string
@@ -586,6 +599,7 @@ type templateData struct {
 	SecurityEnabled      bool
 	BlockedIPs           []string
 	RateLimits           []rateLimitData
+	ProxyTimeout         int
 }
 
 type multiRouteTemplateData struct {
@@ -613,6 +627,7 @@ type locationData struct {
 	Protocol      string
 	StripPrefix   bool
 	OriginalPath  string
+	ProxyTimeout  int
 }
 
 type rateLimitData struct {
@@ -642,8 +657,8 @@ const httpTemplate = `server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_connect_timeout 60s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        proxy_send_timeout {{.ProxyTimeout}}s;
+        proxy_read_timeout {{.ProxyTimeout}}s;
 {{- if .SecurityEnabled}}
         log_by_lua_block {
             security.capture_event()
@@ -730,8 +745,8 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_connect_timeout 60s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        proxy_send_timeout {{.ProxyTimeout}}s;
+        proxy_read_timeout {{.ProxyTimeout}}s;
 {{- if .SecurityEnabled}}
         log_by_lua_block {
             security.capture_event()
@@ -789,8 +804,8 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_connect_timeout 60s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        proxy_send_timeout {{.ProxyTimeout}}s;
+        proxy_read_timeout {{.ProxyTimeout}}s;
 {{- if $.SecurityEnabled}}
         log_by_lua_block {
             security.capture_event()
@@ -878,8 +893,8 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_connect_timeout 60s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        proxy_send_timeout {{.ProxyTimeout}}s;
+        proxy_read_timeout {{.ProxyTimeout}}s;
 {{- if $.SecurityEnabled}}
         log_by_lua_block {
             security.capture_event()
@@ -962,8 +977,8 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_connect_timeout 60s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        proxy_send_timeout {{.ProxyTimeout}}s;
+        proxy_read_timeout {{.ProxyTimeout}}s;
 {{- if $.SecurityEnabled}}
         log_by_lua_block {
             security.capture_event()
@@ -1014,8 +1029,8 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_connect_timeout 60s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 60s;
+        proxy_send_timeout {{.ProxyTimeout}}s;
+        proxy_read_timeout {{.ProxyTimeout}}s;
 {{- if $.SecurityEnabled}}
         log_by_lua_block {
             security.capture_event()

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -26,6 +26,25 @@ type Manager struct {
 	mu                   sync.RWMutex
 }
 
+// mapsConfigFile is a managed http-context snippet (not a vhost) included
+// ahead of the generated vhosts. It defines $connection_upgrade so the
+// Connection header is only sent when a client requests a WebSocket upgrade.
+const mapsConfigFile = "00-flatrun-maps.conf"
+
+const mapsConfigContent = `# Managed by FlatRun. Do not edit.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+`
+
+// infraConfigFiles are conf.d files the agent manages that are not deployment
+// virtual hosts and must be skipped when enumerating vhosts.
+var infraConfigFiles = map[string]bool{
+	mapsConfigFile:     true,
+	"rate_limits.conf": true,
+}
+
 func NewManager(cfg *config.NginxConfig, deploymentsPath string, webrootPath string) *Manager {
 	configPath := cfg.ConfigPath
 	if configPath == "" {
@@ -125,8 +144,26 @@ func (m *Manager) WriteVirtualHost(deploymentName string, content string) error 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if err := m.ensureMapsConfig(); err != nil {
+		return err
+	}
+
 	configFile := filepath.Join(m.configPath, deploymentName+".conf")
 	return os.WriteFile(configFile, []byte(content), 0644)
+}
+
+// ensureMapsConfig writes the managed http-context map snippet that generated
+// vhosts depend on for conditional WebSocket upgrades. It is idempotent.
+// Callers must hold m.mu.
+func (m *Manager) ensureMapsConfig() error {
+	if err := os.MkdirAll(m.configPath, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+	path := filepath.Join(m.configPath, mapsConfigFile)
+	if err := os.WriteFile(path, []byte(mapsConfigContent), 0644); err != nil {
+		return fmt.Errorf("failed to write maps config: %w", err)
+	}
+	return nil
 }
 
 func (m *Manager) UpdateVirtualHost(deployment *models.Deployment) error {
@@ -169,6 +206,9 @@ func (m *Manager) ListVirtualHosts() ([]VirtualHostInfo, error) {
 
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".conf") {
+			continue
+		}
+		if infraConfigFiles[entry.Name()] {
 			continue
 		}
 
@@ -554,8 +594,8 @@ func (m *Manager) CreateMultiDomainVirtualHost(deployment *models.Deployment) er
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if err := os.MkdirAll(m.configPath, 0755); err != nil {
-		return fmt.Errorf("failed to create config directory: %w", err)
+	if err := m.ensureMapsConfig(); err != nil {
+		return err
 	}
 
 	configContent, err := m.generateMultiDomainConfig(deployment)
@@ -651,7 +691,7 @@ const httpTemplate = `server {
         proxy_pass {{.Protocol}}://$upstream;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -739,7 +779,7 @@ server {
         proxy_pass {{.Protocol}}://$upstream;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -798,7 +838,7 @@ server {
         proxy_pass {{.Protocol}}://$upstream;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -887,7 +927,7 @@ server {
         proxy_pass {{.Protocol}}://$upstream;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -971,7 +1011,7 @@ server {
         proxy_pass {{.Protocol}}://$upstream;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -1023,7 +1063,7 @@ server {
         proxy_pass {{.Protocol}}://$upstream;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -675,6 +675,8 @@ const httpTemplate = `server {
 {{- end}}
     location /.well-known/acme-challenge/ {
         root {{.ContainerWebrootPath}};
+        access_log off;
+        log_not_found off;
     }
 }
 `
@@ -685,6 +687,8 @@ const sslTemplate = `server {
 
     location /.well-known/acme-challenge/ {
         root {{.ContainerWebrootPath}};
+        access_log off;
+        log_not_found off;
     }
 
     location / {
@@ -814,6 +818,8 @@ server {
 
     location /.well-known/acme-challenge/ {
         root {{$.ContainerWebrootPath}};
+        access_log off;
+        log_not_found off;
     }
 }
 {{end}}`
@@ -825,6 +831,8 @@ server {
 
     location /.well-known/acme-challenge/ {
         root {{$.ContainerWebrootPath}};
+        access_log off;
+        log_not_found off;
     }
 
     location / {
@@ -907,6 +915,8 @@ server {
 
     location /.well-known/acme-challenge/ {
         root {{$.ContainerWebrootPath}};
+        access_log off;
+        log_not_found off;
     }
 
     location / {
@@ -1033,6 +1043,8 @@ server {
 
     location /.well-known/acme-challenge/ {
         root {{$.ContainerWebrootPath}};
+        access_log off;
+        log_not_found off;
     }
 }
 {{- end}}

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -23,6 +23,7 @@ type Manager struct {
 	configPath           string
 	webrootPath          string
 	containerWebrootPath string
+	staplingChecker      func(sslDomain string) bool
 	mu                   sync.RWMutex
 }
 
@@ -71,6 +72,21 @@ func NewManager(cfg *config.NginxConfig, deploymentsPath string, webrootPath str
 
 func (m *Manager) ConfigPath() string {
 	return m.configPath
+}
+
+// SetStaplingChecker injects a predicate that reports whether ssl_stapling
+// should be enabled for an SSL domain (true when its certificate advertises an
+// OCSP responder). When left unset, stapling stays enabled, preserving prior
+// behaviour.
+func (m *Manager) SetStaplingChecker(fn func(sslDomain string) bool) {
+	m.staplingChecker = fn
+}
+
+func (m *Manager) shouldStaple(sslDomain string) bool {
+	if m.staplingChecker == nil {
+		return true
+	}
+	return m.staplingChecker(sslDomain)
 }
 
 func (m *Manager) UpdateConfig(cfg *config.NginxConfig, deploymentsPath string, webrootPath string) {
@@ -398,6 +414,9 @@ func (m *Manager) generateConfig(deployment *models.Deployment) (string, error) 
 	if data.ProxyTimeout == 0 {
 		data.ProxyTimeout = defaultProxyTimeout
 	}
+	if data.SSLEnabled {
+		data.EnableStapling = m.shouldStaple(data.Domain)
+	}
 
 	var tmpl *template.Template
 	var err error
@@ -565,12 +584,13 @@ func (m *Manager) groupDomainsByHost(domains []models.DomainConfig, deploymentNa
 		}
 
 		servers = append(servers, serverData{
-			Domain:        host,
-			SSLEnabled:    hasSSL,
-			HasSSL:        hasSSL,
-			SSLDomain:     sslDomain,
-			Locations:     locations,
-			ServerAliases: serverAliases,
+			Domain:         host,
+			SSLEnabled:     hasSSL,
+			HasSSL:         hasSSL,
+			SSLDomain:      sslDomain,
+			Locations:      locations,
+			ServerAliases:  serverAliases,
+			EnableStapling: hasSSL && m.shouldStaple(sslDomain),
 		})
 	}
 
@@ -640,6 +660,7 @@ type templateData struct {
 	BlockedIPs           []string
 	RateLimits           []rateLimitData
 	ProxyTimeout         int
+	EnableStapling       bool
 }
 
 type multiRouteTemplateData struct {
@@ -652,12 +673,13 @@ type multiRouteTemplateData struct {
 }
 
 type serverData struct {
-	Domain       string
-	SSLEnabled   bool
-	Locations    []locationData
-	HasSSL       bool
-	SSLDomain    string
-	ServerAliases []string
+	Domain         string
+	SSLEnabled     bool
+	Locations      []locationData
+	HasSSL         bool
+	SSLDomain      string
+	ServerAliases  []string
+	EnableStapling bool
 }
 
 type locationData struct {
@@ -764,8 +786,10 @@ server {
     ssl_prefer_server_ciphers off;
     ssl_session_timeout 1d;
     ssl_session_cache shared:SSL:50m;
+{{- if .EnableStapling}}
     ssl_stapling on;
     ssl_stapling_verify on;
+{{- end}}
 
     add_header Strict-Transport-Security "max-age=63072000" always;
 
@@ -908,8 +932,10 @@ server {
     ssl_prefer_server_ciphers off;
     ssl_session_timeout 1d;
     ssl_session_cache shared:SSL:50m;
+{{- if .EnableStapling}}
     ssl_stapling on;
     ssl_stapling_verify on;
+{{- end}}
 
     add_header Strict-Transport-Security "max-age=63072000" always;
 
@@ -992,8 +1018,10 @@ server {
     ssl_prefer_server_ciphers off;
     ssl_session_timeout 1d;
     ssl_session_cache shared:SSL:50m;
+{{- if .EnableStapling}}
     ssl_stapling on;
     ssl_stapling_verify on;
+{{- end}}
 
     add_header Strict-Transport-Security "max-age=63072000" always;
 

--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -325,6 +325,56 @@ func isNginxConfigValid(output string) bool {
 	return !hasError && hasSuccess
 }
 
+// ProbeTarget checks, from inside the nginx container, whether service:port
+// accepts a TCP connection, using the same name resolution the proxy itself
+// uses. The second return value is false when the check could not be performed
+// (no probe tool in the image, nginx container unavailable, unsupported flags),
+// so callers can stay silent instead of reporting a false dead route.
+func (m *Manager) ProbeTarget(service string, port int) (listening bool, checked bool) {
+	if m.config.ContainerName == "" || service == "" {
+		return false, false
+	}
+
+	probe := fmt.Sprintf("nc -z -w2 %s %d", service, port)
+	out, err := exec.Command("docker", "exec", m.config.ContainerName, "sh", "-c", probe).CombinedOutput()
+
+	exitCode := -1
+	if err == nil {
+		exitCode = 0
+	} else if exitErr, ok := err.(*exec.ExitError); ok {
+		exitCode = exitErr.ExitCode()
+	}
+	return interpretProbe(string(out), exitCode)
+}
+
+// interpretProbe classifies a probe's output and exit code. A missing or
+// unsupported probe tool, or a docker/daemon-level failure (container down,
+// exec failed), is not evidence the target is closed, so it is reported as
+// unchecked rather than a dead route. Only a clean exit-1 from the probe
+// itself counts as "not listening".
+func interpretProbe(output string, exitCode int) (listening bool, checked bool) {
+	if exitCode == 0 {
+		return true, true
+	}
+
+	lower := strings.ToLower(output)
+	uncheckable := []string{
+		"not found", "usage", "invalid", "unrecognized",
+		"error response from daemon", "is not running", "no such container",
+		"oci runtime", "exec failed",
+	}
+	for _, s := range uncheckable {
+		if strings.Contains(lower, s) {
+			return false, false
+		}
+	}
+
+	if exitCode == 1 {
+		return false, true
+	}
+	return false, false
+}
+
 func (m *Manager) waitForContainerReady(maxRetries int) error {
 	for i := 0; i < maxRetries; i++ {
 		cmd := exec.Command("docker", "inspect", "-f", "{{.State.Status}}", m.config.ContainerName)

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -1846,6 +1846,43 @@ func TestGenerateConfig_SSLToggle(t *testing.T) {
 	}
 }
 
+func TestGenerateMultiDomainConfig_StaplingGate(t *testing.T) {
+	deployment := &models.Deployment{
+		Name: "stapling-test",
+		Metadata: &models.ServiceMetadata{
+			Domains: []models.DomainConfig{
+				{ID: "d1", Service: "web", Domain: "app.example.com", SSL: models.SSLConfig{Enabled: true}},
+			},
+		},
+	}
+
+	t.Run("default enables stapling", func(t *testing.T) {
+		m := NewManager(&config.NginxConfig{ContainerWebrootPath: "/var/www/html"}, "/deployments", "")
+		config, err := m.generateMultiDomainConfig(deployment)
+		if err != nil {
+			t.Fatalf("generateMultiDomainConfig failed: %v", err)
+		}
+		if !strings.Contains(config, "ssl_stapling on;") {
+			t.Errorf("stapling should be enabled by default, got:\n%s", config)
+		}
+	})
+
+	t.Run("checker without OCSP disables stapling", func(t *testing.T) {
+		m := NewManager(&config.NginxConfig{ContainerWebrootPath: "/var/www/html"}, "/deployments", "")
+		m.SetStaplingChecker(func(string) bool { return false })
+		config, err := m.generateMultiDomainConfig(deployment)
+		if err != nil {
+			t.Fatalf("generateMultiDomainConfig failed: %v", err)
+		}
+		if strings.Contains(config, "ssl_stapling on;") {
+			t.Errorf("stapling should be omitted when the cert has no OCSP responder, got:\n%s", config)
+		}
+		if !strings.Contains(config, "listen 443 ssl;") {
+			t.Errorf("SSL server block should still be generated, got:\n%s", config)
+		}
+	})
+}
+
 func TestGenerateMultiDomainConfig_SSLToggle(t *testing.T) {
 	cfg := &config.NginxConfig{
 		ContainerWebrootPath: "/var/www/html",

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -2020,6 +2020,55 @@ func TestGenerateMultiDomainConfig_ContainerPort(t *testing.T) {
 	})
 }
 
+func TestCreateVirtualHost_WritesMapsConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "nginx-maps-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	m := NewManager(&config.NginxConfig{ContainerWebrootPath: "/var/www/html"}, tmpDir, "")
+	deployment := &models.Deployment{
+		Name: "ws-app",
+		Metadata: &models.ServiceMetadata{
+			Domains: []models.DomainConfig{
+				{ID: "d1", Service: "web", Domain: "app.example.com"},
+			},
+		},
+	}
+
+	if err := m.CreateVirtualHost(deployment); err != nil {
+		t.Fatalf("CreateVirtualHost failed: %v", err)
+	}
+
+	confDir := filepath.Join(tmpDir, "nginx", "conf.d")
+	vhost, err := os.ReadFile(filepath.Join(confDir, "ws-app.conf"))
+	if err != nil {
+		t.Fatalf("failed to read vhost: %v", err)
+	}
+	if !strings.Contains(string(vhost), "proxy_set_header Connection $connection_upgrade;") {
+		t.Errorf("vhost should use the conditional upgrade variable, got:\n%s", vhost)
+	}
+
+	maps, err := os.ReadFile(filepath.Join(confDir, mapsConfigFile))
+	if err != nil {
+		t.Fatalf("maps config was not written: %v", err)
+	}
+	if !strings.Contains(string(maps), "map $http_upgrade $connection_upgrade") {
+		t.Errorf("maps config missing the upgrade map, got:\n%s", maps)
+	}
+
+	hosts, err := m.ListVirtualHosts()
+	if err != nil {
+		t.Fatalf("ListVirtualHosts failed: %v", err)
+	}
+	for _, h := range hosts {
+		if h.Name == strings.TrimSuffix(mapsConfigFile, ".conf") {
+			t.Errorf("ListVirtualHosts should skip the managed maps file, got %q", h.Name)
+		}
+	}
+}
+
 func TestGenerateMultiDomainConfig_ProxyTimeout(t *testing.T) {
 	m := NewManager(&config.NginxConfig{ContainerWebrootPath: "/var/www/html"}, "/deployments", "")
 

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -2020,6 +2020,50 @@ func TestGenerateMultiDomainConfig_ContainerPort(t *testing.T) {
 	})
 }
 
+func TestGenerateMultiDomainConfig_ProxyTimeout(t *testing.T) {
+	m := NewManager(&config.NginxConfig{ContainerWebrootPath: "/var/www/html"}, "/deployments", "")
+
+	t.Run("uses configured proxy timeout", func(t *testing.T) {
+		deployment := &models.Deployment{
+			Name: "ws-test",
+			Metadata: &models.ServiceMetadata{
+				Domains: []models.DomainConfig{
+					{ID: "d1", Service: "web", Domain: "app.example.com", ProxyTimeout: 3600},
+				},
+			},
+		}
+
+		config, err := m.generateMultiDomainConfig(deployment)
+		if err != nil {
+			t.Fatalf("generateMultiDomainConfig failed: %v", err)
+		}
+
+		if !strings.Contains(config, "proxy_read_timeout 3600s;") || !strings.Contains(config, "proxy_send_timeout 3600s;") {
+			t.Errorf("config should use the configured 3600s timeout, got:\n%s", config)
+		}
+	})
+
+	t.Run("defaults to 60s when unset", func(t *testing.T) {
+		deployment := &models.Deployment{
+			Name: "default-test",
+			Metadata: &models.ServiceMetadata{
+				Domains: []models.DomainConfig{
+					{ID: "d1", Service: "web", Domain: "app.example.com"},
+				},
+			},
+		}
+
+		config, err := m.generateMultiDomainConfig(deployment)
+		if err != nil {
+			t.Fatalf("generateMultiDomainConfig failed: %v", err)
+		}
+
+		if !strings.Contains(config, "proxy_read_timeout 60s;") {
+			t.Errorf("config should default to 60s, got:\n%s", config)
+		}
+	})
+}
+
 func TestGroupDomainsByHost_DeduplicatesLocations(t *testing.T) {
 	m := NewManager(&config.NginxConfig{}, "/deployments", "")
 

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -2057,6 +2057,45 @@ func TestGenerateMultiDomainConfig_ContainerPort(t *testing.T) {
 	})
 }
 
+func TestProbeTarget_UncheckedWithoutContainer(t *testing.T) {
+	m := NewManager(&config.NginxConfig{}, "/deployments", "")
+
+	if listening, checked := m.ProbeTarget("web", 80); checked || listening {
+		t.Errorf("probe must report unchecked when no nginx container is configured, got listening=%v checked=%v", listening, checked)
+	}
+	if _, checked := m.ProbeTarget("", 80); checked {
+		t.Error("probe must report unchecked for an empty service name")
+	}
+}
+
+func TestInterpretProbe(t *testing.T) {
+	tests := []struct {
+		name          string
+		output        string
+		exitCode      int
+		wantListening bool
+		wantChecked   bool
+	}{
+		{"open port", "", 0, true, true},
+		{"connection refused", "nc: connect failed: Connection refused", 1, false, true},
+		{"nc missing", "sh: nc: not found", 127, false, false},
+		{"container down", "Error response from daemon: Container abc is not running", 1, false, false},
+		{"no such container", "Error: No such container: nginx", 1, false, false},
+		{"exec failed", "OCI runtime exec failed: exec failed: ...", 126, false, false},
+		{"unknown nonzero", "something weird", 2, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			listening, checked := interpretProbe(tt.output, tt.exitCode)
+			if listening != tt.wantListening || checked != tt.wantChecked {
+				t.Errorf("interpretProbe(%q, %d) = (%v, %v), want (%v, %v)",
+					tt.output, tt.exitCode, listening, checked, tt.wantListening, tt.wantChecked)
+			}
+		})
+	}
+}
+
 func TestCreateVirtualHost_WritesMapsConfig(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "nginx-maps-*")
 	if err != nil {

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -156,6 +156,18 @@ func (o *Orchestrator) setupMultiDomainDeployment(deployment *models.Deployment,
 		result.NginxReloaded = true
 	}
 
+	for _, d := range domains {
+		port := d.ContainerPort
+		if port == 0 {
+			port = 80
+		}
+		if listening, checked := o.nginx.ProbeTarget(d.Service, port); checked && !listening {
+			warning := fmt.Sprintf("target %s:%d for %s is not reachable; the route may be dead", d.Service, port, d.Domain)
+			log.Printf("warning: %s", warning)
+			result.TargetWarnings = append(result.TargetWarnings, warning)
+		}
+	}
+
 	certResults, err := o.ssl.RequestCertificatesForDomains(domains)
 	if err != nil {
 		log.Printf("warning: failed to request certificates: %v", err)
@@ -376,6 +388,7 @@ type SetupResult struct {
 	CertificateResults   []*ssl.CertificateResult `json:"certificate_results,omitempty"`
 	SSLMessage           string                   `json:"ssl_message,omitempty"`
 	SSLError             string                   `json:"ssl_error,omitempty"`
+	TargetWarnings       []string                 `json:"target_warnings,omitempty"`
 }
 
 type ProxyStatus struct {

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -16,13 +16,19 @@ type Orchestrator struct {
 }
 
 func NewOrchestrator(cfg *config.Config) *Orchestrator {
+	nginxMgr := nginx.NewManager(&cfg.Nginx, cfg.DeploymentsPath, cfg.Certbot.WebrootPath)
+	sslMgr := ssl.NewManager(&cfg.Certbot, cfg.DeploymentsPath, nil)
+	nginxMgr.SetStaplingChecker(sslMgr.HasOCSPResponder)
 	return &Orchestrator{
-		nginx: nginx.NewManager(&cfg.Nginx, cfg.DeploymentsPath, cfg.Certbot.WebrootPath),
-		ssl:   ssl.NewManager(&cfg.Certbot, cfg.DeploymentsPath, nil),
+		nginx: nginxMgr,
+		ssl:   sslMgr,
 	}
 }
 
 func NewOrchestratorWithManagers(nginxMgr *nginx.Manager, sslMgr *ssl.Manager) *Orchestrator {
+	if nginxMgr != nil && sslMgr != nil {
+		nginxMgr.SetStaplingChecker(sslMgr.HasOCSPResponder)
+	}
 	return &Orchestrator{
 		nginx: nginxMgr,
 		ssl:   sslMgr,

--- a/internal/ssl/manager.go
+++ b/internal/ssl/manager.go
@@ -300,6 +300,30 @@ func (m *Manager) ListCertificates() ([]models.Certificate, error) {
 	return certificates, nil
 }
 
+// HasOCSPResponder reports whether the domain's certificate advertises an OCSP
+// responder URL. It returns false when the certificate is missing or cannot be
+// parsed. Used to decide whether enabling ssl_stapling is worthwhile, since
+// stapling on a cert with no responder only produces nginx warnings.
+func (m *Manager) HasOCSPResponder(domain string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	certPath := filepath.Join(m.certsPath, domain, "cert.pem")
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		return false
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return false
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return false
+	}
+	return len(cert.OCSPServer) > 0
+}
+
 func (m *Manager) CertificateExists(domain string) bool {
 	certPath := filepath.Join(m.certsPath, domain, "cert.pem")
 	_, err := os.Stat(certPath)

--- a/pkg/models/deployment.go
+++ b/pkg/models/deployment.go
@@ -49,6 +49,10 @@ type DomainConfig struct {
 	StripPrefix   bool      `yaml:"strip_prefix,omitempty" json:"strip_prefix,omitempty"`
 	SSL           SSLConfig `yaml:"ssl" json:"ssl"`
 	Aliases       []string  `yaml:"aliases,omitempty" json:"aliases,omitempty"`
+	// ProxyTimeout is the proxy read/send timeout in seconds. Defaults to 60
+	// when unset; raise it for domains that proxy long-lived WebSocket
+	// connections so idle sockets are not closed mid-connection.
+	ProxyTimeout int `yaml:"proxy_timeout,omitempty" json:"proxy_timeout,omitempty"`
 }
 
 type DatabaseConfig struct {

--- a/templates/infra/nginx/default.conf
+++ b/templates/infra/nginx/default.conf
@@ -8,6 +8,8 @@ server {
 
     location /.well-known/acme-challenge/ {
         root /usr/share/nginx/html;
+        access_log off;
+        log_not_found off;
     }
 
     location / {


### PR DESCRIPTION
The simplest, self-contained items from the Albacore umbrella (#158), one commit each.

## Fixes

- **#110** `SaveMetadata` errors during a compose update are now propagated instead of silently dropped, so the compose file and `service.yml` can't diverge unnoticed.
- **#111** Primary-service detection prefers a service named `app` or `web` before falling back to the first with ports. Previously the pick depended on Go map iteration order and could vary between runs.
- **#112** ACME challenge locations set `access_log off` / `log_not_found off`, so cleaned-up-challenge 404s stop burying real errors in the nginx logs.

## CLI (#130)

`cmd/agent` now uses cobra. Top-level help lists every subcommand (`serve`, `setup`, `update`, `version`), which the hand-rolled `flag` usage never did. A bare `flatrun-agent` prints that help instead of trying to start the daemon and failing on a missing default config. Passing `--config` (or the new `serve` command) still starts the agent, so the systemd launch (`flatrun-agent --config ...`) is unchanged and the installer needs no update. cobra was already in the module graph, so this adds no new external dependency.

## nginx vhost generation (#156)

- WebSocket proxy read/send timeout is configurable per domain (`proxy_timeout`), defaulting to 60s, so long-lived sockets aren't closed after 60s idle.
- `Connection: upgrade` is sent only when a client requests an upgrade, via a managed `map` snippet, instead of unconditionally on every request. The snippet is written into the conf.d include dir so existing installs pick it up without re-applying the base config.
- `ssl_stapling` is emitted only when the certificate advertises an OCSP responder, removing the per-reload warning on certs without one. It stays enabled when the cert can't be read.
- Proxy setup probes each target through the same path nginx resolves and surfaces a non-fatal warning when a service or port isn't reachable, instead of leaving a silently dead route. The probe stays silent when it genuinely can't check (no probe tool, container down).

Closes #110, #111, #112, #130, #156.
