### PR TITLE
refactor(agent): Gather dashboard and deployment data concurrently

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4936,10 +4936,74 @@ func (s *Server) getSystemStats(c *gin.Context) {
 	}
 	s.statsMu.RUnlock()
 
-	deployments, err := s.manager.ListDeployments()
-	if err != nil {
+	var (
+		wg                 sync.WaitGroup
+		deployments        []models.Deployment
+		depErr             error
+		containerStats     map[string]int
+		imageStats         map[string]int
+		volumeStats        map[string]int
+		systemStats        *system.SystemStats
+		networkCount       int
+		portCount          int
+		systemPortCount    int
+		systemServiceCount int
+		infraCount         int
+		certCount          int
+	)
+
+	// Each of these shells out to docker or the OS and is independent of the
+	// others, so run them concurrently instead of paying the sum of their
+	// latencies. Every closure writes only its own variable.
+	run := func(f func()) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			f()
+		}()
+	}
+	run(func() { deployments, depErr = s.manager.ListDeployments() })
+	run(func() { containerStats, _ = s.networksManager.GetContainerStats() })
+	run(func() { imageStats, _ = s.networksManager.GetImageStats() })
+	run(func() { volumeStats, _ = s.networksManager.GetVolumeStats() })
+	run(func() { systemStats, _ = system.GetSystemStats() })
+	run(func() {
+		if networks, err := s.networksManager.ListNetworks(); err == nil {
+			networkCount = len(networks)
+		}
+	})
+	run(func() {
+		if containers, err := s.networksManager.ListContainers(); err == nil {
+			for _, container := range containers {
+				portCount += len(container.Ports)
+			}
+		}
+	})
+	run(func() {
+		if ports, err := s.networksManager.ListPorts(); err == nil {
+			systemPortCount = len(ports)
+		}
+	})
+	run(func() {
+		if services, err := s.servicesManager.ListServices(); err == nil {
+			systemServiceCount = len(services)
+		}
+	})
+	run(func() {
+		if services, err := s.infraManager.ListServices(); err == nil {
+			infraCount = len(services)
+		}
+	})
+	run(func() {
+		if certs, err := s.proxyOrchestrator.ListCertificates(); err == nil {
+			certCount = len(certs)
+		}
+	})
+	wg.Wait()
+
+	if depErr != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": err.Error(),
+			"error": depErr.Error(),
 		})
 		return
 	}
@@ -4973,42 +5037,6 @@ func (s *Server) getSystemStats(c *gin.Context) {
 		default:
 			depStats["unknown"] = depStats["unknown"].(int) + 1
 		}
-	}
-
-	containerStats, _ := s.networksManager.GetContainerStats()
-	imageStats, _ := s.networksManager.GetImageStats()
-	volumeStats, _ := s.networksManager.GetVolumeStats()
-
-	var networkCount, portCount int
-	if networks, err := s.networksManager.ListNetworks(); err == nil {
-		networkCount = len(networks)
-	}
-	if containers, err := s.networksManager.ListContainers(); err == nil {
-		for _, container := range containers {
-			portCount += len(container.Ports)
-		}
-	}
-
-	systemStats, _ := system.GetSystemStats()
-
-	var systemPortCount int
-	if ports, err := s.networksManager.ListPorts(); err == nil {
-		systemPortCount = len(ports)
-	}
-
-	var systemServiceCount int
-	if services, err := s.servicesManager.ListServices(); err == nil {
-		systemServiceCount = len(services)
-	}
-
-	var infraCount int
-	if services, err := s.infraManager.ListServices(); err == nil {
-		infraCount = len(services)
-	}
-
-	var certCount int
-	if certs, err := s.proxyOrchestrator.ListCertificates(); err == nil {
-		certCount = len(certs)
 	}
 
 	appCount := len(s.pluginRegistry.List())

--- a/internal/docker/manager.go
+++ b/internal/docker/manager.go
@@ -69,10 +69,22 @@ func (m *Manager) ListDeployments() ([]models.Deployment, error) {
 		return nil, err
 	}
 
+	// Each status check shells out to docker compose, so a serial loop makes
+	// list latency grow with the deployment count. Fetch them concurrently with
+	// a bounded worker pool; each goroutine writes only its own index.
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 12)
 	for i := range deployments {
-		status, _ := m.executor.GetStatus(deployments[i].Path)
-		deployments[i].Status = status
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			status, _ := m.executor.GetStatus(deployments[i].Path)
+			deployments[i].Status = status
+		}(i)
 	}
+	wg.Wait()
 
 	return deployments, nil
 }

--- a/internal/networks/manager.go
+++ b/internal/networks/manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync"
 
 	"github.com/flatrun/agent/pkg/models"
 )
@@ -50,19 +51,36 @@ func (m *Manager) ListNetworks() ([]models.Network, error) {
 		return nil, fmt.Errorf("failed to list networks: %w", err)
 	}
 
-	var networks []models.Network
-	ids := strings.Split(strings.TrimSpace(string(output)), "\n")
-
-	for _, id := range ids {
-		if id == "" {
-			continue
+	var ids []string
+	for _, id := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if id != "" {
+			ids = append(ids, id)
 		}
+	}
 
-		network, err := m.inspectNetwork(id)
-		if err != nil {
-			continue
+	// Inspect networks concurrently: a serial loop pays one docker call per
+	// network. Order is preserved; networks that fail to inspect are dropped.
+	results := make([]*models.Network, len(ids))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 12)
+	for i, id := range ids {
+		wg.Add(1)
+		go func(i int, id string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			if network, err := m.inspectNetwork(id); err == nil {
+				results[i] = network
+			}
+		}(i, id)
+	}
+	wg.Wait()
+
+	networks := make([]models.Network, 0, len(ids))
+	for _, network := range results {
+		if network != nil {
+			networks = append(networks, *network)
 		}
-		networks = append(networks, *network)
 	}
 
 	return networks, nil


### PR DESCRIPTION
The agent assembled the dashboard stats and the deployment list by running every docker and OS call in sequence. Each deployment's status check shells out to `docker compose`, so a host with many deployments paid that cost once per deployment, and the dashboard endpoint stacked another dozen independent docker/OS calls on top, all serial. Both add up to noticeably slow dashboard loads, which is the substance of #154.

The independent calls now run concurrently. Deployment status checks and network inspections use a bounded worker pool (12); the dashboard endpoint fans its independent lookups out and waits for all of them. Output is identical: each worker writes only its own slot, and results stay in their original order. Load time drops from the sum of the calls toward the slowest single call.

One thing a reviewer should weigh: a single dashboard request can now spawn up to roughly 35 concurrent `docker` processes at peak (the endpoint's own fan-out plus the nested pools inside the deployment and network lookups). On a small host that's a transient spike. If it shows up under load, a shared cap across the docker-calling managers is the follow-up; the per-site bound of 12 is the floor for now.