### PR TITLE
feat(agent): Run deployment and service actions as streamed jobs

### DIFF
--- a/internal/api/job_stream.go
+++ b/internal/api/job_stream.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/flatrun/agent/internal/auth"
+	"github.com/flatrun/agent/internal/contextkeys"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+// streamDeploymentJob streams an action job's output over a websocket. It
+// mirrors the terminal endpoints: the connection authenticates with a
+// first-message token, then the buffered output is replayed before live lines
+// are pushed, and a final result frame is sent when the job finishes.
+func (s *Server) streamDeploymentJob(c *gin.Context) {
+	name := c.Param("name")
+	jobID := c.Param("jobId")
+
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		log.Printf("WebSocket upgrade failed: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	if s.authMiddleware.IsAuthEnabled() {
+		_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			sendJobError(conn, "Authentication timeout")
+			return
+		}
+
+		var am authMessage
+		if err := json.Unmarshal(message, &am); err != nil || am.Type != "auth" {
+			sendJobError(conn, "Invalid auth message format")
+			return
+		}
+
+		actor, err := s.authMiddleware.ActorForTokenString(am.Token, c.ClientIP())
+		if err != nil {
+			sendJobError(conn, "Invalid or expired token")
+			return
+		}
+		c.Set(contextkeys.Actor, actor)
+
+		_ = conn.SetReadDeadline(time.Time{})
+	} else {
+		c.Set(contextkeys.Actor, &auth.ActorContext{Type: "anonymous", Role: auth.RoleAdmin})
+	}
+
+	actor := auth.GetActorFromContext(c)
+	if actor == nil || !actor.HasPermission(auth.PermDeploymentsRead) {
+		sendJobError(conn, "Permission denied: deployments:read required")
+		return
+	}
+	if !actor.CanAccessDeployment(name, auth.AccessLevelRead) {
+		sendJobError(conn, "No access to this deployment")
+		return
+	}
+	if s.authMiddleware.IsAuthEnabled() {
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"auth_success"}`)); err != nil {
+			return
+		}
+	}
+
+	job := s.jobs.get(jobID)
+	if job == nil || job.Deployment() != name {
+		sendJobError(conn, "Job not found")
+		return
+	}
+
+	buffered, lines, cancel := job.subscribe()
+	defer cancel()
+
+	for _, line := range buffered {
+		if err := writeJobLine(conn, line); err != nil {
+			return
+		}
+	}
+	for line := range lines {
+		if err := writeJobLine(conn, line); err != nil {
+			return
+		}
+	}
+
+	snap := job.snapshot()
+	_ = conn.WriteMessage(websocket.TextMessage, mustJSON(gin.H{
+		"type":   "result",
+		"status": string(snap.Status),
+		"error":  snap.Error,
+	}))
+}
+
+func sendJobError(conn *websocket.Conn, msg string) {
+	_ = conn.WriteMessage(websocket.TextMessage, mustJSON(gin.H{
+		"type":    "error",
+		"message": msg,
+	}))
+}
+
+func writeJobLine(conn *websocket.Conn, line string) error {
+	return conn.WriteMessage(websocket.TextMessage, mustJSON(gin.H{
+		"type": "line",
+		"data": line,
+	}))
+}
+
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return []byte(`{"type":"error","message":"failed to encode message"}`)
+	}
+	return b
+}

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -1,0 +1,242 @@
+package api
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type JobStatus string
+
+const (
+	JobPending   JobStatus = "pending"
+	JobRunning   JobStatus = "running"
+	JobSucceeded JobStatus = "succeeded"
+	JobFailed    JobStatus = "failed"
+)
+
+// jobRetention is how long a finished job stays queryable so a page reloaded
+// shortly after the action still sees its result. Jobs are in-memory only and
+// do not survive an agent restart.
+const jobRetention = 15 * time.Minute
+
+// ActionJob tracks one start/stop/restart/rebuild run for a deployment. Its
+// output lines are buffered as they arrive and fanned out to any live
+// subscribers (the websocket stream).
+type ActionJob struct {
+	id         string
+	deployment string
+	service    string
+	action     string
+	activeKey  string
+
+	mu          sync.Mutex
+	status      JobStatus
+	lines       []string
+	errMsg      string
+	startedAt   time.Time
+	finishedAt  time.Time
+	subscribers map[int]chan string
+	nextSub     int
+}
+
+func (j *ActionJob) ID() string         { return j.id }
+func (j *ActionJob) Deployment() string { return j.deployment }
+func (j *ActionJob) Service() string    { return j.service }
+
+func (j *ActionJob) setRunning() {
+	j.mu.Lock()
+	if j.status == JobPending {
+		j.status = JobRunning
+	}
+	j.mu.Unlock()
+}
+
+func (j *ActionJob) appendLine(line string) {
+	j.mu.Lock()
+	j.lines = append(j.lines, line)
+	for _, c := range j.subscribers {
+		select {
+		case c <- line:
+		default:
+			// Slow subscriber: drop the live line rather than block the action.
+			// The full buffer is still available via the status endpoint.
+		}
+	}
+	j.mu.Unlock()
+}
+
+func (j *ActionJob) finish(status JobStatus, errMsg string) {
+	j.mu.Lock()
+	j.status = status
+	j.errMsg = errMsg
+	j.finishedAt = time.Now()
+	for id, c := range j.subscribers {
+		close(c)
+		delete(j.subscribers, id)
+	}
+	j.mu.Unlock()
+}
+
+// subscribe atomically returns the lines buffered so far plus a channel that
+// receives every subsequent line. The channel is closed when the job finishes.
+// If the job is already finished, the returned channel is closed immediately.
+func (j *ActionJob) subscribe() (buffered []string, ch <-chan string, cancel func()) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	buffered = append([]string(nil), j.lines...)
+
+	if j.status == JobSucceeded || j.status == JobFailed {
+		closed := make(chan string)
+		close(closed)
+		return buffered, closed, func() {}
+	}
+
+	id := j.nextSub
+	j.nextSub++
+	c := make(chan string, 256)
+	j.subscribers[id] = c
+	cancel = func() {
+		j.mu.Lock()
+		if sc, ok := j.subscribers[id]; ok {
+			delete(j.subscribers, id)
+			close(sc)
+		}
+		j.mu.Unlock()
+	}
+	return buffered, c, cancel
+}
+
+type JobSnapshot struct {
+	ID         string     `json:"id"`
+	Deployment string     `json:"deployment"`
+	Service    string     `json:"service,omitempty"`
+	Action     string     `json:"action"`
+	Status     JobStatus  `json:"status"`
+	Output     string     `json:"output"`
+	Lines      []string   `json:"lines"`
+	Error      string     `json:"error,omitempty"`
+	StartedAt  time.Time  `json:"started_at"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
+}
+
+func (j *ActionJob) snapshot() JobSnapshot {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	snap := JobSnapshot{
+		ID:         j.id,
+		Deployment: j.deployment,
+		Service:    j.service,
+		Action:     j.action,
+		Status:     j.status,
+		Output:     strings.Join(j.lines, "\n"),
+		Lines:      append([]string(nil), j.lines...),
+		Error:      j.errMsg,
+		StartedAt:  j.startedAt,
+	}
+	if !j.finishedAt.IsZero() {
+		ft := j.finishedAt
+		snap.FinishedAt = &ft
+	}
+	return snap
+}
+
+// jobRegistry holds action jobs in memory and enforces one in-flight action
+// per deployment.
+type jobRegistry struct {
+	mu     sync.Mutex
+	jobs   map[string]*ActionJob
+	active map[string]string // deployment -> active job id
+}
+
+func newJobRegistry() *jobRegistry {
+	return &jobRegistry{
+		jobs:   make(map[string]*ActionJob),
+		active: make(map[string]string),
+	}
+}
+
+// create registers a new pending job for the deployment. If an action is
+// already in flight for that deployment it returns the existing job and false,
+// so the caller can reject the request and point the client at the live job.
+func (r *jobRegistry) create(deployment, action string) (*ActionJob, bool) {
+	return r.createScoped(deployment, "", action)
+}
+
+// createScoped registers a job serialized on the deployment, or on a single
+// service within it when service is set, so two different services can act
+// concurrently while the same service cannot.
+func (r *jobRegistry) createScoped(deployment, service, action string) (*ActionJob, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.evictLocked(time.Now())
+
+	key := deployment
+	if service != "" {
+		key = deployment + "\x00" + service
+	}
+
+	if id, ok := r.active[key]; ok {
+		if existing := r.jobs[id]; existing != nil {
+			return existing, false
+		}
+		delete(r.active, key)
+	}
+
+	job := &ActionJob{
+		id:          uuid.NewString(),
+		deployment:  deployment,
+		service:     service,
+		action:      action,
+		activeKey:   key,
+		status:      JobPending,
+		startedAt:   time.Now(),
+		subscribers: make(map[int]chan string),
+	}
+	r.jobs[job.id] = job
+	r.active[key] = job.id
+	return job, true
+}
+
+// finish marks the job terminal and frees its slot for the next action.
+func (r *jobRegistry) finish(job *ActionJob, status JobStatus, errMsg string) {
+	r.mu.Lock()
+	if r.active[job.activeKey] == job.id {
+		delete(r.active, job.activeKey)
+	}
+	r.mu.Unlock()
+
+	job.finish(status, errMsg)
+}
+
+func (r *jobRegistry) get(id string) *ActionJob {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.jobs[id]
+}
+
+func (r *jobRegistry) activeFor(deployment string) *ActionJob {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if id, ok := r.active[deployment]; ok {
+		return r.jobs[id]
+	}
+	return nil
+}
+
+func (r *jobRegistry) evictLocked(now time.Time) {
+	for id, job := range r.jobs {
+		job.mu.Lock()
+		finished := job.status == JobSucceeded || job.status == JobFailed
+		expired := finished && !job.finishedAt.IsZero() && now.Sub(job.finishedAt) > jobRetention
+		job.mu.Unlock()
+		if expired {
+			delete(r.jobs, id)
+		}
+	}
+}

--- a/internal/api/jobs_test.go
+++ b/internal/api/jobs_test.go
@@ -1,0 +1,288 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flatrun/agent/internal/auth"
+	"github.com/flatrun/agent/pkg/config"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+// fakeRunner stands in for the docker-backed action runner so tests exercise
+// the job lifecycle over HTTP without shelling out to compose.
+type fakeRunner struct {
+	lines []string
+	err   error
+	gate  chan struct{}
+}
+
+func (f *fakeRunner) run(_, _ string, emit func(string)) error {
+	for _, l := range f.lines {
+		emit(l)
+	}
+	if f.gate != nil {
+		<-f.gate
+	}
+	return f.err
+}
+
+func newJobTestServer(runner *fakeRunner) *Server {
+	gin.SetMode(gin.TestMode)
+	s := &Server{jobs: newJobRegistry()}
+	s.runDeploymentAction = runner.run
+	s.runServiceAction = func(action, name, service string, emit func(string)) error {
+		return runner.run(action, name, emit)
+	}
+	return s
+}
+
+func newJobRouter(s *Server) *gin.Engine {
+	r := gin.New()
+	r.POST("/api/deployments/:name/start", s.startDeployment)
+	r.POST("/api/deployments/:name/stop", s.stopDeployment)
+	r.POST("/api/deployments/:name/restart", s.restartDeployment)
+	r.POST("/api/deployments/:name/services/:service/job", s.enqueueServiceJob)
+	r.GET("/api/deployments/:name/jobs/active", s.getActiveDeploymentJob)
+	r.GET("/api/deployments/:name/jobs/:jobId", s.getDeploymentJob)
+	return r
+}
+
+func enqueue(t *testing.T, srvURL, name, action string) (int, map[string]any) {
+	t.Helper()
+	resp, err := http.Post(srvURL+"/api/deployments/"+name+"/"+action, "application/json", nil)
+	if err != nil {
+		t.Fatalf("%s request failed: %v", action, err)
+	}
+	defer resp.Body.Close()
+	var body map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	return resp.StatusCode, body
+}
+
+func pollJob(t *testing.T, srvURL, name, jobID string) JobSnapshot {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(srvURL + "/api/deployments/" + name + "/jobs/" + jobID)
+		if err != nil {
+			t.Fatalf("status request failed: %v", err)
+		}
+		var snap JobSnapshot
+		_ = json.NewDecoder(resp.Body).Decode(&snap)
+		resp.Body.Close()
+		if snap.Status == JobSucceeded || snap.Status == JobFailed {
+			return snap
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("job %s did not finish in time", jobID)
+	return JobSnapshot{}
+}
+
+func TestDeploymentActionJobLifecycle(t *testing.T) {
+	s := newJobTestServer(&fakeRunner{lines: []string{"Pulling nginx", "Creating web", "Started"}})
+	srv := newSkippableHTTPServer(t, newJobRouter(s))
+	defer srv.Close()
+
+	code, body := enqueue(t, srv.URL, "myapp", "start")
+	if code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", code)
+	}
+	jobID, _ := body["job_id"].(string)
+	if jobID == "" {
+		t.Fatal("expected a job_id in the response")
+	}
+
+	snap := pollJob(t, srv.URL, "myapp", jobID)
+	if snap.Status != JobSucceeded {
+		t.Fatalf("expected succeeded, got %s (err=%s)", snap.Status, snap.Error)
+	}
+	if !strings.Contains(snap.Output, "Pulling nginx") || !strings.Contains(snap.Output, "Started") {
+		t.Fatalf("expected streamed output to be buffered, got %q", snap.Output)
+	}
+
+	// Reload survival: the finished job is still queryable.
+	snap2 := pollJob(t, srv.URL, "myapp", jobID)
+	if snap2.Status != JobSucceeded || snap2.Output != snap.Output {
+		t.Fatalf("finished job should remain queryable with the same output")
+	}
+}
+
+func TestDeploymentActionJobFailureSurfaces(t *testing.T) {
+	s := newJobTestServer(&fakeRunner{lines: []string{"boom"}, err: errStub("compose failed")})
+	srv := newSkippableHTTPServer(t, newJobRouter(s))
+	defer srv.Close()
+
+	_, body := enqueue(t, srv.URL, "myapp", "restart")
+	jobID, _ := body["job_id"].(string)
+
+	snap := pollJob(t, srv.URL, "myapp", jobID)
+	if snap.Status != JobFailed {
+		t.Fatalf("expected failed, got %s", snap.Status)
+	}
+	if !strings.Contains(snap.Error, "compose failed") {
+		t.Fatalf("expected error to surface, got %q", snap.Error)
+	}
+}
+
+func TestDeploymentActionRejectsConcurrent(t *testing.T) {
+	gate := make(chan struct{})
+	s := newJobTestServer(&fakeRunner{lines: []string{"working"}, gate: gate})
+	srv := newSkippableHTTPServer(t, newJobRouter(s))
+	defer srv.Close()
+
+	code, body := enqueue(t, srv.URL, "myapp", "start")
+	if code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", code)
+	}
+	firstID, _ := body["job_id"].(string)
+
+	// Wait until the first job is registered as active.
+	if !waitFor(func() bool { return s.jobs.activeFor("myapp") != nil }) {
+		t.Fatal("first job never became active")
+	}
+
+	code2, body2 := enqueue(t, srv.URL, "myapp", "stop")
+	if code2 != http.StatusConflict {
+		t.Fatalf("expected 409 for concurrent action, got %d", code2)
+	}
+	if body2["active_job_id"] != firstID {
+		t.Fatalf("expected active_job_id %s, got %v", firstID, body2["active_job_id"])
+	}
+
+	close(gate)
+	snap := pollJob(t, srv.URL, "myapp", firstID)
+	if snap.Status != JobSucceeded {
+		t.Fatalf("expected first job to succeed after gate released, got %s", snap.Status)
+	}
+
+	// A new action is accepted once the deployment is free again.
+	code3, _ := enqueue(t, srv.URL, "myapp", "stop")
+	if code3 != http.StatusAccepted {
+		t.Fatalf("expected 202 after the first job finished, got %d", code3)
+	}
+}
+
+func TestServiceRestartJobIsScopedPerService(t *testing.T) {
+	gate := make(chan struct{})
+	s := newJobTestServer(&fakeRunner{lines: []string{"Restarting web"}, gate: gate})
+	srv := newSkippableHTTPServer(t, newJobRouter(s))
+	defer srv.Close()
+
+	post := func(service string) (int, map[string]any) {
+		resp, err := http.Post(
+			srv.URL+"/api/deployments/app/services/"+service+"/job",
+			"application/json",
+			strings.NewReader(`{"action":"restart"}`),
+		)
+		if err != nil {
+			t.Fatalf("service restart request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		var body map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		return resp.StatusCode, body
+	}
+
+	code, body := post("web")
+	if code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", code)
+	}
+	webJobID, _ := body["job_id"].(string)
+	if !waitFor(func() bool { return s.jobs.get(webJobID) != nil }) {
+		t.Fatal("web job not registered")
+	}
+
+	// Same service while running is rejected.
+	if code2, _ := post("web"); code2 != http.StatusConflict {
+		t.Fatalf("expected 409 for the same service, got %d", code2)
+	}
+
+	// A different service runs concurrently.
+	if code3, _ := post("db"); code3 != http.StatusAccepted {
+		t.Fatalf("expected 202 for a different service, got %d", code3)
+	}
+
+	close(gate)
+	snap := pollJob(t, srv.URL, "app", webJobID)
+	if snap.Status != JobSucceeded || snap.Service != "web" {
+		t.Fatalf("expected succeeded web job, got status=%s service=%s", snap.Status, snap.Service)
+	}
+}
+
+func TestDeploymentJobStreamReplaysAndCompletes(t *testing.T) {
+	s := &Server{
+		jobs:           newJobRegistry(),
+		authMiddleware: auth.NewMiddleware(&config.AuthConfig{Enabled: false}),
+	}
+
+	// Pre-populate a finished job so the stream must replay buffered output.
+	job, _ := s.jobs.create("myapp", "start")
+	job.appendLine("Pulling nginx")
+	job.appendLine("Started")
+	s.jobs.finish(job, JobSucceeded, "")
+
+	r := gin.New()
+	r.GET("/api/deployments/:name/jobs/:jobId/stream", s.streamDeploymentJob)
+	srv := newSkippableHTTPServer(t, r)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/api/deployments/myapp/jobs/" + job.ID() + "/stream"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("failed to dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	var lines []string
+	var result map[string]any
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	for {
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		var frame map[string]any
+		if json.Unmarshal(msg, &frame) != nil {
+			continue
+		}
+		switch frame["type"] {
+		case "line":
+			if d, ok := frame["data"].(string); ok {
+				lines = append(lines, d)
+			}
+		case "result":
+			result = frame
+		}
+		if result != nil {
+			break
+		}
+	}
+
+	if len(lines) != 2 || lines[0] != "Pulling nginx" || lines[1] != "Started" {
+		t.Fatalf("expected replayed lines, got %v", lines)
+	}
+	if result == nil || result["status"] != string(JobSucceeded) {
+		t.Fatalf("expected a succeeded result frame, got %v", result)
+	}
+}
+
+func waitFor(cond func() bool) bool {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+type errStub string
+
+func (e errStub) Error() string { return string(e) }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -90,6 +90,13 @@ type Server struct {
 	aiProvider         ai.Provider
 	aiSessions         *ai.SessionStore
 
+	jobs *jobRegistry
+	// runDeploymentAction runs a deployment action and streams each output
+	// line to emit. Overridable in tests so they need not shell out to docker.
+	runDeploymentAction func(action, name string, emit func(line string)) error
+	// runServiceAction runs an action on a single service, streaming output.
+	runServiceAction func(action, name, service string, emit func(line string)) error
+
 	statsMu    sync.RWMutex
 	statsCache gin.H
 	statsAt    time.Time
@@ -282,7 +289,10 @@ func New(cfg *config.Config, configPath string) *Server {
 		setupHandlers:      setup.NewHandlers(setupManager, authManager),
 		planStore:          plan.NewStore(cfg.DeploymentsPath),
 		aiSessions:         ai.NewSessionStore(cfg.DeploymentsPath),
+		jobs:               newJobRegistry(),
 	}
+	s.runDeploymentAction = s.defaultRunDeploymentAction
+	s.runServiceAction = s.defaultRunServiceAction
 
 	s.planStore.StartPruneLoop(context.Background(), time.Hour, time.Duration(cfg.Plans.RetentionDays)*24*time.Hour)
 
@@ -320,6 +330,7 @@ func (s *Server) setupRoutes() {
 		api.GET("/containers/:id/exec", s.containerExec)
 		api.GET("/system/terminal", s.systemTerminal)
 		api.GET("/system/terminal/interactive", s.systemTerminalInteractive)
+		api.GET("/deployments/:name/jobs/:jobId/stream", s.streamDeploymentJob)
 
 		// Setup endpoints (public, gated by setup state)
 		setupGroup := api.Group("/setup")
@@ -359,6 +370,8 @@ func (s *Server) setupRoutes() {
 			protected.POST("/deployments/:name/deploy", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.deployDeployment)
 			protected.POST("/deployments/:name/pull", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.pullDeploymentImage)
 			protected.GET("/deployments/:name/images", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelRead), s.getDeploymentImages)
+			protected.GET("/deployments/:name/jobs/active", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelRead), s.getActiveDeploymentJob)
+			protected.GET("/deployments/:name/jobs/:jobId", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelRead), s.getDeploymentJob)
 			protected.POST("/deployments/:name/actions/:actionId", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.executeQuickAction)
 			protected.GET("/deployments/:name/logs", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelRead), s.getDeploymentLogs)
 			protected.GET("/deployments/:name/compose", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelRead), s.getDeploymentCompose)
@@ -416,6 +429,7 @@ func (s *Server) setupRoutes() {
 			protected.POST("/deployments/:name/services/:service/start", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.serviceActionHandler("start"))
 			protected.POST("/deployments/:name/services/:service/stop", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.serviceActionHandler("stop"))
 			protected.POST("/deployments/:name/services/:service/restart", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.serviceActionHandler("restart"))
+			protected.POST("/deployments/:name/services/:service/job", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.enqueueServiceJob)
 			protected.POST("/deployments/:name/services/:service/rebuild", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.serviceActionHandler("rebuild"))
 			protected.POST("/deployments/:name/services/:service/pull", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.serviceActionHandler("pull"))
 
@@ -1785,66 +1799,15 @@ func (s *Server) deleteDeployment(c *gin.Context) {
 }
 
 func (s *Server) startDeployment(c *gin.Context) {
-	name := c.Param("name")
-
-	auth, opts := s.deploymentAuthOptions(name)
-	defer auth.Close()
-
-	output, err := s.manager.StartDeployment(name, opts...)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":  err.Error(),
-			"output": output,
-		})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"message": "Deployment started",
-		"name":    name,
-		"output":  output,
-	})
+	s.enqueueDeploymentAction(c, "start")
 }
 
 func (s *Server) stopDeployment(c *gin.Context) {
-	name := c.Param("name")
-
-	output, err := s.manager.StopDeployment(name)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":  err.Error(),
-			"output": output,
-		})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"message": "Deployment stopped",
-		"name":    name,
-		"output":  output,
-	})
+	s.enqueueDeploymentAction(c, "stop")
 }
 
 func (s *Server) restartDeployment(c *gin.Context) {
-	name := c.Param("name")
-
-	auth, opts := s.deploymentAuthOptions(name)
-	defer auth.Close()
-
-	output, err := s.manager.RestartDeployment(name, opts...)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":  err.Error(),
-			"output": output,
-		})
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"message": "Deployment restarted",
-		"name":    name,
-		"output":  output,
-	})
+	s.enqueueDeploymentAction(c, "restart")
 }
 
 func (s *Server) rebuildDeployment(c *gin.Context) {
@@ -1852,24 +1815,160 @@ func (s *Server) rebuildDeployment(c *gin.Context) {
 	if !s.requireUnprotectedDeploymentAction(c, name, protectedActionRebuild) {
 		return
 	}
+	s.enqueueDeploymentAction(c, "rebuild")
+}
 
-	auth, opts := s.deploymentAuthOptions(name)
-	defer auth.Close()
+// enqueueDeploymentAction starts a deployment action as a background job and
+// returns its id immediately. A second action while one is in flight for the
+// same deployment is rejected with the active job's id.
+func (s *Server) enqueueDeploymentAction(c *gin.Context, action string) {
+	name := c.Param("name")
 
-	output, err := s.manager.RebuildDeployment(name, opts...)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"error":  err.Error(),
-			"output": output,
+	job, created := s.jobs.create(name, action)
+	if !created {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":         "An action is already running for this deployment",
+			"active_job_id": job.ID(),
 		})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
-		"message": "Deployment rebuilt",
-		"name":    name,
-		"output":  output,
+	go s.runActionJob(job)
+
+	c.JSON(http.StatusAccepted, gin.H{
+		"job_id":     job.ID(),
+		"deployment": name,
+		"action":     action,
+		"status":     string(JobPending),
 	})
+}
+
+func (s *Server) runActionJob(job *ActionJob) {
+	job.setRunning()
+	err := s.runDeploymentAction(job.action, job.deployment, job.appendLine)
+	if err != nil {
+		s.jobs.finish(job, JobFailed, err.Error())
+		return
+	}
+	s.jobs.finish(job, JobSucceeded, "")
+}
+
+func (s *Server) defaultRunDeploymentAction(action, name string, emit func(line string)) error {
+	authCfg, opts := s.deploymentAuthOptions(name)
+	defer authCfg.Close()
+
+	opts = append(opts, docker.WithLineSink(emit))
+
+	var err error
+	switch action {
+	case "start":
+		_, err = s.manager.StartDeployment(name, opts...)
+	case "stop":
+		_, err = s.manager.StopDeployment(name, opts...)
+	case "restart":
+		_, err = s.manager.RestartDeployment(name, opts...)
+	case "rebuild":
+		_, err = s.manager.RebuildDeployment(name, opts...)
+	default:
+		err = fmt.Errorf("unsupported deployment action: %s", action)
+	}
+	return err
+}
+
+var streamableServiceActions = map[string]bool{
+	"start": true, "stop": true, "restart": true, "rebuild": true, "pull": true,
+}
+
+// enqueueServiceJob runs a single service's action as a streamed background job
+// so the UI can show live progress instead of only a spinner. The action is
+// taken from the body so one route covers every action.
+func (s *Server) enqueueServiceJob(c *gin.Context) {
+	var req struct {
+		Action string `json:"action"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body: " + err.Error()})
+		return
+	}
+	if !streamableServiceActions[req.Action] {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Unsupported service action: " + req.Action})
+		return
+	}
+
+	name := c.Param("name")
+	service := c.Param("service")
+
+	job, created := s.jobs.createScoped(name, service, req.Action)
+	if !created {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":         "An action is already running for this service",
+			"active_job_id": job.ID(),
+		})
+		return
+	}
+
+	go s.runServiceActionJob(job)
+
+	c.JSON(http.StatusAccepted, gin.H{
+		"job_id":     job.ID(),
+		"deployment": name,
+		"service":    service,
+		"action":     req.Action,
+		"status":     string(JobPending),
+	})
+}
+
+func (s *Server) runServiceActionJob(job *ActionJob) {
+	job.setRunning()
+	err := s.runServiceAction(job.action, job.deployment, job.service, job.appendLine)
+	if err != nil {
+		s.jobs.finish(job, JobFailed, err.Error())
+		return
+	}
+	s.jobs.finish(job, JobSucceeded, "")
+}
+
+func (s *Server) defaultRunServiceAction(action, name, service string, emit func(line string)) error {
+	authCfg, opts := s.deploymentAuthOptions(name)
+	defer authCfg.Close()
+
+	opts = append(opts, docker.WithLineSink(emit))
+
+	var err error
+	switch action {
+	case "start":
+		_, err = s.manager.StartService(name, service, opts...)
+	case "stop":
+		_, err = s.manager.StopService(name, service, opts...)
+	case "restart":
+		_, err = s.manager.RestartService(name, service, opts...)
+	case "rebuild":
+		_, err = s.manager.RebuildService(name, service, opts...)
+	case "pull":
+		_, err = s.manager.PullService(name, service, opts...)
+	default:
+		err = fmt.Errorf("unsupported service action: %s", action)
+	}
+	return err
+}
+
+func (s *Server) getDeploymentJob(c *gin.Context) {
+	name := c.Param("name")
+	job := s.jobs.get(c.Param("jobId"))
+	if job == nil || job.Deployment() != name {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Job not found"})
+		return
+	}
+	c.JSON(http.StatusOK, job.snapshot())
+}
+
+func (s *Server) getActiveDeploymentJob(c *gin.Context) {
+	job := s.jobs.activeFor(c.Param("name"))
+	if job == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "No active job for this deployment"})
+		return
+	}
+	c.JSON(http.StatusOK, job.snapshot())
 }
 
 func (s *Server) deployDeployment(c *gin.Context) {

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -1,12 +1,15 @@
 package docker
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
@@ -23,6 +26,7 @@ type RunOption func(*runOpts)
 
 type runOpts struct {
 	extraEnv []string
+	lineSink func(string)
 }
 
 func WithDockerConfig(dir string) RunOption {
@@ -30,6 +34,14 @@ func WithDockerConfig(dir string) RunOption {
 		if dir != "" {
 			o.extraEnv = append(o.extraEnv, "DOCKER_CONFIG="+dir)
 		}
+	}
+}
+
+// WithLineSink streams the compose command's combined output to sink one line
+// at a time as it is produced, instead of returning it only on completion.
+func WithLineSink(sink func(string)) RunOption {
+	return func(o *runOpts) {
+		o.lineSink = sink
 	}
 }
 
@@ -310,6 +322,10 @@ func (c *ComposeExecutor) runCompose(deploymentPath string, opts []RunOption, ar
 		cmd.Env = append(os.Environ(), ro.extraEnv...)
 	}
 
+	if ro.lineSink != nil {
+		return runComposeStreaming(cmd, ro.lineSink)
+	}
+
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -320,6 +336,49 @@ func (c *ComposeExecutor) runCompose(deploymentPath string, opts []RunOption, ar
 	}
 
 	return stdout.String(), nil
+}
+
+func runComposeStreaming(cmd *exec.Cmd, sink func(string)) (string, error) {
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return "", err
+	}
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
+
+	var mu sync.Mutex
+	var combined bytes.Buffer
+	var wg sync.WaitGroup
+	scan := func(r io.Reader) {
+		defer wg.Done()
+		sc := bufio.NewScanner(r)
+		// Image pull/build progress lines can be long; raise the per-line cap.
+		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for sc.Scan() {
+			line := sc.Text()
+			sink(line)
+			mu.Lock()
+			combined.WriteString(line)
+			combined.WriteByte('\n')
+			mu.Unlock()
+		}
+	}
+	wg.Add(2)
+	go scan(stdoutPipe)
+	go scan(stderrPipe)
+	wg.Wait()
+
+	err = cmd.Wait()
+	out := combined.String()
+	if err != nil {
+		return out, fmt.Errorf("%w: %s", err, out)
+	}
+	return out, nil
 }
 
 func (c *ComposeExecutor) findComposeCommand() string {

--- a/internal/docker/manager.go
+++ b/internal/docker/manager.go
@@ -358,7 +358,7 @@ func (m *Manager) restoreBindMounts(deploymentPath, snapshotDir string) {
 	})
 }
 
-func (m *Manager) StopDeployment(name string) (string, error) {
+func (m *Manager) StopDeployment(name string, opts ...RunOption) (string, error) {
 	m.mu.RLock()
 	deployment, err := m.discovery.GetDeployment(name)
 	m.mu.RUnlock()
@@ -367,7 +367,7 @@ func (m *Manager) StopDeployment(name string) (string, error) {
 		return "", err
 	}
 
-	return m.executor.Stop(deployment.Path)
+	return m.executor.Stop(deployment.Path, opts...)
 }
 
 func (m *Manager) RestartDeployment(name string, opts ...RunOption) (string, error) {

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -279,33 +279,67 @@ func (c *APIClient) RefreshTemplates() error {
 }
 
 func (c *APIClient) StartDeployment(name string) error {
-	resp, err := c.Post("/deployments/"+name+"/start", nil)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("failed to start deployment: %s - %s", resp.Status, string(body))
-	}
-
-	return nil
+	return c.runDeploymentJob(name, "start")
 }
 
 func (c *APIClient) StopDeployment(name string) error {
-	resp, err := c.Post("/deployments/"+name+"/stop", nil)
+	return c.runDeploymentJob(name, "stop")
+}
+
+type actionJobResponse struct {
+	JobID  string `json:"job_id"`
+	Status string `json:"status"`
+}
+
+type jobStatusResponse struct {
+	Status string `json:"status"`
+	Output string `json:"output"`
+	Error  string `json:"error"`
+}
+
+// runDeploymentJob enqueues a deployment action and waits for the background
+// job to finish, so callers observe the same synchronous behaviour as before.
+func (c *APIClient) runDeploymentJob(name, action string) error {
+	resp, err := c.Post("/deployments/"+name+"/"+action, nil)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusAccepted {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("failed to stop deployment: %s - %s", resp.Status, string(body))
+		return fmt.Errorf("failed to %s deployment: %s - %s", action, resp.Status, string(body))
 	}
 
-	return nil
+	var enqueued actionJobResponse
+	if err := json.NewDecoder(resp.Body).Decode(&enqueued); err != nil {
+		return fmt.Errorf("failed to decode %s job response: %w", action, err)
+	}
+
+	deadline := time.Now().Add(5 * time.Minute)
+	for time.Now().Before(deadline) {
+		statusResp, err := c.Get("/deployments/" + name + "/jobs/" + enqueued.JobID)
+		if err != nil {
+			return err
+		}
+		var job jobStatusResponse
+		decodeErr := json.NewDecoder(statusResp.Body).Decode(&job)
+		statusResp.Body.Close()
+		if decodeErr != nil {
+			return decodeErr
+		}
+
+		switch job.Status {
+		case "succeeded":
+			return nil
+		case "failed":
+			return fmt.Errorf("%s deployment failed: %s - %s", action, job.Error, job.Output)
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return fmt.Errorf("%s deployment timed out", action)
 }
 
 func WaitForHTTP(url string, timeout time.Duration) error {


### PR DESCRIPTION
Closes #150.

Start/stop/restart/rebuild for a whole deployment, and for a single service, were synchronous: compose output came back only on completion, so the UI could show nothing but a spinner and the result was lost on reload.

These actions now run as background jobs. The endpoint returns a job id immediately, compose output streams line by line over a websocket (authenticated with the same first-message handshake as the terminal endpoints), and the output is buffered so the job status stays queryable and survives a page reload. One action runs at a time per deployment, and per service within a deployment, so different services can act concurrently while the same target is rejected. Finished jobs are kept briefly in memory and are not retained across an agent restart, which the page-reload requirement does not need.

Service actions go through a single `POST .../services/:service/job` taking the action in the body, rather than a route per action.

Concurrency was checked under `go test -race` for the job and streaming paths; the e2e helpers now enqueue and poll to keep their existing synchronous behaviour.