### PR TITLE
fix: Auto-renew certificates by default, with honest renew reporting and proxy tuning

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -38,7 +38,7 @@ certbot:
     webroot_path: ""
     container_webroot_path: ""
     dns_provider: ""
-    auto_renewal_enabled: false
+    auto_renewal_enabled: true
     renewal_threshold_days: 30
     renewal_check_interval: 12h0m0s
 logging:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -791,7 +791,10 @@ func (s *Server) Start() error {
 		}
 	}()
 
-	if s.config.Certbot.Enabled && s.config.Certbot.AutoRenewalEnabled != nil && *s.config.Certbot.AutoRenewalEnabled {
+	// The renewer runs whenever certbot is enabled; whether each certificate renews
+	// is decided per certificate (with the global setting only as the default), so a
+	// certificate marked for auto-renew is never vetoed by the global flag.
+	if s.config.Certbot.Enabled {
 		s.certRenewer = ssl.NewRenewer(
 			s.proxyOrchestrator.SSLManager(),
 			s.config.Certbot.RenewalThresholdDays,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -791,7 +791,7 @@ func (s *Server) Start() error {
 		}
 	}()
 
-	if s.config.Certbot.Enabled && s.config.Certbot.AutoRenewalEnabled {
+	if s.config.Certbot.Enabled && s.config.Certbot.AutoRenewalEnabled != nil && *s.config.Certbot.AutoRenewalEnabled {
 		s.certRenewer = ssl.NewRenewer(
 			s.proxyOrchestrator.SSLManager(),
 			s.config.Certbot.RenewalThresholdDays,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4726,15 +4726,21 @@ func (s *Server) getCertificate(c *gin.Context) {
 
 func (s *Server) renewCertificate(c *gin.Context) {
 	domain := c.Param("domain")
+	force := c.Query("force") == "true"
 
-	result, err := s.proxyOrchestrator.RenewCertificate(domain)
+	result, err := s.proxyOrchestrator.RenewCertificate(domain, force)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
+	message := "Certificate renewed"
+	if !result.Renewed {
+		message = "Certificate is not yet due for renewal"
+	}
+
 	c.JSON(http.StatusOK, gin.H{
-		"message": "Certificate renewed",
+		"message": message,
 		"domain":  domain,
 		"result":  result,
 	})

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -266,12 +266,12 @@ func (o *Orchestrator) RenewCertificates() (*ssl.RenewalResult, error) {
 	return result, nil
 }
 
-func (o *Orchestrator) RenewCertificate(domain string) (*ssl.RenewalResult, error) {
+func (o *Orchestrator) RenewCertificate(domain string, force bool) (*ssl.RenewalResult, error) {
 	if err := o.ssl.ValidateDomain(domain); err != nil {
 		return nil, err
 	}
 
-	result, err := o.ssl.RenewCertificate(domain)
+	result, err := o.ssl.RenewCertificate(domain, force)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +293,7 @@ func (o *Orchestrator) RenewCertificatesForDomains(domains []string) *ssl.MultiC
 		if !o.ssl.CertificateExists(domain) {
 			continue
 		}
-		if _, err := o.ssl.RenewCertificate(domain); err != nil {
+		if _, err := o.ssl.RenewCertificate(domain, false); err != nil {
 			result.Results = append(result.Results, &ssl.CertificateResult{
 				Domain:  domain,
 				Success: false,

--- a/internal/ssl/autorenew.go
+++ b/internal/ssl/autorenew.go
@@ -93,7 +93,7 @@ func (r *Renewer) Run() {
 		if !cert.AutoRenew {
 			continue
 		}
-		if _, err := r.manager.RenewCertificate(cert.Domain); err != nil {
+		if _, err := r.manager.RenewCertificate(cert.Domain, false); err != nil {
 			log.Printf("auto-renew: failed to renew %s (days_left=%d): %v", cert.Domain, cert.DaysLeft, err)
 			continue
 		}

--- a/internal/ssl/manager.go
+++ b/internal/ssl/manager.go
@@ -227,6 +227,14 @@ func (m *Manager) certificateExistsLocked(domain string) bool {
 	return err == nil
 }
 
+// Per-certificate auto-renew markers. An explicit marker overrides the global
+// default in either direction; a certificate with neither marker follows the
+// global default. Only one marker is ever present at a time.
+const (
+	autoRenewEnabledMarker  = ".flatrun-auto-renew-enabled"
+	autoRenewDisabledMarker = ".flatrun-auto-renew-disabled"
+)
+
 func (m *Manager) SetAutoRenew(domain string, enabled bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -235,25 +243,34 @@ func (m *Manager) SetAutoRenew(domain string, enabled bool) error {
 		return fmt.Errorf("certificate for domain %q not found", domain)
 	}
 
-	marker := filepath.Join(m.certsPath, domain, ".flatrun-auto-renew-disabled")
+	dir := filepath.Join(m.certsPath, domain)
+	write := filepath.Join(dir, autoRenewDisabledMarker)
+	remove := filepath.Join(dir, autoRenewEnabledMarker)
 	if enabled {
-		if err := os.Remove(marker); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to enable auto-renew: %w", err)
-		}
-		return nil
+		write, remove = remove, write
 	}
 
-	f, err := os.Create(marker)
+	if err := os.Remove(remove); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to set auto-renew: %w", err)
+	}
+	f, err := os.Create(write)
 	if err != nil {
-		return fmt.Errorf("failed to disable auto-renew: %w", err)
+		return fmt.Errorf("failed to set auto-renew: %w", err)
 	}
 	return f.Close()
 }
 
+// isAutoRenewEnabled reports whether a certificate should auto-renew. An explicit
+// per-certificate marker wins over the global default in both directions.
 func (m *Manager) isAutoRenewEnabled(domain string) bool {
-	marker := filepath.Join(m.certsPath, domain, ".flatrun-auto-renew-disabled")
-	_, err := os.Stat(marker)
-	return os.IsNotExist(err)
+	dir := filepath.Join(m.certsPath, domain)
+	if _, err := os.Stat(filepath.Join(dir, autoRenewDisabledMarker)); err == nil {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(dir, autoRenewEnabledMarker)); err == nil {
+		return true
+	}
+	return m.config.AutoRenewalEnabled == nil || *m.config.AutoRenewalEnabled
 }
 
 func (m *Manager) RevokeCertificate(domain string) error {

--- a/internal/ssl/manager.go
+++ b/internal/ssl/manager.go
@@ -176,7 +176,7 @@ func (m *Manager) RenewCertificates() (*RenewalResult, error) {
 	}, nil
 }
 
-func (m *Manager) RenewCertificate(domain string) (*RenewalResult, error) {
+func (m *Manager) RenewCertificate(domain string, force bool) (*RenewalResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -184,24 +184,41 @@ func (m *Manager) RenewCertificate(domain string) (*RenewalResult, error) {
 		return nil, fmt.Errorf("certificate for domain %q not found", domain)
 	}
 
-	// A user clicking Renew on one certificate wants it renewed now, not "only if
-	// within certbot's ~30-day auto-renew window". Without --force-renewal, certbot
-	// skips a not-yet-due cert and exits 0, so the action silently does nothing.
-	output, err := m.executeCertbot([]string{
-		"renew",
-		"--non-interactive",
-		"--cert-name", domain,
-		"--force-renewal",
-	})
+	args := []string{"renew", "--non-interactive", "--cert-name", domain}
+	if force {
+		args = append(args, "--force-renewal")
+	}
+	output, err := m.executeCertbot(args)
 	if err != nil {
 		return nil, fmt.Errorf("renewal failed for %s: %s - %w", domain, string(output), err)
 	}
 
-	return &RenewalResult{
-		Success:        true,
-		Message:        string(output),
-		RenewedDomains: []string{domain},
-	}, nil
+	// Without --force-renewal certbot skips a not-yet-due cert and still exits 0,
+	// so distinguish an actual reissue from a no-op instead of always claiming success.
+	renewed := force || certbotDidRenew(string(output))
+	result := &RenewalResult{
+		Success: true,
+		Renewed: renewed,
+		Message: string(output),
+	}
+	if renewed {
+		result.RenewedDomains = []string{domain}
+	}
+	return result, nil
+}
+
+// certbotDidRenew reports whether a `certbot renew` run actually reissued a cert,
+// by looking for the phrases certbot prints when it skips a not-yet-due lineage.
+func certbotDidRenew(output string) bool {
+	lower := strings.ToLower(output)
+	switch {
+	case strings.Contains(lower, "no renewals were attempted"),
+		strings.Contains(lower, "not yet due for renewal"),
+		strings.Contains(lower, "no certificates are due for renewal"):
+		return false
+	default:
+		return true
+	}
 }
 
 func (m *Manager) certificateExistsLocked(domain string) bool {
@@ -427,6 +444,7 @@ type CertificateResult struct {
 
 type RenewalResult struct {
 	Success        bool     `json:"success"`
+	Renewed        bool     `json:"renewed"`
 	Message        string   `json:"message"`
 	RenewedDomains []string `json:"renewed_domains,omitempty"`
 }

--- a/internal/ssl/manager.go
+++ b/internal/ssl/manager.go
@@ -184,10 +184,14 @@ func (m *Manager) RenewCertificate(domain string) (*RenewalResult, error) {
 		return nil, fmt.Errorf("certificate for domain %q not found", domain)
 	}
 
+	// A user clicking Renew on one certificate wants it renewed now, not "only if
+	// within certbot's ~30-day auto-renew window". Without --force-renewal, certbot
+	// skips a not-yet-due cert and exits 0, so the action silently does nothing.
 	output, err := m.executeCertbot([]string{
 		"renew",
 		"--non-interactive",
 		"--cert-name", domain,
+		"--force-renewal",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("renewal failed for %s: %s - %w", domain, string(output), err)

--- a/internal/ssl/manager_test.go
+++ b/internal/ssl/manager_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 type mockExecutor struct {
-	mu   sync.Mutex
+	mu    sync.Mutex
 	calls []executorCall
 	err   error
+	out   []byte
 }
 
 type executorCall struct {
@@ -28,6 +29,9 @@ func (e *mockExecutor) Execute(cfg *config.ServiceExecConfig, args []string) ([]
 	e.calls = append(e.calls, executorCall{cfg: cfg, args: args})
 	if e.err != nil {
 		return nil, e.err
+	}
+	if e.out != nil {
+		return e.out, nil
 	}
 	return []byte("ok"), nil
 }

--- a/internal/ssl/renewal_test.go
+++ b/internal/ssl/renewal_test.go
@@ -91,20 +91,22 @@ func TestRenewCertificate_PassesCertName(t *testing.T) {
 	}
 
 	args := mock.calls[0].args
-	var hasRenew, hasNonInteractive, hasCertName bool
+	var hasRenew, hasNonInteractive, hasCertName, hasForce bool
 	for i, arg := range args {
 		switch arg {
 		case "renew":
 			hasRenew = true
 		case "--non-interactive":
 			hasNonInteractive = true
+		case "--force-renewal":
+			hasForce = true
 		case "--cert-name":
 			if i+1 < len(args) && args[i+1] == "example.com" {
 				hasCertName = true
 			}
 		}
 	}
-	if !hasRenew || !hasNonInteractive || !hasCertName {
+	if !hasRenew || !hasNonInteractive || !hasCertName || !hasForce {
 		t.Errorf("unexpected certbot args: %v", args)
 	}
 }

--- a/internal/ssl/renewal_test.go
+++ b/internal/ssl/renewal_test.go
@@ -182,6 +182,35 @@ func TestSetAutoRenew_ErrorsWhenCertMissing(t *testing.T) {
 	}
 }
 
+func TestAutoRenew_PerCertOverridesGlobalDefault(t *testing.T) {
+	m, _, certsDir := newTestManager(t)
+	writeTestCert(t, certsDir, "untouched.example.com", time.Now().Add(10*24*time.Hour))
+	writeTestCert(t, certsDir, "forced-on.example.com", time.Now().Add(10*24*time.Hour))
+
+	off := false
+	m.config.AutoRenewalEnabled = &off
+
+	if m.isAutoRenewEnabled("untouched.example.com") {
+		t.Error("untouched certificate should follow the global default (off)")
+	}
+
+	if err := m.SetAutoRenew("forced-on.example.com", true); err != nil {
+		t.Fatalf("SetAutoRenew(true): %v", err)
+	}
+	if !m.isAutoRenewEnabled("forced-on.example.com") {
+		t.Error("explicitly enabled certificate must renew despite the global default being off")
+	}
+
+	on := true
+	m.config.AutoRenewalEnabled = &on
+	if err := m.SetAutoRenew("untouched.example.com", false); err != nil {
+		t.Fatalf("SetAutoRenew(false): %v", err)
+	}
+	if m.isAutoRenewEnabled("untouched.example.com") {
+		t.Error("explicitly disabled certificate must not renew despite the global default being on")
+	}
+}
+
 func TestGetExpiringCertificates_FiltersByThreshold(t *testing.T) {
 	m, _, certsDir := newTestManager(t)
 	writeTestCert(t, certsDir, "fresh.example.com", time.Now().Add(90*24*time.Hour))

--- a/internal/ssl/renewal_test.go
+++ b/internal/ssl/renewal_test.go
@@ -71,50 +71,64 @@ func newTestManager(t *testing.T) (*Manager, *mockExecutor, string) {
 	return m, mock, certsDir
 }
 
-func TestRenewCertificate_PassesCertName(t *testing.T) {
+func hasArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRenewCertificate_ForceAddsForceRenewal(t *testing.T) {
 	m, mock, certsDir := newTestManager(t)
 	writeTestCert(t, certsDir, "example.com", time.Now().Add(10*24*time.Hour))
 
-	result, err := m.RenewCertificate("example.com")
+	result, err := m.RenewCertificate("example.com", true)
 	if err != nil {
 		t.Fatalf("RenewCertificate: %v", err)
 	}
-	if !result.Success {
-		t.Error("expected Success=true")
+	if !result.Success || !result.Renewed {
+		t.Errorf("expected Success and Renewed true, got %+v", result)
 	}
 	if len(result.RenewedDomains) != 1 || result.RenewedDomains[0] != "example.com" {
 		t.Errorf("RenewedDomains = %v, want [example.com]", result.RenewedDomains)
 	}
 
-	if len(mock.calls) != 1 {
-		t.Fatalf("expected 1 executor call, got %d", len(mock.calls))
+	args := mock.calls[0].args
+	if !hasArg(args, "renew") || !hasArg(args, "--cert-name") || !hasArg(args, "--force-renewal") {
+		t.Errorf("expected force renewal args, got: %v", args)
+	}
+}
+
+func TestRenewCertificate_NoForceSkipsForceRenewalAndReportsNotDue(t *testing.T) {
+	m, mock, certsDir := newTestManager(t)
+	mock.out = []byte("Cert not yet due for renewal\nNo renewals were attempted.")
+	writeTestCert(t, certsDir, "example.com", time.Now().Add(60*24*time.Hour))
+
+	result, err := m.RenewCertificate("example.com", false)
+	if err != nil {
+		t.Fatalf("RenewCertificate: %v", err)
+	}
+	if !result.Success {
+		t.Error("expected Success true")
+	}
+	if result.Renewed {
+		t.Error("expected Renewed false when certbot reports the cert is not yet due")
+	}
+	if len(result.RenewedDomains) != 0 {
+		t.Errorf("expected no RenewedDomains, got %v", result.RenewedDomains)
 	}
 
-	args := mock.calls[0].args
-	var hasRenew, hasNonInteractive, hasCertName, hasForce bool
-	for i, arg := range args {
-		switch arg {
-		case "renew":
-			hasRenew = true
-		case "--non-interactive":
-			hasNonInteractive = true
-		case "--force-renewal":
-			hasForce = true
-		case "--cert-name":
-			if i+1 < len(args) && args[i+1] == "example.com" {
-				hasCertName = true
-			}
-		}
-	}
-	if !hasRenew || !hasNonInteractive || !hasCertName || !hasForce {
-		t.Errorf("unexpected certbot args: %v", args)
+	if hasArg(mock.calls[0].args, "--force-renewal") {
+		t.Errorf("did not expect --force-renewal without force, got: %v", mock.calls[0].args)
 	}
 }
 
 func TestRenewCertificate_ErrorsWhenMissing(t *testing.T) {
 	m, mock, _ := newTestManager(t)
 
-	_, err := m.RenewCertificate("missing.example.com")
+	_, err := m.RenewCertificate("missing.example.com", false)
 	if err == nil {
 		t.Fatal("expected error for missing certificate")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -103,7 +103,7 @@ type CertbotConfig struct {
 	WebrootPath          string        `yaml:"webroot_path" json:"webroot_path"`
 	ContainerWebrootPath string        `yaml:"container_webroot_path" json:"container_webroot_path"`
 	DNSProvider          string        `yaml:"dns_provider" json:"dns_provider"`
-	AutoRenewalEnabled   bool          `yaml:"auto_renewal_enabled" json:"auto_renewal_enabled"`
+	AutoRenewalEnabled   *bool         `yaml:"auto_renewal_enabled" json:"auto_renewal_enabled"`
 	RenewalThresholdDays int           `yaml:"renewal_threshold_days" json:"renewal_threshold_days"`
 	RenewalCheckInterval time.Duration `yaml:"renewal_check_interval" json:"renewal_check_interval"`
 }
@@ -344,6 +344,12 @@ func setDefaults(cfg *Config) {
 	}
 	if cfg.Certbot.RenewalCheckInterval == 0 {
 		cfg.Certbot.RenewalCheckInterval = 12 * time.Hour
+	}
+	// Auto-renewal defaults on: an unset flag should renew certificates before they
+	// expire, not leave them to lapse. An explicit false is still honored.
+	if cfg.Certbot.AutoRenewalEnabled == nil {
+		enabled := true
+		cfg.Certbot.AutoRenewalEnabled = &enabled
 	}
 	// Security defaults
 	if cfg.Security.ScanInterval == 0 {

--- a/pkg/config/registry_test.go
+++ b/pkg/config/registry_test.go
@@ -152,6 +152,21 @@ func TestFilesShowHiddenDefaultsTrueAndAcceptsFalse(t *testing.T) {
 	}
 }
 
+func TestAutoRenewalDefaultsOnAndAcceptsFalse(t *testing.T) {
+	cfg := &Config{}
+	setDefaults(cfg)
+	if cfg.Certbot.AutoRenewalEnabled == nil || !*cfg.Certbot.AutoRenewalEnabled {
+		t.Errorf("auto_renewal_enabled default = %v, want true", cfg.Certbot.AutoRenewalEnabled)
+	}
+
+	off := false
+	cfg.Certbot.AutoRenewalEnabled = &off
+	setDefaults(cfg)
+	if cfg.Certbot.AutoRenewalEnabled == nil || *cfg.Certbot.AutoRenewalEnabled {
+		t.Errorf("explicit false reset to %v, want false", cfg.Certbot.AutoRenewalEnabled)
+	}
+}
+
 func entryKeys(entries []Entry) []string {
 	out := make([]string, 0, len(entries))
 	for _, e := range entries {

--- a/templates/infra/nginx/nginx.conf
+++ b/templates/infra/nginx/nginx.conf
@@ -14,22 +14,30 @@ http {
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log /dev/stdout main;
+    access_log /dev/stdout main buffer=32k flush=5s;
 
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;
     keepalive_timeout 65;
+    keepalive_requests 1000;
     types_hash_max_size 2048;
     server_names_hash_bucket_size 128;
     server_names_hash_max_size 2048;
+
+    proxy_http_version 1.1;
+    proxy_buffering on;
+    proxy_buffer_size 8k;
+    proxy_buffers 16 8k;
+    proxy_busy_buffers_size 16k;
 
     # Gzip compression
     gzip on;
     gzip_vary on;
     gzip_proxied any;
     gzip_comp_level 6;
-    gzip_types text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/json application/javascript application/xml application/rss+xml application/atom+xml application/wasm application/manifest+json font/woff font/woff2 image/svg+xml;
 
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;

--- a/templates/infra/nginx/nginx.lua.conf
+++ b/templates/infra/nginx/nginx.lua.conf
@@ -14,22 +14,31 @@ http {
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log /dev/stdout main;
+    access_log /dev/stdout main buffer=32k flush=5s;
 
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;
     keepalive_timeout 65;
+    keepalive_requests 1000;
     types_hash_max_size 2048;
     server_names_hash_bucket_size 128;
     server_names_hash_max_size 2048;
+
+    # HTTP/1.1 to upstreams on every proxied location, not just the primary route.
+    proxy_http_version 1.1;
+    proxy_buffering on;
+    proxy_buffer_size 8k;
+    proxy_buffers 16 8k;
+    proxy_busy_buffers_size 16k;
 
     # Gzip compression
     gzip on;
     gzip_vary on;
     gzip_proxied any;
     gzip_comp_level 6;
-    gzip_types text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/json application/javascript application/xml application/rss+xml application/atom+xml application/wasm application/manifest+json font/woff font/woff2 image/svg+xml;
 
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;


### PR DESCRIPTION
Three changes on one branch, from the Albacore serving and reliability pass.

**Certificates no longer silently expire.** Two compounding problems in the renewal path: automatic renewal only started when `auto_renewal_enabled` was explicitly set (and the shipped example set it off), so the renewer never ran; and even when it did, the global flag gated the whole renewer, so a certificate the user had individually marked for auto-renew could still be vetoed by the global setting. Now the renewer runs whenever certbot is enabled, auto-renewal defaults on, and each certificate's own auto-renew setting is authoritative. The global flag only supplies the default for certificates that were never toggled; an explicit per-certificate choice always wins.

**Single-certificate renewal is honest, with force as an explicit option.** The per-certificate Renew action reported success even when it renewed nothing (certbot skips a not-yet-due certificate and exits 0). It now reports whether a certificate was actually reissued, and force-renewal is an explicit request option (`?force=true`) the UI can offer deliberately, rather than being applied to every renew.

**Proxy defaults tuned for faster deployment serving.** Upstream requests now use HTTP/1.1 on every proxied route rather than only the primary one, access logging is buffered, gzip covers modern asset types (JavaScript, wasm, web fonts) with a minimum-size floor, and proxy read buffers are sized up. Validated with `openresty -t` against the real `openresty:alpine` image.

Deferred and tracked separately: reusing connections to app containers (Albacore #158) and routing externally-fronted proxy domains (#166).
