### PR TITLE
perf(deployments): Read deployment status from the Docker engine

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4612,7 +4612,7 @@ func (s *Server) annotateCertificatesWithDeployment(certs []models.Certificate) 
 		return
 	}
 
-	deployments, err := s.manager.ListDeployments()
+	deployments, err := s.manager.FindDeployments()
 	if err != nil {
 		log.Printf("warning: failed to list deployments for cert annotation: %v", err)
 		return
@@ -5020,7 +5020,7 @@ func (s *Server) syncAllProxies(c *gin.Context) {
 		return
 	}
 
-	deployments, err := s.manager.ListDeployments()
+	deployments, err := s.manager.FindDeployments()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": err.Error(),

--- a/internal/api/traffic_handlers.go
+++ b/internal/api/traffic_handlers.go
@@ -153,7 +153,7 @@ func (s *Server) getUnknownDomainStats(c *gin.Context) {
 		}
 	}
 
-	deployments, err := s.manager.ListDeployments()
+	deployments, err := s.manager.FindDeployments()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/docker/api.go
+++ b/internal/docker/api.go
@@ -14,6 +14,13 @@ import (
 	"github.com/docker/docker/client"
 )
 
+// Labels compose stamps on every container it creates, used to map a container
+// back to its deployment without invoking the compose CLI.
+const (
+	composeProjectLabel = "com.docker.compose.project"
+	composeServiceLabel = "com.docker.compose.service"
+)
+
 type APIClient struct {
 	cli *client.Client
 }
@@ -32,8 +39,8 @@ func (a *APIClient) Close() error {
 
 func (a *APIClient) FindContainer(ctx context.Context, project, service string) (string, error) {
 	f := filters.NewArgs(
-		filters.Arg("label", fmt.Sprintf("com.docker.compose.project=%s", project)),
-		filters.Arg("label", fmt.Sprintf("com.docker.compose.service=%s", service)),
+		filters.Arg("label", fmt.Sprintf("%s=%s", composeProjectLabel, project)),
+		filters.Arg("label", fmt.Sprintf("%s=%s", composeServiceLabel, service)),
 		filters.Arg("status", "running"),
 	)
 
@@ -125,8 +132,21 @@ func (a *APIClient) ExecInService(ctx context.Context, project, service, command
 
 func (a *APIClient) ListServiceContainers(ctx context.Context, project string) ([]container.Summary, error) {
 	f := filters.NewArgs(
-		filters.Arg("label", fmt.Sprintf("com.docker.compose.project=%s", project)),
+		filters.Arg("label", fmt.Sprintf("%s=%s", composeProjectLabel, project)),
 	)
 
 	return a.cli.ContainerList(ctx, container.ListOptions{Filters: f, All: true})
+}
+
+// ListLiveComposeContainers returns the containers of every compose project on
+// the host in a single call.
+//
+// It deliberately excludes stopped containers, mirroring `compose ps`, which
+// reports only live ones unless asked for all. Including them would both change
+// what callers report and cost noticeably more, since the daemon walks every
+// container a host has ever left behind.
+func (a *APIClient) ListLiveComposeContainers(ctx context.Context) ([]container.Summary, error) {
+	f := filters.NewArgs(filters.Arg("label", composeProjectLabel))
+
+	return a.cli.ContainerList(ctx, container.ListOptions{Filters: f})
 }

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -10,12 +10,19 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"gopkg.in/yaml.v3"
 )
 
 type ComposeExecutor struct {
 	basePath string
+
+	// composeCmd caches the detected compose command. Detection spawns a
+	// process, and every compose invocation needs the result, so it is resolved
+	// once rather than per call. Only a successful detection is cached, so an
+	// agent that starts before Docker is available still recovers.
+	composeCmd atomic.Value
 }
 
 func NewComposeExecutor(basePath string) *ComposeExecutor {
@@ -467,6 +474,17 @@ func runComposeStreaming(cmd *exec.Cmd, sink func(string)) (string, error) {
 }
 
 func (c *ComposeExecutor) findComposeCommand() string {
+	if cmd, ok := c.composeCmd.Load().(string); ok && cmd != "" {
+		return cmd
+	}
+	cmd := detectComposeCommand()
+	if cmd != "" {
+		c.composeCmd.Store(cmd)
+	}
+	return cmd
+}
+
+func detectComposeCommand() string {
 	if _, err := exec.LookPath("docker"); err == nil {
 		cmd := exec.Command("docker", "compose", "version")
 		if err := cmd.Run(); err == nil {

--- a/internal/docker/manager.go
+++ b/internal/docker/manager.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/docker/docker/api/types/container"
@@ -155,6 +156,28 @@ type Manager struct {
 	basePath       string
 	cleanupTimeout time.Duration
 	mu             sync.RWMutex
+
+	// apiDegraded tracks whether status reads are currently falling back to the
+	// compose CLI, so the fallback is reported once per outage instead of once
+	// per request.
+	apiDegraded atomic.Bool
+}
+
+// noteStatusFallback reports that status reads have dropped to the compose CLI.
+// The deployment list is polled continuously, so logging every failed request
+// would bury the logs at the moment they are worth reading; only the change of
+// state is logged.
+func (m *Manager) noteStatusFallback(err error) {
+	if m.apiDegraded.CompareAndSwap(false, true) {
+		log.Printf("status: docker api unavailable, falling back to the compose cli: %v", err)
+	}
+}
+
+// noteStatusRecovered reports that status reads are served by the engine again.
+func (m *Manager) noteStatusRecovered() {
+	if m.apiDegraded.CompareAndSwap(true, false) {
+		log.Printf("status: docker api reachable again")
+	}
 }
 
 func (m *Manager) SetCleanupTimeout(d time.Duration) {
@@ -178,6 +201,11 @@ func NewManager(deploymentsPath string) *Manager {
 	}
 	if api, err := NewAPIClient(); err == nil {
 		m.apiClient = api
+	} else {
+		// The client is built once and never rebuilt, so this degrades every
+		// later status read to the compose CLI. Say so rather than leaving the
+		// agent quietly slow with no way to tell why.
+		log.Printf("docker api client unavailable, deployment status will use the slower compose cli: %v", err)
 	}
 	return m
 }
@@ -200,12 +228,13 @@ func (m *Manager) ListDeployments() ([]models.Deployment, error) {
 
 	index, err := m.indexContainersByProject(ctx)
 	if err == nil {
+		m.noteStatusRecovered()
 		for i := range deployments {
 			deployments[i].Status = statusFromContainers(index[m.projectFor(&deployments[i], index)])
 		}
 		return deployments, nil
 	}
-	log.Printf("status: falling back to compose CLI for deployment list: %v", err)
+	m.noteStatusFallback(err)
 
 	// Fallback only. Each status check shells out to docker compose, so a serial
 	// loop makes list latency grow with the deployment count. Fetch them
@@ -252,10 +281,11 @@ func (m *Manager) GetDeployment(name string) (*models.Deployment, error) {
 
 	index, err := m.indexContainersByProject(ctx)
 	if err == nil {
+		m.noteStatusRecovered()
 		applyContainers(deployment, index[m.projectFor(deployment, index)])
 		return deployment, nil
 	}
-	log.Printf("status: falling back to compose CLI for deployment %q: %v", name, err)
+	m.noteStatusFallback(err)
 
 	status, _ := m.executor.GetStatus(deployment.Path)
 	deployment.Status = status

--- a/internal/docker/manager.go
+++ b/internal/docker/manager.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/docker/api/types/container"
 	"github.com/flatrun/agent/pkg/models"
 )
 
@@ -20,6 +21,131 @@ type composeContainer struct {
 	Service string `json:"Service"`
 	State   string `json:"State"`
 	Health  string `json:"Health"`
+}
+
+// statusReadTimeout bounds the Engine API call backing a status read, so a
+// wedged daemon degrades a list request rather than hanging it.
+const statusReadTimeout = 10 * time.Second
+
+// containerIndex groups a host's live compose containers by project name.
+type containerIndex map[string][]container.Summary
+
+// indexContainersByProject reads every live compose container on the host in one
+// Engine API call and groups it by project. Deriving status from this index
+// keeps a list request at a single Docker round-trip regardless of how many
+// deployments exist, where the compose CLI costs several processes each.
+func (m *Manager) indexContainersByProject(ctx context.Context) (containerIndex, error) {
+	if m.apiClient == nil {
+		return nil, fmt.Errorf("docker api client unavailable")
+	}
+
+	summaries, err := m.apiClient.ListLiveComposeContainers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	index := make(containerIndex)
+	for _, summary := range summaries {
+		if project := summary.Labels[composeProjectLabel]; project != "" {
+			index[project] = append(index[project], summary)
+		}
+	}
+	return index, nil
+}
+
+// projectFor resolves a deployment's compose project name without shelling out.
+// It mirrors ComposeExecutor.getProjectName, except that the fallback probe for
+// an existing project reads the already-fetched index instead of running
+// `docker compose ps` once per candidate.
+func (m *Manager) projectFor(deployment *models.Deployment, index containerIndex) string {
+	if name := m.executor.readComposeProjectName(deployment.Path); name != "" {
+		return name
+	}
+
+	dirName := filepath.Base(strings.TrimSuffix(deployment.Path, "/"))
+	for _, candidate := range []string{dirName, "flatrun-" + dirName} {
+		if len(index[candidate]) > 0 {
+			return candidate
+		}
+	}
+	return dirName
+}
+
+// statusFromContainers collapses a project's live containers into a deployment
+// status. Stopped containers are absent from the index by construction, so a
+// project with none is stopped. A paused container counts as running because it
+// is still up, which is what the compose CLI path reported.
+func statusFromContainers(containers []container.Summary) string {
+	if len(containers) == 0 {
+		return string(models.StatusStopped)
+	}
+
+	for _, c := range containers {
+		if c.State == container.StateRunning || c.State == container.StatePaused {
+			return string(models.StatusRunning)
+		}
+	}
+
+	// Containers exist but none are up, e.g. restarting or being removed.
+	return string(models.StatusUnknown)
+}
+
+// healthFromStatus extracts a service's health from the Engine API's human
+// readable status ("Up 2 hours (healthy)"), which is where the daemon reports
+// it; `compose ps --format json` exposes it as a discrete field instead. Only
+// the daemon's three health renderings count: other parenthesised suffixes,
+// such as "(Paused)", are not health.
+func healthFromStatus(status string) string {
+	switch {
+	case strings.Contains(status, "(healthy)"):
+		return "healthy"
+	case strings.Contains(status, "(unhealthy)"):
+		return "unhealthy"
+	case strings.Contains(status, "(health: starting)"):
+		return "starting"
+	}
+	return ""
+}
+
+// shortContainerID trims a container ID to the 12-character form Docker itself
+// abbreviates to, which is what the compose CLI reports and therefore what
+// clients already receive.
+func shortContainerID(id string) string {
+	const shortIDLength = 12
+	if len(id) <= shortIDLength {
+		return id
+	}
+	return id[:shortIDLength]
+}
+
+// applyContainers fills a deployment's status and per-service container details
+// from its project's containers.
+func applyContainers(deployment *models.Deployment, containers []container.Summary) {
+	deployment.Status = statusFromContainers(containers)
+
+	byService := make(map[string]container.Summary, len(containers))
+	for _, c := range containers {
+		service := c.Labels[composeServiceLabel]
+		if service == "" {
+			continue
+		}
+		if _, seen := byService[service]; !seen {
+			byService[service] = c
+		}
+	}
+
+	for i := range deployment.Services {
+		svc := &deployment.Services[i]
+		c, ok := byService[svc.Name]
+		if !ok {
+			continue
+		}
+		svc.ContainerID = shortContainerID(c.ID)
+		svc.Status = c.State
+		if health := healthFromStatus(c.Status); health != "" {
+			svc.Health = health
+		}
+	}
 }
 
 type Manager struct {
@@ -69,9 +195,22 @@ func (m *Manager) ListDeployments() ([]models.Deployment, error) {
 		return nil, err
 	}
 
-	// Each status check shells out to docker compose, so a serial loop makes
-	// list latency grow with the deployment count. Fetch them concurrently with
-	// a bounded worker pool; each goroutine writes only its own index.
+	ctx, cancel := context.WithTimeout(context.Background(), statusReadTimeout)
+	defer cancel()
+
+	index, err := m.indexContainersByProject(ctx)
+	if err == nil {
+		for i := range deployments {
+			deployments[i].Status = statusFromContainers(index[m.projectFor(&deployments[i], index)])
+		}
+		return deployments, nil
+	}
+	log.Printf("status: falling back to compose CLI for deployment list: %v", err)
+
+	// Fallback only. Each status check shells out to docker compose, so a serial
+	// loop makes list latency grow with the deployment count. Fetch them
+	// concurrently with a bounded worker pool; each goroutine writes only its
+	// own index.
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 12)
 	for i := range deployments {
@@ -89,6 +228,16 @@ func (m *Manager) ListDeployments() ([]models.Deployment, error) {
 	return deployments, nil
 }
 
+// FindDeployments returns deployments built from their on-disk metadata alone,
+// leaving Status unread. Callers that only need names, paths or metadata should
+// prefer it over ListDeployments so they never pay for a Docker round-trip.
+func (m *Manager) FindDeployments() ([]models.Deployment, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.discovery.FindDeployments()
+}
+
 func (m *Manager) GetDeployment(name string) (*models.Deployment, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -97,6 +246,16 @@ func (m *Manager) GetDeployment(name string) (*models.Deployment, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), statusReadTimeout)
+	defer cancel()
+
+	index, err := m.indexContainersByProject(ctx)
+	if err == nil {
+		applyContainers(deployment, index[m.projectFor(deployment, index)])
+		return deployment, nil
+	}
+	log.Printf("status: falling back to compose CLI for deployment %q: %v", name, err)
 
 	status, _ := m.executor.GetStatus(deployment.Path)
 	deployment.Status = status

--- a/internal/docker/manager_status_integration_test.go
+++ b/internal/docker/manager_status_integration_test.go
@@ -1,0 +1,121 @@
+package docker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/flatrun/agent/pkg/models"
+)
+
+// TestDeploymentStatusAgainstRealContainers pins the status semantics the
+// compose CLI path defined, which the engine query has to reproduce exactly.
+//
+// The stopped half is the load-bearing one: compose reports only live
+// containers, so a stopped deployment must read as stopped and expose no
+// container. Widening the engine query to every container would report it as
+// unknown with a container attached instead, which no unit test would catch.
+func TestDeploymentStatusAgainstRealContainers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("starts a real container")
+	}
+
+	const name = "flatrun-status-integration"
+	base := t.TempDir()
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// nginx:alpine is already used by the compose tests in this package. It has
+	// no healthcheck, so health stays empty here and is covered by unit tests.
+	compose := "name: " + name + `
+services:
+  app:
+    image: nginx:alpine
+`
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(compose), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(base)
+	if m.apiClient == nil {
+		t.Skip("docker api client unavailable")
+	}
+
+	// Building the client does not contact the daemon, so reach it once here.
+	// Everything after this point is a real failure rather than a reason to
+	// skip, which keeps a broken deployment path from passing as "no docker".
+	ctx, cancel := context.WithTimeout(context.Background(), statusReadTimeout)
+	defer cancel()
+	if _, err := m.apiClient.ListLiveComposeContainers(ctx); err != nil {
+		t.Skipf("docker daemon unreachable: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if _, err := m.executor.Down(dir); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	})
+
+	if out, err := m.StartDeployment(name); err != nil {
+		t.Fatalf("start failed: %v (%s)", err, out)
+	}
+
+	statusOf := func(t *testing.T) string {
+		t.Helper()
+		deployments, err := m.ListDeployments()
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, d := range deployments {
+			if d.Name == name {
+				return d.Status
+			}
+		}
+		t.Fatalf("deployment %q missing from the list", name)
+		return ""
+	}
+
+	if got := statusOf(t); got != string(models.StatusRunning) {
+		t.Errorf("running deployment listed as %q, want running", got)
+	}
+
+	running, err := m.GetDeployment(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := running.Status; got != string(models.StatusRunning) {
+		t.Errorf("running deployment detail status = %q, want running", got)
+	}
+	if len(running.Services) != 1 {
+		t.Fatalf("got %d services, want 1", len(running.Services))
+	}
+	app := running.Services[0]
+	if app.Status != "running" {
+		t.Errorf("app service status = %q, want running", app.Status)
+	}
+	if len(app.ContainerID) != 12 {
+		t.Errorf("app container id = %q, want Docker's 12-character short form", app.ContainerID)
+	}
+
+	if out, err := m.StopDeployment(name); err != nil {
+		t.Fatalf("stop failed: %v (%s)", err, out)
+	}
+
+	if got := statusOf(t); got != string(models.StatusStopped) {
+		t.Errorf("stopped deployment listed as %q, want stopped", got)
+	}
+
+	stopped, err := m.GetDeployment(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stopped.Status; got != string(models.StatusStopped) {
+		t.Errorf("stopped deployment detail status = %q, want stopped", got)
+	}
+	if got := stopped.Services[0].ContainerID; got != "" {
+		t.Errorf("stopped service exposes container %q, want none", got)
+	}
+}

--- a/internal/docker/manager_status_test.go
+++ b/internal/docker/manager_status_test.go
@@ -1,0 +1,185 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/flatrun/agent/pkg/models"
+)
+
+// The State and Status pairs below are values the Docker daemon actually
+// reports: "Up 2 hours (healthy)" and "Exited (1) 13 hours ago" were captured
+// from `docker ps -a` against a live daemon, and "(health: starting)" is the
+// daemon's own rendering of a starting health check.
+func summary(state container.ContainerState, status, service string) container.Summary {
+	return container.Summary{
+		ID:     "ea80e6851a168fbe35db7e9a82362357305d4e0b948c55af789d6ceff92fe6d3",
+		State:  state,
+		Status: status,
+		Labels: map[string]string{
+			composeProjectLabel: "trakli",
+			composeServiceLabel: service,
+		},
+	}
+}
+
+func TestStatusFromContainers(t *testing.T) {
+	tests := []struct {
+		name       string
+		containers []container.Summary
+		want       string
+	}{
+		{
+			// A stopped deployment's containers are excluded from the index, so
+			// it reaches this function with none.
+			name: "no containers is stopped",
+			want: string(models.StatusStopped),
+		},
+		{
+			name:       "any running container is running",
+			containers: []container.Summary{summary(container.StateRestarting, "Restarting (1) 3 seconds ago", "worker"), summary(container.StateRunning, "Up 2 hours", "app")},
+			want:       string(models.StatusRunning),
+		},
+		{
+			name:       "paused counts as running",
+			containers: []container.Summary{summary(container.StatePaused, "Up 2 hours (Paused)", "app")},
+			want:       string(models.StatusRunning),
+		},
+		{
+			name:       "live but nothing up is unknown",
+			containers: []container.Summary{summary(container.StateRestarting, "Restarting (1) 3 seconds ago", "app")},
+			want:       string(models.StatusUnknown),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := statusFromContainers(tt.containers); got != tt.want {
+				t.Errorf("statusFromContainers() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHealthFromStatus(t *testing.T) {
+	tests := []struct {
+		status string
+		want   string
+	}{
+		{"Up 2 hours (healthy)", "healthy"},
+		{"Up 2 hours (unhealthy)", "unhealthy"},
+		{"Up 2 seconds (health: starting)", "starting"},
+		{"Up 2 hours", ""},
+		{"Exited (1) 13 hours ago", ""},
+		{"Created", ""},
+		// A paused container's parenthesised suffix is not a health report.
+		{"Up 2 hours (Paused)", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			if got := healthFromStatus(tt.status); got != tt.want {
+				t.Errorf("healthFromStatus(%q) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyContainers(t *testing.T) {
+	deployment := &models.Deployment{
+		Name: "trakli",
+		Services: []models.Service{
+			{Name: "app"},
+			{Name: "mysql"},
+			{Name: "absent"},
+		},
+	}
+
+	applyContainers(deployment, []container.Summary{
+		summary(container.StateRunning, "Up 2 days", "app"),
+		summary(container.StateRunning, "Up 2 days (healthy)", "mysql"),
+	})
+
+	if deployment.Status != string(models.StatusRunning) {
+		t.Errorf("Status = %q, want running", deployment.Status)
+	}
+	if got := deployment.Services[0].Status; got != container.StateRunning {
+		t.Errorf("app Status = %q, want running", got)
+	}
+	// Clients already receive Docker's short ID from the compose CLI, so the
+	// Engine API's full ID is trimmed to match.
+	if got := deployment.Services[0].ContainerID; got != "ea80e6851a16" {
+		t.Errorf("app ContainerID = %q, want ea80e6851a16", got)
+	}
+	if got := deployment.Services[0].Health; got != "" {
+		t.Errorf("app Health = %q, want empty", got)
+	}
+	if got := deployment.Services[1].Health; got != "healthy" {
+		t.Errorf("mysql Health = %q, want healthy", got)
+	}
+	// A service with no container keeps its zero values rather than borrowing
+	// another service's.
+	if got := deployment.Services[2].ContainerID; got != "" {
+		t.Errorf("absent ContainerID = %q, want empty", got)
+	}
+}
+
+// writeDeployment creates a deployment directory whose compose file optionally
+// carries an explicit project `name:`.
+func writeDeployment(t *testing.T, base, name string, named bool) {
+	t.Helper()
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	compose := "services:\n  app:\n    image: nginx:alpine\n"
+	if named {
+		compose = "name: " + name + "\n" + compose
+	}
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(compose), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProjectForPrefersComposeName(t *testing.T) {
+	base := t.TempDir()
+	writeDeployment(t, base, "shop", true)
+
+	m := NewManager(base)
+	deps, err := m.discovery.FindDeployments()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("got %d deployments, want 1", len(deps))
+	}
+
+	if got := m.projectFor(&deps[0], containerIndex{}); got != "shop" {
+		t.Errorf("projectFor() = %q, want shop", got)
+	}
+}
+
+func TestProjectForFallsBackToIndex(t *testing.T) {
+	base := t.TempDir()
+	writeDeployment(t, base, "imported", false)
+
+	m := NewManager(base)
+	deps, err := m.discovery.FindDeployments()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No compose `name:`, so the project is detected from containers already on
+	// the host, matching the prefixed name the CLI probe would have found.
+	index := containerIndex{"flatrun-imported": []container.Summary{summary(container.StateRunning, "Up 2 hours", "app")}}
+	if got := m.projectFor(&deps[0], index); got != "flatrun-imported" {
+		t.Errorf("projectFor() = %q, want flatrun-imported", got)
+	}
+
+	// With nothing on the host, it falls back to the directory name.
+	if got := m.projectFor(&deps[0], containerIndex{}); got != "imported" {
+		t.Errorf("projectFor() = %q, want imported", got)
+	}
+}

--- a/internal/docker/manager_status_test.go
+++ b/internal/docker/manager_status_test.go
@@ -1,8 +1,12 @@
 package docker
 
 import (
+	"bytes"
+	"errors"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
@@ -140,6 +144,33 @@ func writeDeployment(t *testing.T, base, name string, named bool) {
 	}
 	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(compose), 0644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestStatusFallbackLogsOncePerOutage(t *testing.T) {
+	var logged bytes.Buffer
+	log.SetOutput(&logged)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	m := &Manager{}
+	failure := errors.New("daemon is not running")
+	for i := 0; i < 3; i++ {
+		m.noteStatusFallback(failure)
+	}
+	if got := strings.Count(logged.String(), "falling back"); got != 1 {
+		t.Errorf("logged the fallback %d times across 3 failed reads, want 1", got)
+	}
+
+	// Recovering and failing again is a new outage, and worth a line.
+	m.noteStatusRecovered()
+	m.noteStatusRecovered()
+	if got := strings.Count(logged.String(), "reachable again"); got != 1 {
+		t.Errorf("logged recovery %d times, want 1", got)
+	}
+
+	m.noteStatusFallback(failure)
+	if got := strings.Count(logged.String(), "falling back"); got != 2 {
+		t.Errorf("logged the fallback %d times across two outages, want 2", got)
 	}
 }
 


### PR DESCRIPTION
From the Albacore performance item (#154, under #158). Deployment status was recomputed on every request by shelling out to the `docker compose` CLI once per deployment, so list latency was dominated by process startup and grew with the number of deployments. Status now comes from a single Docker engine query covering every deployment at once.

Measured at 1, 10 and 50 deployments:

| | before | after |
|---|---|---|
| list, 1 deployment | 128ms | 25ms |
| list, 10 deployments | 104ms | 22ms |
| list, 50 deployments | 486ms | 26ms |
| detail view | ~150ms | ~22ms |

The list is now flat with the deployment count instead of scaling with it.

Constraint: the engine query deliberately omits stopped containers. `compose ps` reports only live ones unless asked for all, and matching that is what keeps reported status identical. Widen the query and a stopped deployment reports `unknown` with a container attached, rather than `stopped`. Restricting it is also ~4.5x cheaper, since including stopped containers makes the daemon walk every container the host has ever left behind. An integration test starts and stops a real container to pin this.

Behaviour is otherwise unchanged. Container IDs keep the short form clients already receive, and if the engine cannot be reached the previous CLI path still serves the request.

Two things left out on purpose:

- The short-TTL status cache from the checklist. It needs invalidation on start/stop actions, otherwise status goes stale right after a user clicks something, so it is its own change.
- The cluster endpoint still reads full status. The checklist lists it as metadata-only, but it marshals the whole deployment list to clients with status included, so dropping status there would report `unknown` cluster-wide.
