### PR TITLE
feat(deployments): Bring container content onto the host as flat files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.105.0
 	github.com/cloudflare/cloudflare-go v0.116.0
 	github.com/compose-spec/compose-go/v2 v2.10.1
+	github.com/containerd/errdefs v1.0.0
 	github.com/creack/pty v1.1.24
 	github.com/digitalocean/godo v1.171.0
 	github.com/distribution/reference v0.6.0
@@ -67,7 +68,6 @@ require (
 	github.com/containerd/containerd/api v1.10.0 // indirect
 	github.com/containerd/containerd/v2 v2.2.1 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.2 // indirect

--- a/internal/api/container_files_handlers.go
+++ b/internal/api/container_files_handlers.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// listContainerFiles lists a directory inside a running service's container.
+func (s *Server) listContainerFiles(c *gin.Context) {
+	name := c.Param("name")
+	service := c.Param("service")
+
+	dir := c.Query("path")
+	if dir == "" {
+		dir = "/"
+	}
+
+	project, err := s.manager.ComposeProject(name)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Deployment not found"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+	defer cancel()
+
+	files, err := s.manager.ListServiceFiles(ctx, project, service, dir)
+	if err != nil {
+		// An image without a shell cannot be browsed, but its paths can still be
+		// brought onto the host by name, so say so rather than fail blankly.
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": err.Error(),
+			"hint":  "the service must be running and its image must provide a shell to be browsed",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"path": dir, "service": service, "files": files})
+}
+
+// materializeContainerPath copies a path out of a running service onto the host
+// and mounts it back, so the content becomes editable as ordinary files.
+func (s *Server) materializeContainerPath(c *gin.Context) {
+	name := c.Param("name")
+	service := c.Param("service")
+
+	if !s.requireUnprotectedDeploymentAction(c, name, protectedActionUpdateDeployment) {
+		return
+	}
+
+	var req struct {
+		ContainerPath string `json:"container_path" binding:"required"`
+		HostPath      string `json:"host_path,omitempty"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if !strings.HasPrefix(req.ContainerPath, "/") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "container_path must be absolute"})
+		return
+	}
+
+	hostPath := req.HostPath
+	if hostPath == "" {
+		hostPath = defaultHostPathFor(req.ContainerPath)
+	}
+
+	if err := s.manager.MaterializeMount(name, service, req.ContainerPath, hostPath); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"deployment":     name,
+		"service":        service,
+		"container_path": req.ContainerPath,
+		"host_path":      hostPath,
+	})
+}
+
+// defaultHostPathFor names the host copy after the container path's last
+// element, so /etc/nginx/conf.d becomes ./conf.d beside the compose file.
+func defaultHostPathFor(containerPath string) string {
+	trimmed := strings.Trim(containerPath, "/")
+	if trimmed == "" {
+		return ""
+	}
+
+	parts := strings.Split(trimmed, "/")
+	return "./" + parts[len(parts)-1]
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -569,6 +569,11 @@ func (s *Server) setupRoutes() {
 			protected.PUT("/deployments/:name/permissions/*path", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.chmodDeploymentFile)
 			protected.GET("/deployments/:name/files-info", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelRead), s.getDeploymentFilesInfo)
 
+			// Container file endpoints: browse what a running service holds, and
+			// bring a path onto the host where the file endpoints above can edit it.
+			protected.GET("/deployments/:name/container-files/:service", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelRead), s.listContainerFiles)
+			protected.POST("/deployments/:name/container-files/:service/materialize", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.materializeContainerPath)
+
 			// System file endpoints (admin-only, scoped to SystemFilesRoot)
 			protected.GET("/system/files", s.authMiddleware.RequirePermission(auth.PermSystemFiles), s.listSystemFiles)
 			protected.GET("/system/files-info", s.authMiddleware.RequirePermission(auth.PermSystemFiles), s.getSystemFilesInfo)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -979,6 +979,10 @@ func (s *Server) createDeployment(c *gin.Context) {
 			RegistryURL      string `json:"registry_url,omitempty"`
 		} `json:"registry_credential,omitempty"`
 		ServiceCredentials map[string]string `json:"service_credentials,omitempty"`
+		// SeedMounts names the bind mounts, by host path, to fill from the
+		// image when the host side is empty. A template's own seed mounts are
+		// added to these.
+		SeedMounts []string `json:"seed_mounts,omitempty"`
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -1114,6 +1118,15 @@ func (s *Server) createDeployment(c *gin.Context) {
 		s.processTemplateFiles(req.Name, req.TemplateID, allEnvVars)
 		s.processTemplateEnv(req.Name, req.TemplateID, req.ComposeContent, allEnvVars)
 		s.applyTemplateMountOwnership(req.Name, req.TemplateID)
+	}
+
+	// Seeding reads the images, so it runs before the deployment is started and
+	// only ever fills a host path that is still empty. A mount that cannot be
+	// seeded is reported without failing the deployment, which exists either way.
+	if seedMounts := append(req.SeedMounts, s.templateSeedMounts(req.TemplateID)...); len(seedMounts) > 0 {
+		if err := s.manager.SeedMounts(req.Name, seedMounts); err != nil {
+			log.Printf("Warning: failed to seed mounts for %s: %v", req.Name, err)
+		}
 	}
 
 	if req.Metadata != nil {
@@ -3242,6 +3255,9 @@ type TemplateMount struct {
 	Required       bool     `json:"required" yaml:"required"`
 	User           string   `json:"user,omitempty" yaml:"user,omitempty"`
 	Subdirectories []string `json:"subdirectories,omitempty" yaml:"subdirectories,omitempty"`
+	// Seed fills the mount from the image's own content when the host side is
+	// empty, for images that do not populate their mounts themselves.
+	Seed bool `json:"seed,omitempty" yaml:"seed,omitempty"`
 }
 
 // templateMountHostPath resolves where a template mount lives in the
@@ -4554,17 +4570,46 @@ func mainServiceImage(content string) string {
 	return ""
 }
 
-func (s *Server) applyTemplateMountOwnership(deploymentName, templateID string) {
-	templatesDir := filepath.Join(s.config.DeploymentsPath, ".flatrun", "templates")
-	metadataPath := filepath.Join(templatesDir, templateID, "metadata.yml")
+// loadTemplateMetadata reads an installed template's metadata.
+func (s *Server) loadTemplateMetadata(templateID string) (*TemplateMetadata, error) {
+	metadataPath := filepath.Join(s.config.DeploymentsPath, ".flatrun", "templates", templateID, "metadata.yml")
 
-	metadataContent, err := os.ReadFile(metadataPath)
+	content, err := os.ReadFile(metadataPath)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	var metadata TemplateMetadata
-	if err := yaml.Unmarshal(metadataContent, &metadata); err != nil {
+	if err := yaml.Unmarshal(content, &metadata); err != nil {
+		return nil, err
+	}
+	return &metadata, nil
+}
+
+// templateSeedMounts returns the host paths of a template's mounts that ask to
+// be filled from the image.
+func (s *Server) templateSeedMounts(templateID string) []string {
+	if templateID == "" {
+		return nil
+	}
+
+	metadata, err := s.loadTemplateMetadata(templateID)
+	if err != nil {
+		return nil
+	}
+
+	var hostPaths []string
+	for _, m := range metadata.Mounts {
+		if m.Seed {
+			hostPaths = append(hostPaths, templateMountHostPath(m))
+		}
+	}
+	return hostPaths
+}
+
+func (s *Server) applyTemplateMountOwnership(deploymentName, templateID string) {
+	metadata, err := s.loadTemplateMetadata(templateID)
+	if err != nil {
 		return
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -425,6 +425,7 @@ func (s *Server) setupRoutes() {
 			protected.GET("/deployments/:name/logs", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelRead), s.getDeploymentLogs)
 			protected.GET("/deployments/:name/compose", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelRead), s.getDeploymentCompose)
 			protected.POST("/deployments/:name/compose/mount", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.addDeploymentComposeMount)
+			protected.POST("/deployments/:name/compose/unmount", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.removeDeploymentComposeMount)
 
 			// Network endpoints
 			protected.GET("/networks", s.authMiddleware.RequirePermission(auth.PermNetworksRead), s.listNetworks)
@@ -2497,6 +2498,52 @@ func (s *Server) addDeploymentComposeMount(c *gin.Context) {
 		"service_name": req.ServiceName,
 		"mount":        volumeMount,
 		"added":        !alreadyMounted,
+	})
+}
+
+// removeDeploymentComposeMount unmounts a bind mount and recreates the service,
+// which returns it to what its image holds at that path. The host copy stays.
+func (s *Server) removeDeploymentComposeMount(c *gin.Context) {
+	name := c.Param("name")
+	if !s.requireUnprotectedDeploymentAction(c, name, protectedActionUpdateDeployment) {
+		return
+	}
+
+	var req struct {
+		SourcePath  string `json:"source_path" binding:"required"`
+		TargetPath  string `json:"target_path" binding:"required"`
+		ServiceName string `json:"service_name" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	sourcePath, err := normalizeComposeMountSource(req.SourcePath)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := s.manager.UnmountPath(name, req.ServiceName, sourcePath, strings.TrimSpace(req.TargetPath)); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	content, filename, err := s.manager.GetComposeFile(name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":      "Mount removed",
+		"name":         name,
+		"filename":     filename,
+		"content":      content,
+		"service_name": req.ServiceName,
+		"source_path":  sourcePath,
+		"target_path":  req.TargetPath,
 	})
 }
 

--- a/internal/docker/api.go
+++ b/internal/docker/api.go
@@ -9,8 +9,10 @@ import (
 	"strings"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 )
 
@@ -136,6 +138,56 @@ func (a *APIClient) ListServiceContainers(ctx context.Context, project string) (
 	)
 
 	return a.cli.ContainerList(ctx, container.ListOptions{Filters: f, All: true})
+}
+
+// EnsureImage makes an image available locally, pulling it only when it is
+// absent so a seeded deploy of an already-pulled image costs nothing.
+func (a *APIClient) EnsureImage(ctx context.Context, ref string) error {
+	_, err := a.cli.ImageInspect(ctx, ref)
+	if err == nil {
+		return nil
+	}
+	if !cerrdefs.IsNotFound(err) {
+		return fmt.Errorf("failed to inspect image %s: %w", ref, err)
+	}
+
+	body, err := a.cli.ImagePull(ctx, ref, image.PullOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to pull image %s: %w", ref, err)
+	}
+	defer body.Close()
+
+	// The pull only completes once its progress stream is drained.
+	if _, err := io.Copy(io.Discard, body); err != nil {
+		return fmt.Errorf("failed to pull image %s: %w", ref, err)
+	}
+	return nil
+}
+
+// SeedFromImage copies containerPath out of an image and writes it to hostPath.
+//
+// The container is created but never started: copying reads the image's
+// filesystem, so nothing from the image is executed to seed a host path.
+func (a *APIClient) SeedFromImage(ctx context.Context, ref, containerPath, hostPath string) error {
+	if err := a.EnsureImage(ctx, ref); err != nil {
+		return err
+	}
+
+	created, err := a.cli.ContainerCreate(ctx, &container.Config{Image: ref}, nil, nil, nil, "")
+	if err != nil {
+		return fmt.Errorf("failed to create a container to seed from %s: %w", ref, err)
+	}
+	defer func() {
+		_ = a.cli.ContainerRemove(ctx, created.ID, container.RemoveOptions{Force: true})
+	}()
+
+	reader, stat, err := a.cli.CopyFromContainer(ctx, created.ID, containerPath)
+	if err != nil {
+		return fmt.Errorf("failed to read %s from %s: %w", containerPath, ref, err)
+	}
+	defer reader.Close()
+
+	return extractSeedTar(reader, hostPath, stat.Mode.IsDir())
 }
 
 // ListLiveComposeContainers returns the containers of every compose project on

--- a/internal/docker/api.go
+++ b/internal/docker/api.go
@@ -164,7 +164,23 @@ func (a *APIClient) EnsureImage(ctx context.Context, ref string) error {
 	return nil
 }
 
+// CopyPathToHost writes containerPath from an existing container out to
+// hostPath. The container does not need to be running, so a caller can stop it
+// first and be certain the copy cannot miss a later write.
+func (a *APIClient) CopyPathToHost(ctx context.Context, containerID, containerPath, hostPath string) error {
+	reader, stat, err := a.cli.CopyFromContainer(ctx, containerID, containerPath)
+	if err != nil {
+		return fmt.Errorf("failed to read %s from the container: %w", containerPath, err)
+	}
+	defer reader.Close()
+
+	return extractSeedTar(reader, hostPath, stat.Mode.IsDir())
+}
+
 // SeedFromImage copies containerPath out of an image and writes it to hostPath.
+// It suits a deployment that has no container yet; for one that is already
+// running, copy from the container instead, since an image holds nothing an
+// entrypoint generated at runtime.
 //
 // The container is created but never started: copying reads the image's
 // filesystem, so nothing from the image is executed to seed a host path.
@@ -181,13 +197,7 @@ func (a *APIClient) SeedFromImage(ctx context.Context, ref, containerPath, hostP
 		_ = a.cli.ContainerRemove(ctx, created.ID, container.RemoveOptions{Force: true})
 	}()
 
-	reader, stat, err := a.cli.CopyFromContainer(ctx, created.ID, containerPath)
-	if err != nil {
-		return fmt.Errorf("failed to read %s from %s: %w", containerPath, ref, err)
-	}
-	defer reader.Close()
-
-	return extractSeedTar(reader, hostPath, stat.Mode.IsDir())
+	return a.CopyPathToHost(ctx, created.ID, containerPath, hostPath)
 }
 
 // ListLiveComposeContainers returns the containers of every compose project on

--- a/internal/docker/compose_yaml.go
+++ b/internal/docker/compose_yaml.go
@@ -346,6 +346,44 @@ func AddVolumeToService(content string, serviceName string, volumeMount string) 
 }
 
 // RemoveVolumeFromService removes a volume mount from a specific service in the compose file
+// FindVolumeMount returns a service's volume entry whose host and container
+// sides match, ignoring trailing options such as ":ro". Removal matches the
+// entry's exact text, so a caller that knows only what a mount connects can use
+// this to address it.
+func FindVolumeMount(content, serviceName, hostPath, containerPath string) (string, bool) {
+	compose, err := ParseComposeYAML(content)
+	if err != nil {
+		return "", false
+	}
+
+	services, ok := compose["services"].(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+
+	service, ok := services[serviceName].(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+
+	volumes, ok := service["volumes"].([]interface{})
+	if !ok {
+		return "", false
+	}
+
+	for _, vol := range volumes {
+		volStr, ok := vol.(string)
+		if !ok {
+			continue
+		}
+		host, container := splitBindMount(volStr)
+		if host == hostPath && container == containerPath {
+			return volStr, true
+		}
+	}
+	return "", false
+}
+
 func RemoveVolumeFromService(content string, serviceName string, volumeMount string) (string, error) {
 	if !HasVolumeMount(content, serviceName, volumeMount) {
 		return content, nil

--- a/internal/docker/container_files.go
+++ b/internal/docker/container_files.go
@@ -1,0 +1,157 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+)
+
+// ContainerFile is one entry of a directory inside a container.
+type ContainerFile struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Size        int64  `json:"size"`
+	Mode        string `json:"mode"`
+	IsDir       bool   `json:"is_dir"`
+	IsSymlink   bool   `json:"is_symlink"`
+	LinkTarget  string `json:"link_target,omitempty"`
+	ModifiedRaw string `json:"modified_raw,omitempty"`
+}
+
+// ListContainerPath lists a directory inside a running container.
+//
+// The Engine API can stat a path and archive it, but cannot list a directory,
+// so this asks the container itself. That means an image with no shell, such as
+// a distroless or scratch build, cannot be browsed; its paths can still be
+// copied out by naming them directly.
+func (a *APIClient) ListContainerPath(ctx context.Context, containerID, dir string) ([]ContainerFile, error) {
+	if dir == "" {
+		dir = "/"
+	}
+
+	// dir reaches a shell, so it is quoted rather than interpolated: a path of
+	// "/etc; rm -rf /" would otherwise run.
+	out, err := a.ExecInContainer(ctx, containerID, "ls -lA -- "+shellQuote(dir))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list %s: %w", dir, err)
+	}
+
+	return parseLSOutput(out, dir), nil
+}
+
+// parseLSOutput reads `ls -lA`, whose columns are the same under both busybox
+// and GNU coreutils and differ only in padding:
+//
+//	drwxr-xr-x 2 root root 4096 Jul 14 01:22 conf.d
+func parseLSOutput(out, dir string) []ContainerFile {
+	var files []ContainerFile
+
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" || strings.HasPrefix(line, "total ") {
+			continue
+		}
+
+		name, rest, ok := splitLSFields(line)
+		if !ok {
+			continue
+		}
+
+		file := ContainerFile{
+			Mode:        rest.mode,
+			Size:        rest.size,
+			ModifiedRaw: rest.modified,
+			IsDir:       strings.HasPrefix(rest.mode, "d"),
+			IsSymlink:   strings.HasPrefix(rest.mode, "l"),
+		}
+
+		// A symlink is listed as "link -> target".
+		if file.IsSymlink {
+			if i := strings.Index(name, " -> "); i >= 0 {
+				file.LinkTarget = name[i+4:]
+				name = name[:i]
+			}
+		}
+
+		file.Name = name
+		file.Path = path.Join(dir, name)
+		files = append(files, file)
+	}
+
+	return files
+}
+
+type lsFields struct {
+	mode     string
+	size     int64
+	modified string
+}
+
+// splitLSFields pulls the fixed columns off an `ls -l` line and returns the rest
+// as the name, which is everything after the timestamp so that names containing
+// spaces survive.
+func splitLSFields(line string) (name string, fields lsFields, ok bool) {
+	const columnsBeforeName = 8
+
+	rest := line
+	var columns []string
+	for i := 0; i < columnsBeforeName; i++ {
+		rest = strings.TrimLeft(rest, " \t")
+		cut := strings.IndexAny(rest, " \t")
+		if cut < 0 {
+			return "", lsFields{}, false
+		}
+		columns = append(columns, rest[:cut])
+		rest = rest[cut:]
+	}
+
+	name = strings.TrimLeft(rest, " \t")
+	if name == "" {
+		return "", lsFields{}, false
+	}
+
+	size, _ := strconv.ParseInt(columns[4], 10, 64)
+	return name, lsFields{
+		mode:     columns[0],
+		size:     size,
+		modified: strings.Join(columns[5:8], " "),
+	}, true
+}
+
+// shellQuote wraps a value in single quotes so a shell treats it as one literal
+// argument, escaping any single quote it contains.
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+// ListServicePath lists a directory inside a compose service's running container.
+func (a *APIClient) ListServicePath(ctx context.Context, project, service, dir string) ([]ContainerFile, error) {
+	containerID, err := a.FindContainer(ctx, project, service)
+	if err != nil {
+		return nil, err
+	}
+	return a.ListContainerPath(ctx, containerID, dir)
+}
+
+// ComposeProject returns the project name a deployment's containers are labelled
+// with, which is what addresses them on the engine.
+func (m *Manager) ComposeProject(name string) (string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	deployment, err := m.discovery.GetDeployment(name)
+	if err != nil {
+		return "", err
+	}
+	return m.projectFor(deployment, containerIndex{}), nil
+}
+
+// ListServiceFiles lists a directory inside a running service's container.
+func (m *Manager) ListServiceFiles(ctx context.Context, project, service, dir string) ([]ContainerFile, error) {
+	if m.apiClient == nil {
+		return nil, fmt.Errorf("docker api client not available")
+	}
+	return m.apiClient.ListServicePath(ctx, project, service, dir)
+}

--- a/internal/docker/container_files_integration_test.go
+++ b/internal/docker/container_files_integration_test.go
@@ -1,0 +1,84 @@
+package docker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestListServicePathAgainstRealContainer lists a real container's directory,
+// which is the only way to know the parser agrees with the ls the image ships.
+func TestListServicePathAgainstRealContainer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("starts a real container")
+	}
+
+	const name = "flatrun-listfiles-integration"
+	base := t.TempDir()
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	compose := "name: " + name + `
+services:
+  app:
+    image: nginx:alpine
+`
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(compose), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(base)
+	if m.apiClient == nil {
+		t.Skip("docker api client unavailable")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	if _, err := m.apiClient.ListLiveComposeContainers(ctx); err != nil {
+		t.Skipf("docker daemon unreachable: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := m.executor.Down(dir); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	})
+	if out, err := m.StartDeployment(name); err != nil {
+		t.Fatalf("start failed: %v (%s)", err, out)
+	}
+
+	files, err := m.apiClient.ListServicePath(ctx, name, "app", "/etc/nginx")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	byName := make(map[string]ContainerFile, len(files))
+	for _, f := range files {
+		byName[f.Name] = f
+	}
+
+	confd, ok := byName["conf.d"]
+	if !ok {
+		t.Fatalf("conf.d missing from %d entries", len(files))
+	}
+	if !confd.IsDir {
+		t.Error("conf.d should be reported as a directory")
+	}
+	if confd.Path != "/etc/nginx/conf.d" {
+		t.Errorf("path = %q", confd.Path)
+	}
+
+	conf, ok := byName["nginx.conf"]
+	if !ok {
+		t.Fatal("nginx.conf missing")
+	}
+	if conf.IsDir || conf.Size == 0 {
+		t.Errorf("nginx.conf = %+v, want a non-empty file", conf)
+	}
+
+	// A path that reaches a shell stays one literal argument.
+	if _, err := m.apiClient.ListServicePath(ctx, name, "app", "/etc/nginx; echo pwned"); err == nil {
+		t.Error("expected an error for a path that does not exist, not shell execution")
+	}
+}

--- a/internal/docker/container_files_test.go
+++ b/internal/docker/container_files_test.go
@@ -1,0 +1,91 @@
+package docker
+
+import (
+	"testing"
+)
+
+// The two outputs below were captured from real containers: nginx:alpine for
+// busybox and nginx:latest for GNU coreutils. They differ only in padding, so
+// one parser has to read both.
+const busyboxLS = `total 32
+drwxr-xr-x    2 root     root          4096 Jun 22 19:46 conf.d
+-rw-r--r--    1 root     root          1077 Jun 17 15:58 fastcgi.conf
+lrwxrwxrwx    1 root     root            22 Jun 17 15:58 modules -> /usr/lib/nginx/modules
+`
+
+const gnuLS = `total 28
+drwxr-xr-x 2 root root 4096 Jul 14 01:22 conf.d
+-rw-r--r-- 1 root root 1007 Jun 17 14:40 fastcgi_params
+-rw-r--r-- 1 root root 5349 Jun 17 14:40 mime.types
+`
+
+func TestParseLSOutputBusybox(t *testing.T) {
+	files := parseLSOutput(busyboxLS, "/etc/nginx")
+
+	if len(files) != 3 {
+		t.Fatalf("got %d entries, want 3: %+v", len(files), files)
+	}
+
+	if !files[0].IsDir || files[0].Name != "conf.d" {
+		t.Errorf("entry 0 = %+v, want the conf.d directory", files[0])
+	}
+	if files[0].Path != "/etc/nginx/conf.d" {
+		t.Errorf("path = %q, want /etc/nginx/conf.d", files[0].Path)
+	}
+
+	if files[1].IsDir || files[1].Size != 1077 {
+		t.Errorf("entry 1 = %+v, want a 1077 byte file", files[1])
+	}
+
+	// A symlink's target is listed after the name and must not become part of it.
+	if !files[2].IsSymlink || files[2].Name != "modules" {
+		t.Errorf("entry 2 = %+v, want the modules symlink", files[2])
+	}
+	if files[2].LinkTarget != "/usr/lib/nginx/modules" {
+		t.Errorf("link target = %q", files[2].LinkTarget)
+	}
+}
+
+func TestParseLSOutputGNU(t *testing.T) {
+	files := parseLSOutput(gnuLS, "/etc/nginx")
+
+	if len(files) != 3 {
+		t.Fatalf("got %d entries, want 3: %+v", len(files), files)
+	}
+	if !files[0].IsDir || files[0].Name != "conf.d" {
+		t.Errorf("entry 0 = %+v, want the conf.d directory", files[0])
+	}
+	if files[2].Name != "mime.types" || files[2].Size != 5349 {
+		t.Errorf("entry 2 = %+v, want mime.types at 5349 bytes", files[2])
+	}
+}
+
+func TestParseLSOutputKeepsNamesWithSpaces(t *testing.T) {
+	files := parseLSOutput("-rw-r--r-- 1 root root 12 Jun 17 14:40 my config.conf\n", "/etc")
+
+	if len(files) != 1 {
+		t.Fatalf("got %d entries, want 1", len(files))
+	}
+	if files[0].Name != "my config.conf" {
+		t.Errorf("name = %q, want it to keep its space", files[0].Name)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"/etc/nginx", `'/etc/nginx'`},
+		// The path reaches sh -c, so a shell metacharacter has to stay data.
+		{"/etc; rm -rf /", `'/etc; rm -rf /'`},
+		{"/etc/$(whoami)", `'/etc/$(whoami)'`},
+		{"/it's", `'/it'\''s'`},
+	}
+
+	for _, tt := range tests {
+		if got := shellQuote(tt.in); got != tt.want {
+			t.Errorf("shellQuote(%q) = %s, want %s", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/docker/materialize_integration_test.go
+++ b/internal/docker/materialize_integration_test.go
@@ -1,0 +1,114 @@
+package docker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMaterializeMountPreservesRuntimeContent is the case the feature exists
+// for: a path the container populated after it started is copied to the host and
+// mounted back, and the service carries on with exactly the content it had.
+//
+// The marker file is written into the running container and exists in no image
+// layer, so copying from the image instead of the container would lose it and
+// the service would come back on different content.
+func TestMaterializeMountPreservesRuntimeContent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("starts a real container")
+	}
+
+	const (
+		name    = "flatrun-materialize-integration"
+		service = "app"
+		marker  = "/etc/nginx/conf.d/runtime.conf"
+	)
+
+	base := t.TempDir()
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	compose := "name: " + name + `
+services:
+  app:
+    image: nginx:alpine
+`
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(compose), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(base)
+	if m.apiClient == nil {
+		t.Skip("docker api client unavailable")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	if _, err := m.apiClient.ListLiveComposeContainers(ctx); err != nil {
+		t.Skipf("docker daemon unreachable: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if _, err := m.executor.Down(dir); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	})
+
+	if out, err := m.StartDeployment(name); err != nil {
+		t.Fatalf("start failed: %v (%s)", err, out)
+	}
+
+	// Content that exists only because the container is running. It is written
+	// as a comment because nginx parses every .conf in this directory once the
+	// host copy is mounted back.
+	if _, err := m.apiClient.ExecInService(ctx, name, service, "echo '# runtime-generated' > "+marker); err != nil {
+		t.Fatalf("could not write the runtime marker: %v", err)
+	}
+
+	if err := m.MaterializeMount(name, service, "/etc/nginx/conf.d", "./conf.d"); err != nil {
+		t.Fatalf("MaterializeMount: %v", err)
+	}
+
+	hostMarker := filepath.Join(dir, "conf.d", "runtime.conf")
+	content, err := os.ReadFile(hostMarker)
+	if err != nil {
+		t.Fatalf("runtime content did not reach the host: %v", err)
+	}
+	if !strings.Contains(string(content), "runtime-generated") {
+		t.Errorf("host marker = %q, want it to carry runtime-generated", content)
+	}
+
+	// The image's own content has to survive alongside it.
+	if _, err := os.Stat(filepath.Join(dir, "conf.d", "default.conf")); err != nil {
+		t.Errorf("image content missing from the host copy: %v", err)
+	}
+
+	updated, _, err := m.discovery.GetComposeFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(updated, "./conf.d:/etc/nginx/conf.d") {
+		t.Errorf("compose file was not given the mount:\n%s", updated)
+	}
+
+	deployment, err := m.GetDeployment(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deployment.Status != "running" {
+		t.Errorf("deployment status = %q, want running after materializing", deployment.Status)
+	}
+
+	// The service resumed on the same content, now served from the host.
+	out, err := m.apiClient.ExecInService(ctx, name, service, "cat "+marker)
+	if err != nil {
+		t.Fatalf("service lost the runtime content: %v", err)
+	}
+	if !strings.Contains(out, "runtime-generated") {
+		t.Errorf("container reads %q, want runtime-generated", out)
+	}
+}

--- a/internal/docker/seed.go
+++ b/internal/docker/seed.go
@@ -1,0 +1,163 @@
+package docker
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// extractSeedTar writes the tar Docker produces for a copied container path to
+// destPath on the host.
+//
+// Docker roots the archive at the basename of the copied path, so copying
+// /etc/nginx/conf.d yields "conf.d/" and "conf.d/default.conf", and copying the
+// file /etc/nginx/nginx.conf yields the single entry "nginx.conf". That leading
+// component is stripped: destPath is the copied path itself, not its parent.
+//
+// srcIsDir selects between the two: a file source writes the lone entry to
+// destPath, a directory source becomes destPath's contents.
+func extractSeedTar(r io.Reader, destPath string, srcIsDir bool) error {
+	tr := tar.NewReader(r)
+
+	if !srcIsDir {
+		return extractSeedFile(tr, destPath)
+	}
+
+	if err := os.MkdirAll(destPath, 0755); err != nil {
+		return err
+	}
+
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		rel := stripRoot(header.Name)
+		if rel == "" {
+			continue
+		}
+
+		target, err := resolveSeedPath(destPath, rel)
+		if err != nil {
+			return err
+		}
+
+		if err := writeSeedEntry(tr, header, target); err != nil {
+			return err
+		}
+	}
+}
+
+// extractSeedFile writes the first regular entry of a file copy to destPath.
+func extractSeedFile(tr *tar.Reader, destPath string) error {
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			return fmt.Errorf("archive held no file to seed %s", destPath)
+		}
+		if err != nil {
+			return err
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+			return err
+		}
+		return writeSeedFile(tr, destPath, header.FileInfo().Mode())
+	}
+}
+
+// writeSeedEntry materialises one archive entry beneath an already-resolved
+// target path. Entry types other than files, directories and symlinks (devices,
+// fifos) are skipped: an image may carry them, but they are not configuration
+// worth reproducing on the host.
+func writeSeedEntry(tr *tar.Reader, header *tar.Header, target string) error {
+	switch header.Typeflag {
+	case tar.TypeDir:
+		return os.MkdirAll(target, header.FileInfo().Mode().Perm())
+	case tar.TypeReg:
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			return err
+		}
+		return writeSeedFile(tr, target, header.FileInfo().Mode())
+	case tar.TypeSymlink:
+		// A symlink's target is not followed, so a link pointing outside the
+		// deployment only breaks; it cannot be used to write through.
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			return err
+		}
+		_ = os.Remove(target)
+		return os.Symlink(header.Linkname, target)
+	default:
+		return nil
+	}
+}
+
+func writeSeedFile(r io.Reader, path string, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode.Perm())
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, r); err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+// stripRoot removes the archive's leading path component, which Docker sets to
+// the basename of the copied container path.
+func stripRoot(name string) string {
+	name = strings.TrimPrefix(filepath.ToSlash(name), "./")
+	if i := strings.Index(name, "/"); i >= 0 {
+		return strings.Trim(name[i+1:], "/")
+	}
+	return ""
+}
+
+// resolveSeedPath joins an archive entry onto the destination and refuses
+// anything that would land outside it. Image content is untrusted input: an
+// entry named ../../etc/passwd would otherwise write through the deployment
+// directory.
+func resolveSeedPath(destPath, rel string) (string, error) {
+	target := filepath.Join(destPath, rel)
+
+	prefix := filepath.Clean(destPath) + string(os.PathSeparator)
+	if !strings.HasPrefix(target, prefix) {
+		return "", fmt.Errorf("archive entry %q escapes %s", rel, destPath)
+	}
+	return target, nil
+}
+
+// isSeedable reports whether a host path may be seeded. Only a missing path or
+// an empty directory qualifies, mirroring the copy-on-first-use semantics of
+// named volumes, so content a user already has is never overwritten. Empty
+// directories count because deployment creation pre-creates mount directories
+// before anything is seeded.
+func isSeedable(hostPath string) (bool, error) {
+	info, err := os.Stat(hostPath)
+	if os.IsNotExist(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.IsDir() {
+		return false, nil
+	}
+
+	entries, err := os.ReadDir(hostPath)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) == 0, nil
+}

--- a/internal/docker/seed.go
+++ b/internal/docker/seed.go
@@ -2,12 +2,113 @@ package docker
 
 import (
 	"archive/tar"
+	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+// materializeTimeout bounds the copy out of a container. A path holding an
+// application's whole data directory can be large, so this is generous.
+const materializeTimeout = 10 * time.Minute
+
+// MaterializeMount copies a path out of a running service's container onto the
+// host, then mounts the host copy back at the same place and brings the service
+// up again.
+//
+// The order matters. A bind mount pushes the host's content into the container,
+// so mounting a path the container populated would hide it. Copying first means
+// the service resumes on exactly the content it was already running, now visible
+// and editable on the host. The service is stopped before the copy so no write
+// can land between the copy and the mount taking effect and be lost.
+func (m *Manager) MaterializeMount(name, service, containerPath, hostPath string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.apiClient == nil {
+		return fmt.Errorf("docker api client not available")
+	}
+
+	deployment, err := m.discovery.GetDeployment(name)
+	if err != nil {
+		return err
+	}
+
+	hostPath = normalizeMountHostPath(hostPath)
+	fullPath := filepath.Join(deployment.Path, filepath.Clean(hostPath))
+
+	content, filename, err := m.discovery.GetComposeFile(name)
+	if err != nil {
+		return err
+	}
+
+	mount := hostPath + ":" + containerPath
+	if HasVolumeMount(content, service, mount) {
+		return fmt.Errorf("%s is already mounted at %s", containerPath, hostPath)
+	}
+
+	// Refuse rather than merge: the host copy has to be the container's content
+	// alone, or the service would resume on something it never had.
+	seedable, err := isSeedable(fullPath)
+	if err != nil {
+		return err
+	}
+	if !seedable {
+		return fmt.Errorf("%s already has content on the host", hostPath)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), materializeTimeout)
+	defer cancel()
+
+	project := m.projectFor(deployment, containerIndex{})
+	containerID, err := m.apiClient.FindContainer(ctx, project, service)
+	if err != nil {
+		return fmt.Errorf("service %s must be running to copy %s from it: %w", service, containerPath, err)
+	}
+
+	if out, err := m.executor.StopService(deployment.Path, service); err != nil {
+		return fmt.Errorf("failed to stop %s before copying: %w (%s)", service, err, out)
+	}
+
+	if err := m.apiClient.CopyPathToHost(ctx, containerID, containerPath, fullPath); err != nil {
+		// Leave the service as it was found rather than stopped on a failure
+		// that has changed nothing else.
+		if _, upErr := m.executor.Up(deployment.Path); upErr != nil {
+			log.Printf("mounts: failed to restart %s after a failed copy: %v", name, upErr)
+		}
+		return err
+	}
+
+	updated, err := AddVolumeToService(content, service, mount)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(deployment.Path, filename), []byte(updated), 0644); err != nil {
+		return err
+	}
+
+	if out, err := m.executor.Up(deployment.Path, WithForceRecreate()); err != nil {
+		return fmt.Errorf("failed to bring %s back up on the mounted copy: %w (%s)", name, err, out)
+	}
+	return nil
+}
+
+// normalizeMountHostPath keeps a host path in the relative form compose files
+// use, so a mount reads the same whether the caller passed "nginx" or "./nginx".
+func normalizeMountHostPath(hostPath string) string {
+	hostPath = strings.TrimSpace(hostPath)
+	if hostPath == "" {
+		return ""
+	}
+	if strings.HasPrefix(hostPath, "./") || strings.HasPrefix(hostPath, "../") || filepath.IsAbs(hostPath) {
+		return hostPath
+	}
+	return "./" + hostPath
+}
 
 // extractSeedTar writes the tar Docker produces for a copied container path to
 // destPath on the host.

--- a/internal/docker/seed.go
+++ b/internal/docker/seed.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // materializeTimeout bounds the copy out of a container. A path holding an
@@ -95,6 +97,100 @@ func (m *Manager) MaterializeMount(name, service, containerPath, hostPath string
 		return fmt.Errorf("failed to bring %s back up on the mounted copy: %w (%s)", name, err, out)
 	}
 	return nil
+}
+
+// SeedMounts fills the named bind mounts of a deployment that has not started
+// yet with the content its images hold at those paths.
+//
+// It suits a deployment with no container to copy from. An image holds nothing
+// an entrypoint generates on first start, so an already-running deployment is
+// better served by copying the container itself.
+//
+// Only mounts named by the caller are seeded, and only where the host side is
+// still missing or empty, so seeding never overwrites content a user has.
+func (m *Manager) SeedMounts(name string, hostPaths []string) error {
+	if len(hostPaths) == 0 {
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.apiClient == nil {
+		return fmt.Errorf("docker api client not available")
+	}
+
+	deployment, err := m.discovery.GetDeployment(name)
+	if err != nil {
+		return err
+	}
+
+	content, _, err := m.discovery.GetComposeFile(name)
+	if err != nil {
+		return err
+	}
+
+	var compose struct {
+		Services map[string]struct {
+			Image   string   `yaml:"image"`
+			Volumes []string `yaml:"volumes"`
+		} `yaml:"services"`
+	}
+	if err := yaml.Unmarshal([]byte(content), &compose); err != nil {
+		return fmt.Errorf("failed to read the compose file: %w", err)
+	}
+
+	wanted := make(map[string]bool, len(hostPaths))
+	for _, p := range hostPaths {
+		wanted[normalizeMountHostPath(p)] = true
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), materializeTimeout)
+	defer cancel()
+
+	var failures []string
+	for _, service := range compose.Services {
+		if service.Image == "" {
+			continue
+		}
+		for _, volume := range service.Volumes {
+			hostPath, containerPath := splitBindMount(volume)
+			if hostPath == "" || containerPath == "" || !wanted[normalizeMountHostPath(hostPath)] {
+				continue
+			}
+
+			fullPath := filepath.Join(deployment.Path, filepath.Clean(hostPath))
+			seedable, err := isSeedable(fullPath)
+			if err != nil {
+				return err
+			}
+			if !seedable {
+				continue
+			}
+
+			if err := m.apiClient.SeedFromImage(ctx, service.Image, containerPath, fullPath); err != nil {
+				failures = append(failures, fmt.Sprintf("%s: %v", hostPath, err))
+			}
+		}
+	}
+
+	if len(failures) > 0 {
+		return fmt.Errorf("failed to seed %s", strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+// splitBindMount splits a compose volume into its host and container sides,
+// ignoring named volumes, which Docker already populates from the image.
+func splitBindMount(volume string) (hostPath, containerPath string) {
+	parts := strings.Split(volume, ":")
+	if len(parts) < 2 {
+		return "", ""
+	}
+	if !strings.HasPrefix(parts[0], ".") && !strings.HasPrefix(parts[0], "/") {
+		return "", ""
+	}
+	return parts[0], parts[1]
 }
 
 // normalizeMountHostPath keeps a host path in the relative form compose files

--- a/internal/docker/seed.go
+++ b/internal/docker/seed.go
@@ -40,8 +40,11 @@ func (m *Manager) MaterializeMount(name, service, containerPath, hostPath string
 		return err
 	}
 
+	fullPath, err := resolveMountHostPath(deployment.Path, hostPath)
+	if err != nil {
+		return err
+	}
 	hostPath = normalizeMountHostPath(hostPath)
-	fullPath := filepath.Join(deployment.Path, filepath.Clean(hostPath))
 
 	content, filename, err := m.discovery.GetComposeFile(name)
 	if err != nil {
@@ -203,7 +206,11 @@ func (m *Manager) SeedMounts(name string, hostPaths []string) error {
 				continue
 			}
 
-			fullPath := filepath.Join(deployment.Path, filepath.Clean(hostPath))
+			fullPath, err := resolveMountHostPath(deployment.Path, hostPath)
+			if err != nil {
+				return err
+			}
+
 			seedable, err := isSeedable(fullPath)
 			if err != nil {
 				return err
@@ -235,6 +242,30 @@ func splitBindMount(volume string) (hostPath, containerPath string) {
 		return "", ""
 	}
 	return parts[0], parts[1]
+}
+
+// resolveMountHostPath turns a mount's host side into an absolute path inside
+// the deployment, refusing anything that would land outside it.
+//
+// These paths arrive from API requests and compose files, so they are untrusted:
+// without this, "../../etc" would write a container's content anywhere the agent
+// can reach. An absolute path is refused for the same reason, even though compose
+// itself allows one.
+func resolveMountHostPath(deploymentPath, hostPath string) (string, error) {
+	normalized := normalizeMountHostPath(hostPath)
+	if normalized == "" {
+		return "", fmt.Errorf("a host path is required")
+	}
+	if filepath.IsAbs(normalized) {
+		return "", fmt.Errorf("host path %q must stay inside the deployment directory", hostPath)
+	}
+
+	full := filepath.Join(deploymentPath, normalized)
+	prefix := filepath.Clean(deploymentPath) + string(os.PathSeparator)
+	if !strings.HasPrefix(full, prefix) {
+		return "", fmt.Errorf("host path %q must stay inside the deployment directory", hostPath)
+	}
+	return full, nil
 }
 
 // normalizeMountHostPath keeps a host path in the relative form compose files

--- a/internal/docker/seed.go
+++ b/internal/docker/seed.go
@@ -99,6 +99,50 @@ func (m *Manager) MaterializeMount(name, service, containerPath, hostPath string
 	return nil
 }
 
+// UnmountPath removes a bind mount from a service and recreates it, so the
+// service goes back to whatever its image holds at that path.
+//
+// The recreate is what makes the unmount real. Dropping the mount from the
+// compose file alone leaves the running container still bound to the host, so
+// the host copy would keep reaching into it.
+//
+// The host copy is left on disk. It is the only place the mounted content
+// exists, and the service no longer reads it, so deleting it is a separate
+// decision for the caller to make deliberately.
+func (m *Manager) UnmountPath(name, service, hostPath, containerPath string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	deployment, err := m.discovery.GetDeployment(name)
+	if err != nil {
+		return err
+	}
+
+	content, filename, err := m.discovery.GetComposeFile(name)
+	if err != nil {
+		return err
+	}
+
+	hostPath = normalizeMountHostPath(hostPath)
+	volume, found := FindVolumeMount(content, service, hostPath, containerPath)
+	if !found {
+		return fmt.Errorf("%s is not mounted at %s in %s", hostPath, containerPath, service)
+	}
+
+	updated, err := RemoveVolumeFromService(content, service, volume)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(deployment.Path, filename), []byte(updated), 0644); err != nil {
+		return err
+	}
+
+	if out, err := m.executor.Up(deployment.Path, WithForceRecreate()); err != nil {
+		return fmt.Errorf("failed to recreate %s without the mount: %w (%s)", name, err, out)
+	}
+	return nil
+}
+
 // SeedMounts fills the named bind mounts of a deployment that has not started
 // yet with the content its images hold at those paths.
 //

--- a/internal/docker/seed_escape_test.go
+++ b/internal/docker/seed_escape_test.go
@@ -1,0 +1,77 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMaterializeMountRefusesEscapingHostPath pins that a host path is confined
+// to the deployment directory. The path arrives from an API request, so without
+// this a caller could write a container's content anywhere the agent can reach.
+func TestMaterializeMountRefusesEscapingHostPath(t *testing.T) {
+	base := t.TempDir()
+	name := "escape-test"
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	compose := "name: " + name + `
+services:
+  app:
+    image: nginx:alpine
+`
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(compose), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(base)
+
+	for _, hostPath := range []string{
+		"../../escaped",
+		"./conf/../../../escaped",
+		"/etc/flatrun-escaped",
+	} {
+		t.Run(hostPath, func(t *testing.T) {
+			err := m.MaterializeMount(name, "app", "/etc/nginx/conf.d", hostPath)
+			if err == nil {
+				t.Fatalf("host path %q was accepted, it must stay inside the deployment", hostPath)
+			}
+			if !strings.Contains(err.Error(), "deployment directory") {
+				t.Errorf("error = %v, want it to say the path must stay inside the deployment directory", err)
+			}
+		})
+	}
+}
+
+// TestSeedMountsRefusesEscapingHostPath covers the same confinement on the
+// seeding path, where the mount is read from the compose file.
+func TestSeedMountsRefusesEscapingHostPath(t *testing.T) {
+	base := t.TempDir()
+	name := "seed-escape-test"
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	compose := "name: " + name + `
+services:
+  app:
+    image: nginx:alpine
+    volumes:
+      - ../../escaped:/etc/nginx/conf.d
+`
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(compose), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(base)
+
+	err := m.SeedMounts(name, []string{"../../escaped"})
+	if err == nil {
+		t.Fatal("a mount pointing outside the deployment was seeded")
+	}
+	if _, statErr := os.Stat(filepath.Join(base, "..", "escaped")); statErr == nil {
+		t.Error("seeding wrote outside the deployment directory")
+	}
+}

--- a/internal/docker/seed_integration_test.go
+++ b/internal/docker/seed_integration_test.go
@@ -1,0 +1,83 @@
+package docker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestSeedFromImageAgainstRealImage seeds from a real image, which is the only
+// way to know the extractor agrees with what Docker actually streams back.
+//
+// The single-file case is the bug this feature exists for: mounting a host path
+// that does not exist over a container file makes Docker create a directory
+// there, and the container then fails to start.
+func TestSeedFromImageAgainstRealImage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("creates a real container")
+	}
+
+	api, err := NewAPIClient()
+	if err != nil {
+		t.Skipf("docker api client unavailable: %v", err)
+	}
+	defer api.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// nginx:alpine is already used by the compose tests in this package.
+	const ref = "nginx:alpine"
+	if err := api.EnsureImage(ctx, ref); err != nil {
+		t.Skipf("docker unavailable or image cannot be fetched: %v", err)
+	}
+
+	t.Run("file", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "nginx.conf")
+
+		if err := api.SeedFromImage(ctx, ref, "/etc/nginx/nginx.conf", dest); err != nil {
+			t.Fatal(err)
+		}
+
+		info, err := os.Stat(dest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.IsDir() {
+			t.Fatal("seeded a directory where the image has a file")
+		}
+		if info.Size() == 0 {
+			t.Error("seeded file is empty")
+		}
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "conf.d")
+
+		if err := api.SeedFromImage(ctx, ref, "/etc/nginx/conf.d", dest); err != nil {
+			t.Fatal(err)
+		}
+
+		// Docker roots the archive at the copied directory's own name, so this
+		// asserts the root was stripped rather than nested.
+		if _, err := os.Stat(filepath.Join(dest, "conf.d")); !os.IsNotExist(err) {
+			t.Error("archive root was not stripped")
+		}
+		if _, err := os.Stat(filepath.Join(dest, "default.conf")); err != nil {
+			t.Errorf("expected default.conf from the image: %v", err)
+		}
+	})
+
+	t.Run("missing container path", func(t *testing.T) {
+		dest := filepath.Join(t.TempDir(), "absent")
+
+		if err := api.SeedFromImage(ctx, ref, "/no/such/path", dest); err == nil {
+			t.Error("expected an error for a path the image does not have")
+		}
+		if _, err := os.Stat(dest); !os.IsNotExist(err) {
+			t.Error("a failed seed left something behind")
+		}
+	})
+}

--- a/internal/docker/seed_mounts_integration_test.go
+++ b/internal/docker/seed_mounts_integration_test.go
@@ -1,0 +1,127 @@
+package docker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestSeedMountsFillsOptedInMountsOnly covers the fresh-deploy case, where no
+// container exists yet and the image is the only thing to copy from.
+func TestSeedMountsFillsOptedInMountsOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("creates a real container")
+	}
+
+	const name = "flatrun-seedmounts-integration"
+	base := t.TempDir()
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	compose := "name: " + name + `
+services:
+  app:
+    image: nginx:alpine
+    volumes:
+      - ./conf.d:/etc/nginx/conf.d
+      - ./untouched:/usr/share/nginx/html
+`
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(compose), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(base)
+	if m.apiClient == nil {
+		t.Skip("docker api client unavailable")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	if _, err := m.apiClient.ListLiveComposeContainers(ctx); err != nil {
+		t.Skipf("docker daemon unreachable: %v", err)
+	}
+
+	// Deployment creation pre-creates mount directories, so seeding meets empty
+	// directories rather than absent ones.
+	for _, sub := range []string{"conf.d", "untouched"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0777); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := m.SeedMounts(name, []string{"./conf.d"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "conf.d", "default.conf")); err != nil {
+		t.Errorf("opted-in mount was not seeded from the image: %v", err)
+	}
+
+	// A mount nobody asked to seed stays exactly as it was.
+	entries, err := os.ReadDir(filepath.Join(dir, "untouched"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("a mount that was not opted in got %d entries", len(entries))
+	}
+}
+
+func TestSeedMountsLeavesExistingContentAlone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("creates a real container")
+	}
+
+	const name = "flatrun-seedmounts-existing"
+	base := t.TempDir()
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(filepath.Join(dir, "conf.d"), 0777); err != nil {
+		t.Fatal(err)
+	}
+
+	compose := "name: " + name + `
+services:
+  app:
+    image: nginx:alpine
+    volumes:
+      - ./conf.d:/etc/nginx/conf.d
+`
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(compose), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mine := filepath.Join(dir, "conf.d", "mine.conf")
+	if err := os.WriteFile(mine, []byte("# mine\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(base)
+	if m.apiClient == nil {
+		t.Skip("docker api client unavailable")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	if _, err := m.apiClient.ListLiveComposeContainers(ctx); err != nil {
+		t.Skipf("docker daemon unreachable: %v", err)
+	}
+
+	if err := m.SeedMounts(name, []string{"./conf.d"}); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(mine)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "# mine\n" {
+		t.Errorf("existing file = %q, want it untouched", content)
+	}
+	// The image's own config must not appear beside it: a mount with content is
+	// skipped whole, never merged.
+	if _, err := os.Stat(filepath.Join(dir, "conf.d", "default.conf")); !os.IsNotExist(err) {
+		t.Error("seeded into a mount that already had content")
+	}
+}

--- a/internal/docker/seed_test.go
+++ b/internal/docker/seed_test.go
@@ -1,0 +1,178 @@
+package docker
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// tarOf builds an archive laid out the way Docker lays out a copied container
+// path. The shapes mirror what `docker cp` really produced from nginx:alpine:
+// copying the file /etc/nginx/nginx.conf gave the single entry "nginx.conf",
+// and copying the directory /etc/nginx/conf.d gave "conf.d/" followed by
+// "conf.d/default.conf".
+func tarOf(t *testing.T, entries []tar.Header, bodies map[string]string) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for i := range entries {
+		h := entries[i]
+		if body, ok := bodies[h.Name]; ok {
+			h.Size = int64(len(body))
+		}
+		if err := tw.WriteHeader(&h); err != nil {
+			t.Fatal(err)
+		}
+		if body, ok := bodies[h.Name]; ok {
+			if _, err := tw.Write([]byte(body)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return &buf
+}
+
+func TestExtractSeedTarFile(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "nginx.conf")
+	archive := tarOf(t,
+		[]tar.Header{{Name: "nginx.conf", Typeflag: tar.TypeReg, Mode: 0644}},
+		map[string]string{"nginx.conf": "worker_processes auto;\n"},
+	)
+
+	if err := extractSeedTar(archive, dest, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// The copied file lands at the destination itself, not inside a directory
+	// named after it, which is the whole point of seeding a single-file mount.
+	content, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "worker_processes auto;\n" {
+		t.Errorf("content = %q", content)
+	}
+
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.IsDir() {
+		t.Error("seeded a directory where a file belongs")
+	}
+	if got := info.Mode().Perm(); got != 0644 {
+		t.Errorf("mode = %o, want 644", got)
+	}
+}
+
+func TestExtractSeedTarDirectory(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "conf.d")
+	archive := tarOf(t,
+		[]tar.Header{
+			{Name: "conf.d/", Typeflag: tar.TypeDir, Mode: 0755},
+			{Name: "conf.d/default.conf", Typeflag: tar.TypeReg, Mode: 0644},
+			{Name: "conf.d/nested/deep.conf", Typeflag: tar.TypeReg, Mode: 0600},
+		},
+		map[string]string{
+			"conf.d/default.conf":     "server {}\n",
+			"conf.d/nested/deep.conf": "deep\n",
+		},
+	)
+
+	if err := extractSeedTar(archive, dest, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// The archive's root component is the copied directory itself, so it must
+	// not reappear as conf.d/conf.d on the host.
+	if _, err := os.Stat(filepath.Join(dest, "conf.d")); !os.IsNotExist(err) {
+		t.Error("archive root component was not stripped")
+	}
+
+	content, err := os.ReadFile(filepath.Join(dest, "default.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "server {}\n" {
+		t.Errorf("content = %q", content)
+	}
+
+	if _, err := os.Stat(filepath.Join(dest, "nested", "deep.conf")); err != nil {
+		t.Errorf("nested entry missing: %v", err)
+	}
+}
+
+func TestExtractSeedTarRejectsTraversal(t *testing.T) {
+	base := t.TempDir()
+	dest := filepath.Join(base, "conf.d")
+	outside := filepath.Join(base, "escaped.conf")
+
+	// Stripping the root leaves "../escaped.conf", which resolves to escaped.conf
+	// beside the destination: image content is untrusted, so it must not write
+	// there.
+	archive := tarOf(t,
+		[]tar.Header{{Name: "conf.d/../escaped.conf", Typeflag: tar.TypeReg, Mode: 0644}},
+		map[string]string{"conf.d/../escaped.conf": "pwned"},
+	)
+
+	if err := extractSeedTar(archive, dest, true); err == nil {
+		t.Error("expected an error for an entry escaping the destination")
+	}
+	if _, err := os.Stat(outside); !os.IsNotExist(err) {
+		t.Error("an archive entry wrote outside the destination")
+	}
+}
+
+func TestIsSeedable(t *testing.T) {
+	base := t.TempDir()
+
+	t.Run("missing path", func(t *testing.T) {
+		got, err := isSeedable(filepath.Join(base, "absent"))
+		if err != nil || !got {
+			t.Errorf("got %v (err %v), want true", got, err)
+		}
+	})
+
+	t.Run("empty directory", func(t *testing.T) {
+		// Deployment creation pre-creates mount directories, so an empty one is
+		// the normal state at seeding time.
+		dir := filepath.Join(base, "empty")
+		if err := os.MkdirAll(dir, 0777); err != nil {
+			t.Fatal(err)
+		}
+		got, err := isSeedable(dir)
+		if err != nil || !got {
+			t.Errorf("got %v (err %v), want true", got, err)
+		}
+	})
+
+	t.Run("directory with content", func(t *testing.T) {
+		dir := filepath.Join(base, "full")
+		if err := os.MkdirAll(dir, 0777); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "user.conf"), []byte("mine"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		got, err := isSeedable(dir)
+		if err != nil || got {
+			t.Errorf("got %v (err %v), want false: user data must never be overwritten", got, err)
+		}
+	})
+
+	t.Run("existing file", func(t *testing.T) {
+		path := filepath.Join(base, "existing.conf")
+		if err := os.WriteFile(path, []byte("mine"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		got, err := isSeedable(path)
+		if err != nil || got {
+			t.Errorf("got %v (err %v), want false", got, err)
+		}
+	})
+}

--- a/internal/docker/unmount_integration_test.go
+++ b/internal/docker/unmount_integration_test.go
@@ -1,0 +1,113 @@
+package docker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestUnmountDetachesTheContainerFromTheHost pins the rule the UI warns about:
+// while a path is mounted the host copy is what the container reads, so deleting
+// it there takes it from the container too; once unmounted the container is back
+// on its image's content and the host copy cannot reach it.
+func TestUnmountDetachesTheContainerFromTheHost(t *testing.T) {
+	if testing.Short() {
+		t.Skip("starts a real container")
+	}
+
+	const (
+		name    = "flatrun-unmount-integration"
+		service = "app"
+		marker  = "/etc/nginx/conf.d/marker.conf"
+	)
+
+	base := t.TempDir()
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	compose := "name: " + name + `
+services:
+  app:
+    image: nginx:alpine
+`
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(compose), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(base)
+	if m.apiClient == nil {
+		t.Skip("docker api client unavailable")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	if _, err := m.apiClient.ListLiveComposeContainers(ctx); err != nil {
+		t.Skipf("docker daemon unreachable: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := m.executor.Down(dir); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	})
+
+	if out, err := m.StartDeployment(name); err != nil {
+		t.Fatalf("start failed: %v (%s)", err, out)
+	}
+	if _, err := m.apiClient.ExecInService(ctx, name, service, "echo '# marker' > "+marker); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.MaterializeMount(name, service, "/etc/nginx/conf.d", "./conf.d"); err != nil {
+		t.Fatal(err)
+	}
+
+	hostMarker := filepath.Join(dir, "conf.d", "marker.conf")
+	if _, err := os.Stat(hostMarker); err != nil {
+		t.Fatalf("host copy missing: %v", err)
+	}
+
+	// While mounted, the host copy is the container's content: removing it there
+	// removes it from the running service too.
+	if err := os.Remove(hostMarker); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.apiClient.ExecInService(ctx, name, service, "cat "+marker); err == nil {
+		t.Error("deleting a mounted file left it readable in the container")
+	}
+
+	if err := m.UnmountPath(name, service, "./conf.d", "/etc/nginx/conf.d"); err != nil {
+		t.Fatalf("UnmountPath: %v", err)
+	}
+
+	// Unmounted, the service is back on its image's own content.
+	out, err := m.apiClient.ExecInService(ctx, name, service, "cat /etc/nginx/conf.d/default.conf")
+	if err != nil {
+		t.Fatalf("service did not return to its image content: %v", err)
+	}
+	if !strings.Contains(out, "server") {
+		t.Errorf("image config not restored, got %q", out)
+	}
+
+	// The host copy survives an unmount; it is the only place that content lives.
+	if _, err := os.Stat(filepath.Join(dir, "conf.d")); err != nil {
+		t.Errorf("unmount removed the host copy: %v", err)
+	}
+
+	// And now the host copy is detached: deleting it cannot touch the container.
+	if err := os.RemoveAll(filepath.Join(dir, "conf.d")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.apiClient.ExecInService(ctx, name, service, "cat /etc/nginx/conf.d/default.conf"); err != nil {
+		t.Errorf("deleting an unmounted host copy reached into the container: %v", err)
+	}
+
+	updated, _, err := m.discovery.GetComposeFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(updated, "./conf.d:/etc/nginx/conf.d") {
+		t.Errorf("compose still lists the mount:\n%s", updated)
+	}
+}


### PR DESCRIPTION
Closes #139, and departs from it on one point: the issue proposed filling a mount from the image, but the content that matters is usually written by an entrypoint at first start and exists in no image layer. WordPress, Nextcloud and Ghost all populate their mounts that way, so copying from the image would bring a service back on content it never had. The copy reads the container.

A bind mount only goes one way: it pushes the host's side in. Mounting a path a container populated hides it, and mounting an empty host path over it leaves the service with nothing. So the copy runs first, and the service is stopped for it, which is the only way nothing can be written between the copy and the mount taking effect.

Unmounting recreates the service. Removing the mount from the compose file alone leaves the running container still bound to the host, so a caller told the mount was gone would be wrong.

Listing a container's directory asks its shell, because the engine can stat a path and archive it but cannot list one. An image without a shell cannot be browsed and says so; its paths can still be copied out by name.

Constraints worth knowing before changing this code:

- Host paths arrive from requests and are confined to the deployment directory.
- Image content is untrusted, so an archive entry resolving outside its target is refused.
- Only a missing or empty target is ever written, mirroring named volumes.
- A host copy survives an unmount; it is then the only place that content exists.
