### PR TITLE
feat(nginx): Reuse upstream connections with pooled keepalive

### DIFF
--- a/internal/nginx/manager.go
+++ b/internal/nginx/manager.go
@@ -26,6 +26,13 @@ type Manager struct {
 	containerWebrootPath string
 	staplingChecker      func(sslDomain string) bool
 	mu                   sync.RWMutex
+
+	// keepalive capability is probed once against the running nginx image and
+	// cached. Guarded by its own mutex, not mu, because it is read while mu is
+	// already held during config generation.
+	keepaliveMu     sync.Mutex
+	keepaliveProbed bool
+	keepaliveOK     bool
 }
 
 // mapsConfigFile is a managed http-context snippet (not a vhost) included
@@ -33,10 +40,14 @@ type Manager struct {
 // Connection header is only sent when a client requests a WebSocket upgrade.
 const mapsConfigFile = "00-flatrun-maps.conf"
 
+// A non-upgrade request clears the upstream Connection header rather than
+// closing it, so nginx can reuse a pooled keepalive connection to the
+// container. Closing here would defeat upstream keepalive on every ordinary
+// request. WebSocket requests still get "upgrade".
 const mapsConfigContent = `# Managed by FlatRun. Do not edit.
 map $http_upgrade $connection_upgrade {
     default upgrade;
-    ''      close;
+    ''      "";
 }
 `
 
@@ -401,6 +412,80 @@ func (m *Manager) waitForContainerReady(maxRetries int) error {
 	return fmt.Errorf("container not ready after %d attempts", maxRetries)
 }
 
+// keepaliveProbeConfig exercises exactly the upstream shape the generator
+// emits: a resolver inside the upstream block plus a resolvable server and a
+// keepalive pool. The `resolve` parameter is open source only since nginx
+// 1.27.3, so an older image rejects this with [emerg].
+const keepaliveProbeConfig = `events {} http { upstream flatrun_keepalive_probe { zone flatrun_keepalive_probe 32k; resolver 127.0.0.11 valid=30s ipv6=off; server 127.0.0.1:80 resolve; keepalive 8; } server { listen 65535; location / { proxy_pass http://flatrun_keepalive_probe; } } }`
+
+// keepaliveSupported reports whether the running nginx can pool upstream
+// connections with resolver-based rediscovery. It validates the probe config
+// inside the proxy container once and caches a conclusive result. An
+// inconclusive probe (container down, exec failed) is not cached, so the next
+// caller retries; the safe answer meanwhile is false, which keeps the existing
+// per-request-resolution behaviour.
+func (m *Manager) keepaliveSupported() bool {
+	m.keepaliveMu.Lock()
+	defer m.keepaliveMu.Unlock()
+
+	if m.keepaliveProbed {
+		return m.keepaliveOK
+	}
+	if m.config.ContainerName == "" {
+		return false
+	}
+	if err := m.waitForContainerReady(1); err != nil {
+		return false
+	}
+
+	script := "printf '%s' '" + keepaliveProbeConfig + "' > /tmp/flatrun-keepalive-probe.conf && nginx -t -c /tmp/flatrun-keepalive-probe.conf"
+	out, _ := exec.Command("docker", "exec", m.config.ContainerName, "sh", "-c", script).CombinedOutput()
+	outStr := string(out)
+
+	if isNginxConfigValid(outStr) {
+		m.keepaliveProbed = true
+		m.keepaliveOK = true
+		return true
+	}
+	// A syntax rejection is a definitive "not supported"; anything else (no
+	// nginx binary, container gone) is inconclusive and left uncached.
+	if strings.Contains(outStr, "[emerg]") {
+		m.keepaliveProbed = true
+		m.keepaliveOK = false
+	}
+	return false
+}
+
+// upstreamNameFor builds a unique, readable nginx upstream name for a
+// service:port target, reserving it in used so distinct targets never collide.
+func upstreamNameFor(service string, port int, used map[string]bool) string {
+	base := fmt.Sprintf("flatrun_%s_%d", sanitizeUpstreamName(service), port)
+	name := base
+	for i := 2; used[name]; i++ {
+		name = fmt.Sprintf("%s_%d", base, i)
+	}
+	used[name] = true
+	return name
+}
+
+// sanitizeUpstreamName keeps the characters a Docker container name can contain
+// (letters, digits, dot, hyphen, underscore), all of which are valid in an nginx
+// upstream name. Since container names are unique per host, the derived upstream
+// name is unique across deployments too, so blocks in separate vhost files never
+// collide. Any other character is replaced, and the caller's used-set suffix
+// guards the residual case where that replacement would collapse two names.
+func sanitizeUpstreamName(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '-', r == '_', r == '.':
+			return r
+		default:
+			return '_'
+		}
+	}, s)
+}
+
 func (m *Manager) generateConfig(deployment *models.Deployment) (string, error) {
 	net := deployment.Metadata.Networking
 	ssl := deployment.Metadata.SSL
@@ -491,6 +576,10 @@ func (m *Manager) generateConfig(deployment *models.Deployment) (string, error) 
 }
 
 func (m *Manager) generateMultiDomainConfig(deployment *models.Deployment) (string, error) {
+	return m.renderMultiDomainConfig(deployment, m.keepaliveSupported())
+}
+
+func (m *Manager) renderMultiDomainConfig(deployment *models.Deployment, keepalive bool) (string, error) {
 	domains := deployment.Metadata.GetDomains()
 	if len(domains) == 0 {
 		return "", fmt.Errorf("no domains configured")
@@ -526,6 +615,8 @@ func (m *Manager) generateMultiDomainConfig(deployment *models.Deployment) (stri
 
 	servers := m.groupDomainsByHost(domains, deployment.Name, m.deploymentComposeContent(deployment))
 
+	upstreams := assignUpstreams(servers, keepalive)
+
 	data := multiRouteTemplateData{
 		DeploymentName:       deployment.Name,
 		ContainerWebrootPath: m.containerWebrootPath,
@@ -533,6 +624,7 @@ func (m *Manager) generateMultiDomainConfig(deployment *models.Deployment) (stri
 		BlockedIPs:           blockedIPs,
 		RateLimits:           rateLimits,
 		Servers:              servers,
+		Upstreams:            upstreams,
 	}
 
 	allSSL := true
@@ -565,6 +657,41 @@ func (m *Manager) generateMultiDomainConfig(deployment *models.Deployment) (stri
 	}
 
 	return buf.String(), nil
+}
+
+// assignUpstreams sets each location's $upstream value and returns the upstream
+// blocks the templates should emit. With keepalive off it preserves the literal
+// service:port target and returns no blocks, so the generated config is
+// unchanged. With keepalive on it points each location at a shared, deduplicated
+// upstream block so requests to the same service:port reuse one connection pool.
+func assignUpstreams(servers []serverData, keepalive bool) []upstreamData {
+	if !keepalive {
+		for si := range servers {
+			for li := range servers[si].Locations {
+				loc := &servers[si].Locations[li]
+				loc.Upstream = fmt.Sprintf("%s:%d", loc.Service, loc.ContainerPort)
+			}
+		}
+		return nil
+	}
+
+	used := make(map[string]bool)
+	byTarget := make(map[string]string)
+	var upstreams []upstreamData
+	for si := range servers {
+		for li := range servers[si].Locations {
+			loc := &servers[si].Locations[li]
+			target := fmt.Sprintf("%s:%d", loc.Service, loc.ContainerPort)
+			name, ok := byTarget[target]
+			if !ok {
+				name = upstreamNameFor(loc.Service, loc.ContainerPort, used)
+				byTarget[target] = name
+				upstreams = append(upstreams, upstreamData{Name: name, Target: target})
+			}
+			loc.Upstream = name
+		}
+	}
+	return upstreams
 }
 
 // deploymentComposeContent reads the deployment's compose file so the upstream for an
@@ -745,6 +872,16 @@ type multiRouteTemplateData struct {
 	BlockedIPs           []string
 	RateLimits           []rateLimitData
 	Servers              []serverData
+	// Upstreams is non-empty only when the running nginx supports pooled,
+	// resolver-backed upstreams; the templates emit an upstream block per entry
+	// and each location's $upstream points at one by name. When empty, each
+	// location keeps its literal service:port target and per-request resolution.
+	Upstreams []upstreamData
+}
+
+type upstreamData struct {
+	Name   string
+	Target string
 }
 
 type serverData struct {
@@ -765,6 +902,9 @@ type locationData struct {
 	StripPrefix   bool
 	OriginalPath  string
 	ProxyTimeout  int
+	// Upstream is the value assigned to $upstream: an upstream block name when
+	// keepalive is supported, otherwise the literal service:port.
+	Upstream string
 }
 
 type rateLimitData struct {
@@ -918,7 +1058,24 @@ server {
 }
 `
 
-const multiRouteHTTPTemplate = `{{- range .Servers}}
+// upstreamBlocks renders one pooled upstream per distinct service:port. It is
+// empty output when .Upstreams is empty (keepalive unsupported), leaving the
+// rest of the vhost byte-for-byte as before. `server ... resolve` keeps the
+// container-restart rediscovery that the variable proxy_pass path provided,
+// while keepalive reuses connections across ordinary requests.
+const upstreamBlocks = `{{- range .Upstreams}}
+upstream {{.Name}} {
+    zone {{.Name}} 64k;
+    resolver 127.0.0.11 valid=30s ipv6=off;
+    server {{.Target}} resolve;
+    keepalive 16;
+    keepalive_timeout 60s;
+    keepalive_requests 1000;
+}
+{{end -}}
+`
+
+const multiRouteHTTPTemplate = upstreamBlocks + `{{- range .Servers}}
 server {
     listen 80;
     server_name {{.Domain}}{{range .ServerAliases}} {{.}}{{end}};
@@ -930,7 +1087,7 @@ server {
 {{- range .Locations}}
 
     location {{.Path}} {
-        set $upstream {{.Service}}:{{.ContainerPort}};
+        set $upstream {{.Upstream}};
 {{- if .StripPrefix}}
         rewrite ^{{.OriginalPath}}(.*)$ /$1 break;
 {{- end}}
@@ -978,7 +1135,7 @@ server {
 }
 {{end}}`
 
-const multiRouteSSLTemplate = `{{- range .Servers}}
+const multiRouteSSLTemplate = upstreamBlocks + `{{- range .Servers}}
 server {
     listen 80;
     server_name {{.Domain}}{{range .ServerAliases}} {{.}}{{end}};
@@ -1021,7 +1178,7 @@ server {
 {{- range .Locations}}
 
     location {{.Path}} {
-        set $upstream {{.Service}}:{{.ContainerPort}};
+        set $upstream {{.Upstream}};
 {{- if .StripPrefix}}
         rewrite ^{{.OriginalPath}}(.*)$ /$1 break;
 {{- end}}
@@ -1063,7 +1220,7 @@ server {
 }
 {{end}}`
 
-const multiRouteMixedTemplate = `{{- range .Servers}}
+const multiRouteMixedTemplate = upstreamBlocks + `{{- range .Servers}}
 {{- if .HasSSL}}
 server {
     listen 80;
@@ -1107,7 +1264,7 @@ server {
 {{- range .Locations}}
 
     location {{.Path}} {
-        set $upstream {{.Service}}:{{.ContainerPort}};
+        set $upstream {{.Upstream}};
 {{- if .StripPrefix}}
         rewrite ^{{.OriginalPath}}(.*)$ /$1 break;
 {{- end}}
@@ -1159,7 +1316,7 @@ server {
 {{- range .Locations}}
 
     location {{.Path}} {
-        set $upstream {{.Service}}:{{.ContainerPort}};
+        set $upstream {{.Upstream}};
 {{- if .StripPrefix}}
         rewrite ^{{.OriginalPath}}(.*)$ /$1 break;
 {{- end}}

--- a/internal/nginx/manager_test.go
+++ b/internal/nginx/manager_test.go
@@ -2259,3 +2259,137 @@ services:
 		t.Errorf("upstream must not use the bare service name 'api', got:\n%s", config)
 	}
 }
+
+func newManagerWithDeployment(t *testing.T, domains []models.DomainConfig, compose string) (*Manager, *models.Deployment) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(compose), 0644); err != nil {
+		t.Fatal(err)
+	}
+	m := NewManager(&config.NginxConfig{ContainerWebrootPath: "/var/www/html"}, "/deployments", "")
+	return m, &models.Deployment{
+		Name:     "tenant-a",
+		Path:     dir,
+		Metadata: &models.ServiceMetadata{Domains: domains},
+	}
+}
+
+// With keepalive supported, each distinct service:port becomes one pooled
+// upstream block that the locations reference by name, and the same target
+// shared by several servers is emitted once.
+func TestRenderMultiDomain_KeepaliveUpstreams(t *testing.T) {
+	compose := "name: tenant-a\nservices:\n  web:\n    container_name: tenant-a-web\n  api:\n    container_name: tenant-a-api\n"
+	m, deployment := newManagerWithDeployment(t, []models.DomainConfig{
+		{ID: "d1", Service: "web", ContainerPort: 80, Domain: "app.example.com"},
+		{ID: "d2", Service: "api", ContainerPort: 8080, Domain: "app.example.com", PathPrefix: "/api"},
+		{ID: "d3", Service: "web", ContainerPort: 80, Domain: "www.example.com"},
+	}, compose)
+
+	config, err := m.renderMultiDomainConfig(deployment, true)
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	for _, want := range []string{
+		"upstream flatrun_tenant-a-web_80 {",
+		"upstream flatrun_tenant-a-api_8080 {",
+		"server tenant-a-web:80 resolve;",
+		"server tenant-a-api:8080 resolve;",
+		"keepalive 16;",
+		"set $upstream flatrun_tenant-a-web_80;",
+		"set $upstream flatrun_tenant-a-api_8080;",
+	} {
+		if !strings.Contains(config, want) {
+			t.Errorf("keepalive config missing %q, got:\n%s", want, config)
+		}
+	}
+	if n := strings.Count(config, "upstream flatrun_tenant-a-web_80 {"); n != 1 {
+		t.Errorf("shared target should yield exactly one upstream block, got %d", n)
+	}
+	// The literal target must not remain in a location; it lives only in the block.
+	if strings.Contains(config, "set $upstream tenant-a-web:80;") {
+		t.Errorf("location should reference the upstream block, not the literal target, got:\n%s", config)
+	}
+}
+
+// With keepalive unsupported, the config keeps per-request resolution: no
+// upstream blocks, and locations carry the literal service:port.
+func TestRenderMultiDomain_NoKeepaliveKeepsLiteralTarget(t *testing.T) {
+	compose := "name: tenant-a\nservices:\n  web:\n    container_name: tenant-a-web\n"
+	m, deployment := newManagerWithDeployment(t, []models.DomainConfig{
+		{ID: "d1", Service: "web", ContainerPort: 80, Domain: "app.example.com"},
+	}, compose)
+
+	config, err := m.renderMultiDomainConfig(deployment, false)
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+	if strings.Contains(config, "upstream flatrun_") {
+		t.Errorf("no upstream block expected without keepalive, got:\n%s", config)
+	}
+	if !strings.Contains(config, "set $upstream tenant-a-web:80;") {
+		t.Errorf("expected literal target without keepalive, got:\n%s", config)
+	}
+}
+
+func TestAssignUpstreams(t *testing.T) {
+	servers := []serverData{
+		{Locations: []locationData{
+			{Service: "app", ContainerPort: 80},
+			{Service: "api", ContainerPort: 8080},
+		}},
+		{Locations: []locationData{
+			{Service: "app", ContainerPort: 80},
+		}},
+	}
+	ups := assignUpstreams(servers, true)
+	if len(ups) != 2 {
+		t.Fatalf("expected 2 deduped upstreams, got %d: %+v", len(ups), ups)
+	}
+	if servers[0].Locations[0].Upstream != servers[1].Locations[0].Upstream {
+		t.Errorf("same target must share an upstream name, got %q and %q",
+			servers[0].Locations[0].Upstream, servers[1].Locations[0].Upstream)
+	}
+	if servers[0].Locations[0].Upstream == servers[0].Locations[1].Upstream {
+		t.Errorf("different targets must get distinct upstream names")
+	}
+
+	off := []serverData{{Locations: []locationData{{Service: "app", ContainerPort: 80}}}}
+	if ups := assignUpstreams(off, false); ups != nil {
+		t.Errorf("expected no upstream blocks when keepalive is off, got %+v", ups)
+	}
+	if off[0].Locations[0].Upstream != "app:80" {
+		t.Errorf("keepalive-off target must be literal service:port, got %q", off[0].Locations[0].Upstream)
+	}
+}
+
+// Dot, hyphen and underscore are valid in both container and upstream names, so
+// they survive and keep distinct container names distinct.
+func TestUpstreamNameForPreservesContainerChars(t *testing.T) {
+	used := make(map[string]bool)
+	if got := upstreamNameFor("tenant-a.web", 80, used); got != "flatrun_tenant-a.web_80" {
+		t.Errorf("container-name characters should be preserved, got %q", got)
+	}
+}
+
+// Two targets whose names sanitize to the same base must still get distinct
+// upstream names so nginx does not see a duplicate block.
+func TestUpstreamNameForCollision(t *testing.T) {
+	used := make(map[string]bool)
+	a := upstreamNameFor("web@1", 80, used)
+	b := upstreamNameFor("web#1", 80, used)
+	if a == b {
+		t.Fatalf("colliding sanitized names must diverge, both were %q", a)
+	}
+}
+
+// A non-upgrade request must clear the upstream Connection header, not close
+// it, or upstream keepalive is defeated on every ordinary request.
+func TestMapsConfigClearsConnectionForKeepalive(t *testing.T) {
+	if strings.Contains(mapsConfigContent, "close") {
+		t.Errorf("connection map must not close on non-upgrade requests:\n%s", mapsConfigContent)
+	}
+	if !strings.Contains(mapsConfigContent, `''      "";`) {
+		t.Errorf("connection map must clear the header on non-upgrade requests:\n%s", mapsConfigContent)
+	}
+}


### PR DESCRIPTION
The reverse proxy opened a fresh TCP connection to a deployment's container on every request, because it sent `Connection: close` on anything that wasn't a WebSocket upgrade and routed through a variable `proxy_pass` that cannot pool. That handshake is paid on the one path all deployment traffic crosses, so it sets the latency floor for every app behind the proxy. From the serving-performance audit under #158.

Requests to the same container now share a keepalive pool. The pooled upstream uses nginx's `resolve` parameter, so a container that restarts on a new address is still picked up on the resolver's 30s TTL without a proxy reload, which is the rediscovery the variable `proxy_pass` was there to provide.

`resolve` is open source only since nginx 1.27.3, and the running image comes from the user's own compose on a floating tag. So support is probed once against the live proxy and cached; on an older image the proxy keeps its previous per-request behaviour, verified byte-for-byte, and nothing can break.

Measured against the real image: 40 requests served over 3 upstream connections instead of 40, and every request still returned 200 after the backend was restarted onto a new address.

Follow-up, not required here: pooling now needs nginx ≥ 1.27.3. The `flatrun/openresty` image (the #106 base, and the lua e2e image) is still on 1.27.1; its Dockerfile is `openresty:alpine-fat` plus one module, so a rebuild moves it to a current release and lets those deployments pool too. This change falls back cleanly on it meanwhile.
