### PR TITLE
chore: Fold small Albacore follow-ups (backup pruning + docs)

### DIFF
--- a/docs/DEPLOYMENT_TUNING.md
+++ b/docs/DEPLOYMENT_TUNING.md
@@ -1,0 +1,47 @@
+# Per-deployment tuning
+
+Knobs an operator can turn to change how a single deployment serves traffic and
+uses host resources. These are distinct from FlatRun's own dashboard/API speed;
+they affect how fast and how reliably a deployed app answers its end users.
+
+Everything here is a flat-file field or a container-level limit, so it stays
+readable and portable: the serving knobs live in the deployment's `service.yml`
+metadata, and the resource limits are applied to the running container.
+
+## Reverse-proxy serving (per domain)
+
+Each entry under `domains` in a deployment's `service.yml` carries its own
+serving knobs. Set them from the UI's domain form, or over the API with
+`PUT /api/deployments/:name/domains/:domainId`.
+
+| Field | Type | Default | What it does |
+|-------|------|---------|--------------|
+| `proxy_timeout` | seconds | 60 | Proxy read/send timeout. Raise it for a domain that proxies long-lived WebSocket connections so an idle socket is not closed mid-connection. |
+| `static_cache` | bool | off | Opt the domain into a long browser cache for static assets (css, js, images, fonts). It applies only to responses whose request path has a static extension; dynamic responses keep the app's own cache headers. |
+
+Both are opt-in per domain: a domain that never sets them keeps the stock proxy
+behaviour. Because the fields live in `service.yml`, the same values move with
+the deployment directory.
+
+## Container resource limits
+
+Memory and CPU caps are applied to the running container, not the compose file,
+so they take effect without a rewrite or a restart. Set them from the UI or over
+the API:
+
+- `GET /api/deployments/:name/resources` reads the current limits.
+- `PUT /api/containers/:id/resources` updates them.
+
+| Limit | Unit | What it does |
+|-------|------|--------------|
+| `memory_limit` | bytes | Hard memory ceiling for the container. |
+| `memory_swap` | bytes | Memory + swap ceiling. |
+| `cpus` | cores | Fractional CPU cap (e.g. `1.5`). |
+| `cpu_shares` | relative weight | Relative CPU priority under contention. |
+
+## App-level worker counts
+
+How many workers or processes an app runs (for example a PHP-FPM pool, a Gunicorn
+worker count, or `WEB_CONCURRENCY`) is the app's own setting, not a FlatRun field.
+Set it through the service's environment or command in the deployment's compose
+file. FlatRun does not override it, so the app's own tuning stays authoritative.

--- a/docs/RELEASE_NAMING.md
+++ b/docs/RELEASE_NAMING.md
@@ -1,0 +1,23 @@
+# Release naming
+
+Umbrella releases are codenamed after sea creatures, advancing one letter of the
+alphabet per release. When opening a new `group(enhancements):` umbrella issue,
+pick the next unused letter and a sea creature that starts with it.
+
+```
+Albacore (A) -> Barnacle (B) -> Cuttlefish (C) -> Dolphin (D) -> ...
+```
+
+## How to use it
+
+- One codename per umbrella release, one letter per release, in alphabetical order.
+- The codename names the release theme; the umbrella issue collects every item
+  that ships in that cycle.
+- Carry the current codename into the changelog entry and the beta/release notes
+  so a release and its umbrella are easy to line up.
+
+## History
+
+| Letter | Codename | Theme |
+|--------|----------|-------|
+| A | Albacore | Full deployment lifecycle and self-healing operations |

--- a/internal/docker/discovery.go
+++ b/internal/docker/discovery.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -579,6 +580,8 @@ func (d *Discovery) UpdateComposeFile(name string, content string) error {
 		return err
 	}
 
+	d.pruneComposeBackups(composePath, maxComposeBackups)
+
 	metadataPath := filepath.Join(dirPath, "service.yml")
 	if _, err := os.Stat(metadataPath); err == nil {
 		if newMeta := d.generateMetadataFromCompose(composePath, name); newMeta != nil {
@@ -600,6 +603,30 @@ func (d *Discovery) UpdateComposeFile(name string, content string) error {
 	}
 
 	return nil
+}
+
+// maxComposeBackups bounds how many timestamped compose backups are retained
+// after a rewrite. The most recent ones are kept so a rollback copy still exists
+// while older backups no longer accumulate in the deployment directory.
+const maxComposeBackups = 5
+
+// pruneComposeBackups keeps the newest `keep` `<compose>.bak.<ts>` files next to
+// composePath and removes the rest. The timestamp suffix is written with a
+// lexicographically ordered layout, so a sorted glob is chronological.
+func (d *Discovery) pruneComposeBackups(composePath string, keep int) {
+	if keep < 0 {
+		keep = 0
+	}
+
+	matches, err := filepath.Glob(composePath + ".bak.*")
+	if err != nil || len(matches) <= keep {
+		return
+	}
+
+	sort.Strings(matches)
+	for _, stale := range matches[:len(matches)-keep] {
+		_ = os.Remove(stale)
+	}
 }
 
 func (d *Discovery) SaveMetadata(name string, metadata *models.ServiceMetadata) error {

--- a/internal/docker/discovery_test.go
+++ b/internal/docker/discovery_test.go
@@ -650,6 +650,53 @@ func TestUpdateComposeFile_SyncsMetadata(t *testing.T) {
 	}
 }
 
+func TestUpdateComposeFile_PrunesOldBackups(t *testing.T) {
+	tmpDir := t.TempDir()
+	deployDir := filepath.Join(tmpDir, "myapp")
+	if err := os.MkdirAll(deployDir, 0755); err != nil {
+		t.Fatalf("Failed to create deploy dir: %v", err)
+	}
+
+	composePath := filepath.Join(deployDir, "docker-compose.yml")
+	if err := os.WriteFile(composePath, []byte("services:\n  app:\n    image: myapp:latest\n"), 0644); err != nil {
+		t.Fatalf("Failed to write compose: %v", err)
+	}
+
+	// Seed backups using the exact production filename shape written by
+	// UpdateComposeFile (discovery.go: composePath + ".bak." + yyyymmddhhmmss).
+	// Older timestamps sort earlier, so the two oldest should be pruned.
+	seeded := []string{
+		"20200101000001", "20200101000002", "20200101000003",
+		"20200101000004", "20200101000005", "20200101000006",
+	}
+	for _, ts := range seeded {
+		if err := os.WriteFile(composePath+".bak."+ts, []byte("old"), 0644); err != nil {
+			t.Fatalf("Failed to seed backup %s: %v", ts, err)
+		}
+	}
+
+	d := NewDiscovery(tmpDir)
+	if err := d.UpdateComposeFile("myapp", "services:\n  app:\n    image: myapp:v2\n"); err != nil {
+		t.Fatalf("UpdateComposeFile failed: %v", err)
+	}
+
+	backups, err := filepath.Glob(composePath + ".bak.*")
+	if err != nil {
+		t.Fatalf("Glob failed: %v", err)
+	}
+	if len(backups) != maxComposeBackups {
+		t.Fatalf("backup count = %d, want %d", len(backups), maxComposeBackups)
+	}
+
+	// The two oldest seeded backups must be gone; the newest seeded ones remain.
+	if _, err := os.Stat(composePath + ".bak.20200101000001"); !os.IsNotExist(err) {
+		t.Error("oldest backup should have been pruned")
+	}
+	if _, err := os.Stat(composePath + ".bak.20200101000006"); err != nil {
+		t.Errorf("newest seeded backup should be retained: %v", err)
+	}
+}
+
 func TestExtractBindMounts(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Closes the three small, single-repo leftovers from the Albacore umbrella (#158) that were too minor to each warrant their own PR.

- Compose rewrites accumulated a timestamped backup every time and never removed them, so an actively-edited deployment slowly filled its directory with backups. A successful rewrite now retains a bounded number of the most recent backups and prunes the rest, keeping a rollback copy while stopping the pile-up.
- Adds an operator reference for the knobs that change how one deployment serves traffic and uses host resources (per-domain proxy timeout and static-asset cache, container CPU/memory limits), plus the durable record of the sea-creature release-naming convention.