### PR TITLE
feat(deployments): Deploy from a git source behind a provider interface

### DIFF
--- a/internal/api/deployment_source.go
+++ b/internal/api/deployment_source.go
@@ -15,11 +15,16 @@ import (
 // deploy from, instead of inline compose content. Type selects the provider
 // (e.g. "git"); Ref is the provider's locator (a repository URL for git).
 type deploymentSource struct {
-	Type         string `json:"type"`
-	Ref          string `json:"ref"`
-	Branch       string `json:"branch,omitempty"`
-	Subpath      string `json:"subpath,omitempty"`
+	Type    string `json:"type"`
+	Ref     string `json:"ref"`
+	Branch  string `json:"branch,omitempty"`
+	Subpath string `json:"subpath,omitempty"`
+	// CredentialID names a stored credential to authenticate a private source.
+	// Username and Token authenticate inline instead, for a one-off private
+	// source with no saved credential. CredentialID wins when both are given.
 	CredentialID string `json:"credential_id,omitempty"`
+	Username     string `json:"username,omitempty"`
+	Token        string `json:"token,omitempty"`
 }
 
 // fetchedSource is a materialized source ready to become a deployment: the
@@ -42,7 +47,7 @@ func (s *Server) fetchDeploymentSource(ctx context.Context, req *deploymentSourc
 		return nil, fmt.Errorf("unknown source type %q", req.Type)
 	}
 
-	auth, err := s.resolveSourceAuth(req.CredentialID)
+	auth, err := s.resolveSourceAuth(req)
 	if err != nil {
 		return nil, err
 	}
@@ -91,18 +96,22 @@ func (s *Server) fetchDeploymentSource(ctx context.Context, req *deploymentSourc
 	}, nil
 }
 
-// resolveSourceAuth turns a stored credential id into provider auth. A missing id
-// means an anonymous fetch (a public repository).
-func (s *Server) resolveSourceAuth(credentialID string) (*source.Auth, error) {
-	if credentialID == "" {
-		return nil, nil
+// resolveSourceAuth turns a request's credential into provider auth: a stored
+// credential id when given, otherwise an inline token. Neither means an
+// anonymous fetch (a public repository).
+func (s *Server) resolveSourceAuth(req *deploymentSource) (*source.Auth, error) {
+	if req.CredentialID != "" {
+		cred, err := s.credentialsManager.GetGenericCredential(req.CredentialID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load source credential: %w", err)
+		}
+		return &source.Auth{
+			Username: cred.Data["username"],
+			Token:    cred.Data["token"],
+		}, nil
 	}
-	cred, err := s.credentialsManager.GetGenericCredential(credentialID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load source credential: %w", err)
+	if req.Token != "" {
+		return &source.Auth{Username: req.Username, Token: req.Token}, nil
 	}
-	return &source.Auth{
-		Username: cred.Data["username"],
-		Token:    cred.Data["token"],
-	}, nil
+	return nil, nil
 }

--- a/internal/api/deployment_source.go
+++ b/internal/api/deployment_source.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/flatrun/agent/internal/docker"
+	"github.com/flatrun/agent/internal/source"
+)
+
+// deploymentSource is the create-deployment request field that points at code to
+// deploy from, instead of inline compose content. Type selects the provider
+// (e.g. "git"); Ref is the provider's locator (a repository URL for git).
+type deploymentSource struct {
+	Type         string `json:"type"`
+	Ref          string `json:"ref"`
+	Branch       string `json:"branch,omitempty"`
+	Subpath      string `json:"subpath,omitempty"`
+	CredentialID string `json:"credential_id,omitempty"`
+}
+
+// fetchedSource is a materialized source ready to become a deployment: the
+// directory holding its files, the compose file found inside it, and the compose
+// content read from it. cleanup removes the temporary fetch directory.
+type fetchedSource struct {
+	dir            string
+	composeName    string
+	composeContent string
+	cleanup        func()
+}
+
+// fetchDeploymentSource resolves the source's provider, fetches into a temporary
+// directory, and locates the compose file the deployment will run. The temporary
+// directory is the caller's to release through the returned cleanup once the
+// files have been copied into the deployment.
+func (s *Server) fetchDeploymentSource(ctx context.Context, req *deploymentSource) (*fetchedSource, error) {
+	provider, ok := s.sourceRegistry.Get(req.Type)
+	if !ok {
+		return nil, fmt.Errorf("unknown source type %q", req.Type)
+	}
+
+	auth, err := s.resolveSourceAuth(req.CredentialID)
+	if err != nil {
+		return nil, err
+	}
+
+	tmp, err := os.MkdirTemp("", "flatrun-source-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create fetch directory: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tmp) }
+
+	descriptor := source.Descriptor{
+		Type: req.Type,
+		Ref:  req.Ref,
+		Params: map[string]string{
+			"branch":  req.Branch,
+			"subpath": req.Subpath,
+		},
+		Auth: auth,
+	}
+
+	result, err := provider.Fetch(ctx, descriptor, filepath.Join(tmp, "src"), func(line string) {
+		log.Printf("[source:%s] %s", req.Type, line)
+	})
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+
+	composePath := docker.FindComposeFile(result.Dir)
+	if composePath == "" {
+		cleanup()
+		return nil, fmt.Errorf("no compose file found in source")
+	}
+
+	content, err := os.ReadFile(composePath)
+	if err != nil {
+		cleanup()
+		return nil, fmt.Errorf("failed to read compose file from source: %w", err)
+	}
+
+	return &fetchedSource{
+		dir:            result.Dir,
+		composeName:    filepath.Base(composePath),
+		composeContent: string(content),
+		cleanup:        cleanup,
+	}, nil
+}
+
+// resolveSourceAuth turns a stored credential id into provider auth. A missing id
+// means an anonymous fetch (a public repository).
+func (s *Server) resolveSourceAuth(credentialID string) (*source.Auth, error) {
+	if credentialID == "" {
+		return nil, nil
+	}
+	cred, err := s.credentialsManager.GetGenericCredential(credentialID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load source credential: %w", err)
+	}
+	return &source.Auth{
+		Username: cred.Data["username"],
+		Token:    cred.Data["token"],
+	}, nil
+}

--- a/internal/api/deployment_source_test.go
+++ b/internal/api/deployment_source_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/flatrun/agent/internal/source"
+)
+
+func gitRepoWithCompose(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"),
+		[]byte("services:\n  app:\n    image: nginx\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "-A")
+	run("commit", "-m", "init")
+	return dir
+}
+
+func TestFetchDeploymentSource_UnknownType(t *testing.T) {
+	s := &Server{sourceRegistry: source.NewRegistry(source.GitProvider{})}
+
+	_, err := s.fetchDeploymentSource(context.Background(), &deploymentSource{Type: "svn", Ref: "x"})
+	if err == nil {
+		t.Fatal("expected an error for an unknown source type")
+	}
+}
+
+func TestFetchDeploymentSource_Git(t *testing.T) {
+	repo := gitRepoWithCompose(t)
+	s := &Server{sourceRegistry: source.NewRegistry(source.GitProvider{})}
+
+	fetched, err := s.fetchDeploymentSource(context.Background(), &deploymentSource{
+		Type:   "git",
+		Ref:    "file://" + repo,
+		Branch: "main",
+	})
+	if err != nil {
+		t.Fatalf("fetchDeploymentSource failed: %v", err)
+	}
+	defer fetched.cleanup()
+
+	if fetched.composeName != "docker-compose.yml" {
+		t.Errorf("composeName = %q, want docker-compose.yml", fetched.composeName)
+	}
+	if fetched.composeContent == "" {
+		t.Error("expected compose content to be read from the source")
+	}
+}
+
+func TestFetchDeploymentSource_NoCompose(t *testing.T) {
+	// A repo with no compose file must be rejected, not deployed empty.
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	run("init", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "-A")
+	run("commit", "-m", "init")
+
+	s := &Server{sourceRegistry: source.NewRegistry(source.GitProvider{})}
+	_, err := s.fetchDeploymentSource(context.Background(), &deploymentSource{
+		Type: "git", Ref: "file://" + dir, Branch: "main",
+	})
+	if err == nil {
+		t.Fatal("expected an error when the source has no compose file")
+	}
+}

--- a/internal/api/deployment_source_test.go
+++ b/internal/api/deployment_source_test.go
@@ -35,6 +35,22 @@ func gitRepoWithCompose(t *testing.T) string {
 	return dir
 }
 
+func TestResolveSourceAuth(t *testing.T) {
+	s := &Server{}
+
+	if auth, err := s.resolveSourceAuth(&deploymentSource{}); err != nil || auth != nil {
+		t.Errorf("no credential should mean anonymous: auth=%v err=%v", auth, err)
+	}
+
+	auth, err := s.resolveSourceAuth(&deploymentSource{Username: "me", Token: "secret"})
+	if err != nil {
+		t.Fatalf("inline token: %v", err)
+	}
+	if auth == nil || auth.Token != "secret" || auth.Username != "me" {
+		t.Errorf("inline token not resolved: %+v", auth)
+	}
+}
+
 func TestFetchDeploymentSource_UnknownType(t *testing.T) {
 	s := &Server{sourceRegistry: source.NewRegistry(source.GitProvider{})}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -46,6 +46,7 @@ import (
 	"github.com/flatrun/agent/internal/scheduler"
 	"github.com/flatrun/agent/internal/security"
 	"github.com/flatrun/agent/internal/setup"
+	"github.com/flatrun/agent/internal/source"
 	"github.com/flatrun/agent/internal/ssl"
 	"github.com/flatrun/agent/internal/system"
 	"github.com/flatrun/agent/internal/traffic"
@@ -86,6 +87,7 @@ type Server struct {
 	databaseManager    *database.Manager
 	infraManager       *infra.Manager
 	credentialsManager *credentials.Manager
+	sourceRegistry     *source.Registry
 	securityManager    *security.Manager
 	trafficManager     *traffic.Manager
 	dashboards         *dashboards.Store
@@ -332,6 +334,7 @@ func New(cfg *config.Config, configPath string) *Server {
 		databaseManager:    databaseManager,
 		infraManager:       infraManager,
 		credentialsManager: credentialsManager,
+		sourceRegistry:     source.NewRegistry(source.GitProvider{}),
 		securityManager:    securityManager,
 		trafficManager:     trafficManager,
 		dashboards:         dashboards.NewStore(cfg.DeploymentsPath),
@@ -1030,6 +1033,10 @@ func (s *Server) createDeployment(c *gin.Context) {
 		// image when the host side is empty. A template's own seed mounts are
 		// added to these.
 		SeedMounts []string `json:"seed_mounts,omitempty"`
+		// Source deploys from fetched code (a git URL today) instead of inline
+		// compose content: the fetched tree becomes the deployment directory and
+		// its compose file is what runs.
+		Source *deploymentSource `json:"source,omitempty"`
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -1037,6 +1044,20 @@ func (s *Server) createDeployment(c *gin.Context) {
 			"error": err.Error(),
 		})
 		return
+	}
+
+	var fetched *fetchedSource
+	if req.Source != nil {
+		f, err := s.fetchDeploymentSource(c.Request.Context(), req.Source)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "Failed to fetch source: " + err.Error(),
+			})
+			return
+		}
+		defer f.cleanup()
+		fetched = f
+		req.ComposeContent = f.composeContent
 	}
 
 	if req.ComposeContent == "" {
@@ -1097,9 +1118,15 @@ func (s *Server) createDeployment(c *gin.Context) {
 		req.ComposeContent = s.addContainerNetwork(req.ComposeContent, req.ExistingDatabaseContainer)
 	}
 
-	if err := s.manager.CreateDeployment(req.Name, req.ComposeContent, nil); err != nil {
+	var createErr error
+	if fetched != nil {
+		createErr = s.manager.CreateDeploymentFromSource(req.Name, fetched.dir, req.ComposeContent, fetched.composeName)
+	} else {
+		createErr = s.manager.CreateDeployment(req.Name, req.ComposeContent, nil)
+	}
+	if createErr != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
-			"error": err.Error(),
+			"error": createErr.Error(),
 		})
 		return
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -666,6 +666,10 @@ func (s *Server) setupRoutes() {
 			protected.DELETE("/credentials/:id", s.authMiddleware.RequirePermission(auth.PermRegistriesDelete), s.deleteCredential)
 			protected.POST("/credentials/:id/test", s.authMiddleware.RequirePermission(auth.PermRegistriesRead), s.testCredential)
 
+			protected.GET("/source-credentials", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.listSourceCredentials)
+			protected.POST("/source-credentials", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.createSourceCredential)
+			protected.DELETE("/source-credentials/:id", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.deleteSourceCredential)
+
 			// Storage credential endpoints (S3 and other object-storage secrets)
 			protected.GET("/storage-credentials", s.authMiddleware.RequirePermission(auth.PermBackupsRead), s.listStorageCredentials)
 			protected.POST("/storage-credentials", s.authMiddleware.RequirePermission(auth.PermBackupsWrite), s.createStorageCredential)

--- a/internal/api/source_credential_handlers.go
+++ b/internal/api/source_credential_handlers.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/flatrun/agent/pkg/models"
+	"github.com/gin-gonic/gin"
+)
+
+// listSourceCredentials returns the saved credentials for reaching a private
+// source (git today), so a deployment can reuse a stored token instead of the
+// operator pasting one each time. Tokens are masked in the response.
+func (s *Server) listSourceCredentials(c *gin.Context) {
+	creds := s.credentialsManager.ListGenericCredentials(models.CredentialKindGit)
+	c.JSON(http.StatusOK, gin.H{"credentials": creds})
+}
+
+func (s *Server) createSourceCredential(c *gin.Context) {
+	var req struct {
+		Name     string `json:"name" binding:"required"`
+		Username string `json:"username"`
+		Token    string `json:"token" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	data := map[string]string{"token": req.Token}
+	if req.Username != "" {
+		data["username"] = req.Username
+	}
+
+	cred, err := s.credentialsManager.CreateGenericCredential(req.Name, models.CredentialKindGit, data)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{"message": "Credential created", "credential": cred})
+}
+
+func (s *Server) deleteSourceCredential(c *gin.Context) {
+	id := c.Param("id")
+	if err := s.credentialsManager.DeleteGenericCredential(id); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "Credential deleted", "id": id})
+}

--- a/internal/api/source_credential_handlers_test.go
+++ b/internal/api/source_credential_handlers_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/flatrun/agent/internal/credentials"
+	"github.com/gin-gonic/gin"
+)
+
+func TestSourceCredentials_CreateThenList(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	s := &Server{credentialsManager: credentials.NewManager(t.TempDir())}
+	router := gin.New()
+	router.GET("/source-credentials", s.listSourceCredentials)
+	router.POST("/source-credentials", s.createSourceCredential)
+
+	body, _ := json.Marshal(map[string]string{"name": "gh", "token": "secret-pat"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/source-credentials", bytes.NewReader(body)))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: got %d: %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/source-credentials", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Credentials []struct {
+			Name string            `json:"name"`
+			Data map[string]string `json:"data"`
+		} `json:"credentials"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Credentials) != 1 || resp.Credentials[0].Name != "gh" {
+		t.Fatalf("expected one credential named gh, got %+v", resp.Credentials)
+	}
+	// The token must be masked in the listing, never returned in the clear.
+	if resp.Credentials[0].Data["token"] == "secret-pat" {
+		t.Error("token was returned unmasked in the listing")
+	}
+}
+
+func TestCreateSourceCredential_RequiresToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	s := &Server{credentialsManager: credentials.NewManager(t.TempDir())}
+	router := gin.New()
+	router.POST("/source-credentials", s.createSourceCredential)
+
+	body, _ := json.Marshal(map[string]string{"name": "gh"})
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/source-credentials", bytes.NewReader(body)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for a credential with no token, got %d", w.Code)
+	}
+}

--- a/internal/credentials/generic.go
+++ b/internal/credentials/generic.go
@@ -14,7 +14,8 @@ type genericCredentialsFile struct {
 }
 
 var knownCredentialKinds = map[models.CredentialKind]bool{
-	models.CredentialKindS3: true,
+	models.CredentialKindS3:  true,
+	models.CredentialKindGit: true,
 }
 
 func (m *Manager) loadGenericCredentials() error {

--- a/internal/docker/discovery.go
+++ b/internal/docker/discovery.go
@@ -268,6 +268,62 @@ func (d *Discovery) CreateDeployment(name string, composeContent string, fileMou
 	return os.WriteFile(composePath, []byte(composeContent), 0644)
 }
 
+// CreateDeploymentFromSource creates a deployment whose files come from a fetched
+// source tree rather than a single compose string. The whole tree is copied into
+// the deployment directory (so code, not just compose, is preserved), then the
+// transformed compose content is written back over the source's own compose file
+// under composeName, keeping the source's layout. Bind mount directories are
+// created as for a plain compose deployment.
+func (d *Discovery) CreateDeploymentFromSource(name, srcDir, composeContent, composeName string) error {
+	dirPath := filepath.Join(d.basePath, name)
+
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		return err
+	}
+
+	if err := copyTree(srcDir, dirPath); err != nil {
+		return fmt.Errorf("failed to copy source into deployment: %w", err)
+	}
+
+	composeContent = d.ensureComposeName(name, composeContent)
+
+	if err := d.createBindMountDirs(dirPath, composeContent, nil); err != nil {
+		return fmt.Errorf("failed to create mount directories: %w", err)
+	}
+
+	if composeName == "" {
+		composeName = "docker-compose.yml"
+	}
+	composePath := filepath.Join(dirPath, filepath.Base(composeName))
+	return os.WriteFile(composePath, []byte(composeContent), 0644)
+}
+
+// copyTree recursively copies the contents of src into dst, creating dst
+// subdirectories as needed. File modes are preserved.
+func copyTree(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, info.Mode().Perm()|0700)
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode().Perm())
+	})
+}
+
 // createBindMountDirs parses compose content and creates bind mount directories
 // with world-writable permissions to support non-root containers (e.g., Bitnami).
 // fileMounts lists relative paths (e.g., "./nginx.conf") that are file mounts

--- a/internal/docker/discovery_test.go
+++ b/internal/docker/discovery_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/flatrun/agent/pkg/models"
@@ -647,6 +648,46 @@ func TestUpdateComposeFile_SyncsMetadata(t *testing.T) {
 	}
 	if !updated.Networking.Expose {
 		t.Error("Expose should be preserved as true")
+	}
+}
+
+func TestCreateDeploymentFromSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	d := NewDiscovery(tmpDir)
+
+	// A fetched source tree: a compose file plus application code.
+	srcDir := filepath.Join(t.TempDir(), "src")
+	if err := os.MkdirAll(filepath.Join(srcDir, "app"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	for rel, content := range map[string]string{
+		"docker-compose.yml": "services:\n  app:\n    image: nginx\n",
+		"app/index.html":     "<h1>hi</h1>",
+	} {
+		if err := os.WriteFile(filepath.Join(srcDir, rel), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	transformed := "services:\n  app:\n    image: nginx\n    container_name: myapp-app\n"
+	if err := d.CreateDeploymentFromSource("myapp", srcDir, transformed, "docker-compose.yml"); err != nil {
+		t.Fatalf("CreateDeploymentFromSource failed: %v", err)
+	}
+
+	deployDir := filepath.Join(tmpDir, "myapp")
+
+	// The application code comes across.
+	if _, err := os.Stat(filepath.Join(deployDir, "app", "index.html")); err != nil {
+		t.Errorf("source code was not copied into the deployment: %v", err)
+	}
+
+	// The compose file holds the transformed content, not the source's original.
+	got, err := os.ReadFile(filepath.Join(deployDir, "docker-compose.yml"))
+	if err != nil {
+		t.Fatalf("compose file missing: %v", err)
+	}
+	if !strings.Contains(string(got), "container_name: myapp-app") {
+		t.Errorf("compose file does not hold the transformed content:\n%s", got)
 	}
 }
 

--- a/internal/docker/manager.go
+++ b/internal/docker/manager.go
@@ -356,6 +356,13 @@ func (m *Manager) CreateDeployment(name string, composeContent string, fileMount
 	return m.discovery.CreateDeployment(name, composeContent, fileMounts)
 }
 
+func (m *Manager) CreateDeploymentFromSource(name, srcDir, composeContent, composeName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.discovery.CreateDeploymentFromSource(name, srcDir, composeContent, composeName)
+}
+
 func (m *Manager) ApplyMountOwnership(name string, mounts []MountOwnership) error {
 	deploymentPath := filepath.Join(m.basePath, name)
 	return m.discovery.ApplyMountOwnership(deploymentPath, mounts)

--- a/internal/source/git.go
+++ b/internal/source/git.go
@@ -1,0 +1,123 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// GitProvider fetches a source by shallow-cloning a git repository. It shells out
+// to the git binary rather than embedding a git implementation, matching how the
+// agent already drives docker and nftables.
+type GitProvider struct{}
+
+func (GitProvider) Type() string { return "git" }
+
+// Fetch shallow-clones d.Ref into destDir. A branch and a subpath within the
+// repository are honoured through d.Params. Private repositories authenticate
+// with d.Auth, injected into the clone URL. The .git directory is removed so the
+// deployment stays a plain directory of files with no VCS metadata.
+func (GitProvider) Fetch(ctx context.Context, d Descriptor, destDir string, log func(string)) (*Result, error) {
+	if strings.TrimSpace(d.Ref) == "" {
+		return nil, fmt.Errorf("git source requires a repository URL")
+	}
+
+	cloneURL, err := authenticatedURL(d.Ref, d.Auth)
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{"clone", "--depth", "1"}
+	if branch := d.Params["branch"]; branch != "" {
+		args = append(args, "--branch", branch)
+	}
+	args = append(args, cloneURL, destDir)
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	// Never block on an interactive credential or host-key prompt: a private
+	// repo with no or wrong auth must fail fast, not hang the request.
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	out, runErr := cmd.CombinedOutput()
+	if log != nil {
+		if line := strings.TrimSpace(scrub(string(out), d.Auth)); line != "" {
+			log(line)
+		}
+	}
+	if runErr != nil {
+		return nil, fmt.Errorf("git clone failed: %s", scrub(strings.TrimSpace(string(out)), d.Auth))
+	}
+
+	revision := gitRevision(ctx, destDir)
+	_ = os.RemoveAll(filepath.Join(destDir, ".git"))
+
+	contentDir, err := resolveSubpath(destDir, d.Params["subpath"])
+	if err != nil {
+		return nil, err
+	}
+	if info, err := os.Stat(contentDir); err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("subpath %q not found in repository", d.Params["subpath"])
+	}
+
+	return &Result{Dir: contentDir, Revision: revision}, nil
+}
+
+// authenticatedURL injects auth into an https clone URL. It leaves ssh and other
+// schemes untouched, since those authenticate out of band (an agent key), and it
+// leaves the URL alone when no token is supplied.
+func authenticatedURL(raw string, auth *Auth) (string, error) {
+	if auth == nil || auth.Token == "" {
+		return raw, nil
+	}
+	// Only http(s) URLs carry credentials in the URL. ssh and scp-style remotes
+	// (git@host:path) authenticate out of band and do not even parse as URLs.
+	if !strings.HasPrefix(raw, "https://") && !strings.HasPrefix(raw, "http://") {
+		return raw, nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid repository URL: %w", err)
+	}
+	username := auth.Username
+	if username == "" {
+		// A bare token authenticates as the user it belongs to; git only needs a
+		// non-empty username alongside it, and this value is conventional.
+		username = "oauth2"
+	}
+	u.User = url.UserPassword(username, auth.Token)
+	return u.String(), nil
+}
+
+// resolveSubpath returns the directory for an optional in-repo subpath, rejecting
+// any path that would escape the clone.
+func resolveSubpath(root, subpath string) (string, error) {
+	if subpath == "" {
+		return root, nil
+	}
+	target := filepath.Join(root, subpath)
+	rel, err := filepath.Rel(root, target)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("subpath %q escapes the repository", subpath)
+	}
+	return target, nil
+}
+
+func gitRevision(ctx context.Context, dir string) string {
+	out, err := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// scrub removes the auth token from text before it is logged or returned, so a
+// clone URL echoed in git output never carries the secret onward.
+func scrub(text string, auth *Auth) string {
+	if auth != nil && auth.Token != "" {
+		text = strings.ReplaceAll(text, auth.Token, "***")
+	}
+	return text
+}

--- a/internal/source/git_test.go
+++ b/internal/source/git_test.go
@@ -1,0 +1,137 @@
+package source
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// makeRepo creates a local git repository with the given files (relative path ->
+// content) and returns its path. Tests clone from it over file:// so no network
+// is involved.
+func makeRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	run("init", "-b", "main")
+	for rel, content := range files {
+		p := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	run("add", "-A")
+	run("commit", "-m", "init")
+	return dir
+}
+
+func TestGitProvider_FetchLocalRepo(t *testing.T) {
+	repo := makeRepo(t, map[string]string{
+		"docker-compose.yml": "services:\n  app:\n    image: nginx\n",
+		"README.md":          "hello",
+	})
+
+	dest := filepath.Join(t.TempDir(), "src")
+	res, err := GitProvider{}.Fetch(context.Background(),
+		Descriptor{Type: "git", Ref: "file://" + repo, Params: map[string]string{"branch": "main"}},
+		dest, nil)
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(res.Dir, "docker-compose.yml")); err != nil {
+		t.Errorf("compose file missing from fetched source: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(res.Dir, "README.md")); err != nil {
+		t.Errorf("source file missing from fetched source: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(res.Dir, ".git")); !os.IsNotExist(err) {
+		t.Error(".git should be stripped from the fetched source")
+	}
+	if res.Revision == "" {
+		t.Error("expected a resolved revision")
+	}
+}
+
+func TestGitProvider_Subpath(t *testing.T) {
+	repo := makeRepo(t, map[string]string{
+		"deploy/docker-compose.yml": "services:\n  app:\n    image: nginx\n",
+		"src/main.go":               "package main",
+	})
+
+	dest := filepath.Join(t.TempDir(), "src")
+	res, err := GitProvider{}.Fetch(context.Background(),
+		Descriptor{Type: "git", Ref: "file://" + repo, Params: map[string]string{"subpath": "deploy"}},
+		dest, nil)
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(res.Dir, "docker-compose.yml")); err != nil {
+		t.Errorf("compose file missing under subpath: %v", err)
+	}
+}
+
+func TestGitProvider_MissingURL(t *testing.T) {
+	_, err := GitProvider{}.Fetch(context.Background(), Descriptor{Type: "git"}, t.TempDir(), nil)
+	if err == nil {
+		t.Fatal("expected an error for a git source with no URL")
+	}
+}
+
+func TestAuthenticatedURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		auth *Auth
+		want string
+	}{
+		{"no auth leaves url alone", "https://github.com/o/r.git", nil, "https://github.com/o/r.git"},
+		{"empty token leaves url alone", "https://github.com/o/r.git", &Auth{}, "https://github.com/o/r.git"},
+		{"token injected as userinfo", "https://github.com/o/r.git", &Auth{Token: "secret"}, "https://oauth2:secret@github.com/o/r.git"},
+		{"username honoured", "https://github.com/o/r.git", &Auth{Username: "me", Token: "secret"}, "https://me:secret@github.com/o/r.git"},
+		{"ssh untouched", "git@github.com:o/r.git", &Auth{Token: "secret"}, "git@github.com:o/r.git"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := authenticatedURL(tt.raw, tt.auth)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("authenticatedURL(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveSubpath_RejectsEscape(t *testing.T) {
+	root := t.TempDir()
+	if _, err := resolveSubpath(root, "../../etc"); err == nil {
+		t.Fatal("expected an escaping subpath to be rejected")
+	}
+}
+
+func TestScrubRemovesToken(t *testing.T) {
+	got := scrub("cloning https://oauth2:secret@github.com/o/r.git", &Auth{Token: "secret"})
+	if got == "cloning https://oauth2:secret@github.com/o/r.git" {
+		t.Fatal("token was not scrubbed")
+	}
+}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -1,0 +1,71 @@
+// Package source fetches the code that becomes a deployment from wherever it
+// lives. A deployment used to require compose content in hand; a Provider turns
+// a Descriptor (a git URL, an upload token, a webhook delivery) into a directory
+// on disk. Providers register behind one interface so a new source is an added
+// registration, not a change to the deploy flow, and no single source (git today)
+// is special.
+package source
+
+import "context"
+
+// Descriptor names a source and how to reach it. Params carries provider-specific
+// options (branch, subpath, ...). Auth is resolved by the caller from the
+// credential manager, so a provider never sees a raw credential id and the
+// package stays free of any credential-store dependency.
+type Descriptor struct {
+	Type   string
+	Ref    string
+	Params map[string]string
+	Auth   *Auth
+}
+
+// Auth is credential material a provider needs to reach a private source.
+type Auth struct {
+	Username string
+	Token    string
+}
+
+// Result reports where the fetched source landed and which revision it was, so
+// the caller can find the compose file and record provenance.
+type Result struct {
+	Dir      string
+	Revision string
+}
+
+// Provider fetches a source into destDir. log, when non-nil, receives progress
+// lines (a provider must not send secrets through it). destDir is the provider's
+// to populate; the caller owns creating and cleaning up its parent.
+type Provider interface {
+	Type() string
+	Fetch(ctx context.Context, d Descriptor, destDir string, log func(string)) (*Result, error)
+}
+
+// Registry resolves a source type to its provider.
+type Registry struct {
+	providers map[string]Provider
+}
+
+// NewRegistry indexes the providers by their Type(). A later registration for
+// the same type wins, which keeps the call site a plain list.
+func NewRegistry(providers ...Provider) *Registry {
+	r := &Registry{providers: make(map[string]Provider, len(providers))}
+	for _, p := range providers {
+		r.providers[p.Type()] = p
+	}
+	return r
+}
+
+// Get returns the provider for a source type, or false when none is registered.
+func (r *Registry) Get(typ string) (Provider, bool) {
+	p, ok := r.providers[typ]
+	return p, ok
+}
+
+// Types lists the registered source types.
+func (r *Registry) Types() []string {
+	types := make([]string, 0, len(r.providers))
+	for t := range r.providers {
+		types = append(types, t)
+	}
+	return types
+}

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -1,0 +1,27 @@
+package source
+
+import (
+	"context"
+	"testing"
+)
+
+type stubProvider struct{ typ string }
+
+func (s stubProvider) Type() string { return s.typ }
+func (s stubProvider) Fetch(context.Context, Descriptor, string, func(string)) (*Result, error) {
+	return &Result{}, nil
+}
+
+func TestRegistry(t *testing.T) {
+	r := NewRegistry(stubProvider{"git"}, stubProvider{"upload"})
+
+	if _, ok := r.Get("git"); !ok {
+		t.Error("expected git provider to be registered")
+	}
+	if _, ok := r.Get("nope"); ok {
+		t.Error("unregistered type should not resolve")
+	}
+	if len(r.Types()) != 2 {
+		t.Errorf("Types() = %v, want 2 entries", r.Types())
+	}
+}

--- a/pkg/models/credential.go
+++ b/pkg/models/credential.go
@@ -8,7 +8,8 @@ import (
 type CredentialKind string
 
 const (
-	CredentialKindS3 CredentialKind = "s3"
+	CredentialKindS3  CredentialKind = "s3"
+	CredentialKindGit CredentialKind = "git"
 )
 
 // Credential is a generic, kind-tagged secret held by the credential manager,
@@ -32,7 +33,8 @@ const CredentialMask = "********"
 // credentialSecretKeys lists the Data keys whose values must never leave the
 // agent in a JSON response, per credential kind.
 var credentialSecretKeys = map[CredentialKind]map[string]bool{
-	CredentialKindS3: {"secret_access_key": true},
+	CredentialKindS3:  {"secret_access_key": true},
+	CredentialKindGit: {"token": true},
 }
 
 // IsSecretKey reports whether a Data key holds a secret for the given kind.


### PR DESCRIPTION
A deployment used to require compose content in hand: pasted, generated from an
image, or taken from a template. This adds deploying from fetched code, starting
with a git repository (part of the Albacore Integrations item, #158).

The fetch sits behind a small provider interface with a registry, so a source is
a registered implementation rather than a branch in the deploy flow, and no
single source is special. That is deliberate: git is the first provider, and
upload and webhook delivery are meant to register the same way, so the
abstraction leads rather than a git-shaped API. If GitHub stops being the way
code arrives, it is one provider to swap, not a rewrite.

A source is fetched into a temp directory and required to contain a compose file
before anything is created, so a bad or compose-less fetch leaves no half-made
deployment. The whole tree becomes the deployment directory, keeping code next
to compose, and the rest of create (networks, databases, env, metadata) is
untouched. Private repositories authenticate with a token from the credential
manager, injected into https clone URLs only and scrubbed from logs.

Deferred on purpose: live fetch-progress streaming (this path is synchronous),
and the "Deploy from source" UI, which is a separate flatrun/ui change. Upload
and webhook providers are the next phases behind the same interface.