### PR TITLE
feat: Albacore follow-ups — host metrics, agent scheduling, run history

### DIFF
--- a/internal/ai/agent.go
+++ b/internal/ai/agent.go
@@ -16,11 +16,18 @@ import (
 // shared tool set; the file is the whole definition, so it can be read,
 // edited, and versioned like any other deployment file.
 type Agent struct {
-	Name         string `json:"name" yaml:"-"`
-	Description  string `json:"description" yaml:"description"`
-	Scope        string `json:"scope" yaml:"scope"`
-	Deployment   string `json:"deployment,omitempty" yaml:"deployment"`
-	Instructions string `json:"-" yaml:"-"`
+	Name        string `json:"name" yaml:"-"`
+	Description string `json:"description" yaml:"description"`
+	Scope       string `json:"scope" yaml:"scope"`
+	Deployment  string `json:"deployment,omitempty" yaml:"deployment"`
+	// Schedule is an optional cron expression. When set, the agent runs on that
+	// schedule without a human present.
+	Schedule string `json:"schedule,omitempty" yaml:"schedule"`
+	// Permissions is the grant a scheduled (headless) run executes under: the
+	// runtime auto-approves tools these permissions cover and denies the rest.
+	// Empty means read-only, since a cron run has no human to approve a change.
+	Permissions  []string `json:"permissions,omitempty" yaml:"permissions"`
+	Instructions string   `json:"-" yaml:"-"`
 }
 
 var frontmatterPattern = regexp.MustCompile(`(?s)\A---\s*\n(.*?)\n---\s*\n?`)

--- a/internal/ai/agent_test.go
+++ b/internal/ai/agent_test.go
@@ -25,6 +25,28 @@ Check the logs directory and report anything unusual.`)
 	}
 }
 
+func TestParseAgentScheduleAndPermissions(t *testing.T) {
+	rt, err := ParseAgent("nightly", `---
+description: Nightly checkup
+scope: deployment
+deployment: myapp
+schedule: "0 3 * * *"
+permissions:
+  - deployments:read
+  - deployments:write
+---
+Restart the app if it is unhealthy.`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rt.Schedule != "0 3 * * *" {
+		t.Errorf("schedule = %q", rt.Schedule)
+	}
+	if len(rt.Permissions) != 2 || rt.Permissions[0] != "deployments:read" || rt.Permissions[1] != "deployments:write" {
+		t.Errorf("permissions = %v", rt.Permissions)
+	}
+}
+
 func TestParseAgentBareMarkdown(t *testing.T) {
 	rt, err := ParseAgent("hello", "Say hello to the operator.")
 	if err != nil {

--- a/internal/api/agent_handlers.go
+++ b/internal/api/agent_handlers.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/flatrun/agent/internal/ai"
@@ -55,7 +57,27 @@ func (s *Server) putAgent(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	s.syncAgentSchedule(agent)
 	c.JSON(http.StatusOK, gin.H{"agent": agent})
+}
+
+// syncAgentSchedule keeps the scheduler in step with an agent's file: a schedule
+// registers (or updates) a task, and no schedule removes any task the agent had.
+// A sync failure (e.g. an invalid cron) is logged, not fatal, so the definition
+// still saves.
+func (s *Server) syncAgentSchedule(agent *ai.Agent) {
+	if s.schedulerManager == nil {
+		return
+	}
+	if agent.Schedule == "" {
+		if err := s.schedulerManager.RemoveAgentTask(agent.Name); err != nil {
+			log.Printf("scheduler: failed to remove agent task for %s: %v", agent.Name, err)
+		}
+		return
+	}
+	if err := s.schedulerManager.SyncAgentTask(agent.Name, agent.Schedule, agent.Deployment); err != nil {
+		log.Printf("scheduler: failed to schedule agent %s (%q): %v", agent.Name, agent.Schedule, err)
+	}
 }
 
 // deleteAgent removes an agent definition.
@@ -67,6 +89,11 @@ func (s *Server) deleteAgent(c *gin.Context) {
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
+	}
+	if s.schedulerManager != nil {
+		if err := s.schedulerManager.RemoveAgentTask(c.Param("name")); err != nil {
+			log.Printf("scheduler: failed to remove agent task for %s: %v", c.Param("name"), err)
+		}
 	}
 	c.JSON(http.StatusOK, gin.H{"message": "Agent deleted", "name": c.Param("name")})
 }
@@ -107,4 +134,57 @@ func (s *Server) runAgent(c *gin.Context) {
 		return
 	}
 	s.sessionResponse(c, sess)
+}
+
+// runAgentHeadless runs an agent without a human present, for the scheduler. It
+// executes under an actor carrying only the agent's granted permissions, and
+// auto-approves tools: the grant, not a person, is the gate, so a tool the grant
+// does not cover fails inside the tool. A no-grant agent is read-only. The run is
+// saved as a session, which is what the agent's run history reads.
+func (s *Server) runAgentHeadless(ctx context.Context, agentName string) (string, error) {
+	if s.aiProvider == nil {
+		return "", fmt.Errorf("AI assistant is not enabled")
+	}
+	agent, err := s.aiAgents.Get(agentName)
+	if err != nil {
+		return "", err
+	}
+
+	actor := agentActor(agent)
+	gc := toolGinContext(ctx, actor)
+
+	prompt := ai.BuildSessionPrompt(agent.Scope, agent.Deployment, s.config.AI.DocsURL)
+	sess := ai.NewSession(agent.Scope, agent.Deployment, true, ai.SessionActor{ID: "agent:" + agent.Name, Name: agent.Name}, prompt)
+	sess.Agent = agent.Name
+	sess.AddUserMessage(s.redactSessionInput(sess, agent.Instructions), fmt.Sprintf("Scheduled run of %q", agent.Name), false)
+
+	if err := s.advanceSessionWith(gc, sess, true); err != nil {
+		return "", err
+	}
+	if err := s.aiSessions.Save(sess); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("agent %q run recorded as session %s (%s)", agent.Name, sess.ID, sess.Status), nil
+}
+
+// agentActor builds the actor a scheduled run executes under. The base is
+// read-only (viewer); the agent's declared permissions add whatever writes it is
+// trusted with, and a deployment-scoped agent is granted access to only its own
+// deployment, at the level its grant implies.
+func agentActor(agent *ai.Agent) *auth.ActorContext {
+	actor := &auth.ActorContext{
+		Type:        "agent",
+		Role:        auth.RoleViewer,
+		Permissions: append([]string(nil), agent.Permissions...),
+	}
+	if agent.Scope == ai.SessionScopeDeployment && agent.Deployment != "" {
+		level := auth.AccessLevelRead
+		for _, p := range agent.Permissions {
+			if p == string(auth.PermDeploymentsWrite) {
+				level = auth.AccessLevelWrite
+			}
+		}
+		actor.Deployments = map[string]string{agent.Deployment: level}
+	}
+	return actor
 }

--- a/internal/api/agent_handlers_test.go
+++ b/internal/api/agent_handlers_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/flatrun/agent/internal/ai"
+	"github.com/flatrun/agent/internal/auth"
 	"github.com/flatrun/agent/pkg/models"
 )
 
@@ -198,5 +200,79 @@ func TestRunAgentNotFound(t *testing.T) {
 	resp, _ := doJSON(t, http.MethodPost, ts.URL+"/api/ai/agents/ghost/run", nil)
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestAgentActor_NoGrantIsReadOnly(t *testing.T) {
+	actor := agentActor(&ai.Agent{Name: "a", Scope: ai.SessionScopeSystem})
+	if actor.Role == auth.RoleAdmin {
+		t.Fatal("a headless agent actor must never be admin")
+	}
+	if actor.HasPermission(auth.PermSettingsWrite) || actor.HasPermission(auth.PermDeploymentsWrite) {
+		t.Error("no grant must not allow any write permission")
+	}
+}
+
+func TestAgentActor_GrantAllowsOnlyWhatItLists(t *testing.T) {
+	actor := agentActor(&ai.Agent{Name: "a", Scope: ai.SessionScopeSystem,
+		Permissions: []string{string(auth.PermSettingsWrite)}})
+	if !actor.HasPermission(auth.PermSettingsWrite) {
+		t.Error("granted settings:write should be allowed")
+	}
+	if actor.HasPermission(auth.PermDeploymentsWrite) {
+		t.Error("an ungranted permission must stay denied")
+	}
+}
+
+func TestAgentActor_DeploymentScopeGrantsOnlyItsOwn(t *testing.T) {
+	write := agentActor(&ai.Agent{Name: "a", Scope: ai.SessionScopeDeployment, Deployment: "shop",
+		Permissions: []string{string(auth.PermDeploymentsWrite)}})
+	if !write.CanAccessDeployment("shop", auth.AccessLevelWrite) {
+		t.Error("a deployment write grant should allow writing its own deployment")
+	}
+	if write.CanAccessDeployment("other", auth.AccessLevelWrite) {
+		t.Error("the grant must not reach another deployment")
+	}
+	read := agentActor(&ai.Agent{Name: "a", Scope: ai.SessionScopeDeployment, Deployment: "shop"})
+	if read.CanAccessDeployment("shop", auth.AccessLevelWrite) {
+		t.Error("no grant must not allow writing the deployment")
+	}
+}
+
+func TestRunAgentHeadless_AutoApprovesWithinGrant(t *testing.T) {
+	s, tmpDir, _ := setupPlanTestServer(t)
+	s.aiAgents = ai.NewAgentStore(tmpDir)
+	createTestDeployment(t, tmpDir, "myapp", &models.ServiceMetadata{Name: "myapp"})
+	writeAgentFile(t, tmpDir, "fixer.md",
+		"---\nscope: deployment\ndeployment: myapp\nschedule: \"0 3 * * *\"\npermissions:\n  - deployments:write\n---\nWrite conf/app.conf.")
+	s.aiProvider = &scriptedProvider{responses: []*ai.Response{
+		{ToolCalls: []ai.ToolCall{{ID: "c1", Name: "write_deployment_file",
+			Arguments: `{"path":"conf/app.conf","content":"key = value\n"}`}}, Model: "scripted"},
+		{Content: "Done.", Model: "scripted"},
+	}}
+	if _, err := s.runAgentHeadless(context.Background(), "fixer"); err != nil {
+		t.Fatalf("headless run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "myapp", "conf", "app.conf")); err != nil {
+		t.Fatalf("a granted headless run should write the file without pausing: %v", err)
+	}
+}
+
+func TestRunAgentHeadless_FailsClosedWithoutGrant(t *testing.T) {
+	s, tmpDir, _ := setupPlanTestServer(t)
+	s.aiAgents = ai.NewAgentStore(tmpDir)
+	createTestDeployment(t, tmpDir, "myapp", &models.ServiceMetadata{Name: "myapp"})
+	writeAgentFile(t, tmpDir, "fixer.md",
+		"---\nscope: deployment\ndeployment: myapp\n---\nWrite conf/app.conf.")
+	s.aiProvider = &scriptedProvider{responses: []*ai.Response{
+		{ToolCalls: []ai.ToolCall{{ID: "c1", Name: "write_deployment_file",
+			Arguments: `{"path":"conf/app.conf","content":"key = value\n"}`}}, Model: "scripted"},
+		{Content: "Could not write.", Model: "scripted"},
+	}}
+	if _, err := s.runAgentHeadless(context.Background(), "fixer"); err != nil {
+		t.Fatalf("headless run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, "myapp", "conf", "app.conf")); !os.IsNotExist(err) {
+		t.Fatal("a headless run without the write grant must not write the file")
 	}
 }

--- a/internal/api/ai_session_handlers.go
+++ b/internal/api/ai_session_handlers.go
@@ -74,8 +74,15 @@ const aiStepLimitMessage = "I stopped after investigating several steps without 
 // runner: it calls the model, runs any requested tools (auto-run) or pauses for
 // approval, and repeats until a final answer or the step budget is spent.
 func (s *Server) advanceSession(c *gin.Context, sess *ai.Session) error {
+	return s.advanceSessionWith(c, sess, false)
+}
+
+// advanceSessionWith drives a session turn. autoApprove runs every requested
+// tool without pausing: it is for headless (scheduled) runs, where the actor's
+// permission grant, not a human, is the gate. Interactive turns pass false.
+func (s *Server) advanceSessionWith(c *gin.Context, sess *ai.Session, autoApprove bool) error {
 	engine := ai.NewCapturingEngine(s.aiProvider)
-	runner := s.aiRunner(c, sess, engine)
+	runner := s.aiRunner(c, sess, engine, autoApprove)
 	conv := &agents.Conversation{Messages: ai.MessagesToAgents(sess.Messages)}
 	from := len(conv.Messages)
 	_, err := runner.Advance(c.Request.Context(), conv)
@@ -86,7 +93,7 @@ func (s *Server) advanceSession(c *gin.Context, sess *ai.Session) error {
 // auto-run pauses before any tools run, surfacing them for per-call approval.
 // Even with auto-run on, a batch containing a state-changing tool pauses:
 // reads run free, writes always ask.
-func (s *Server) aiRunner(c *gin.Context, sess *ai.Session, engine agents.Engine) agents.Runner {
+func (s *Server) aiRunner(c *gin.Context, sess *ai.Session, engine agents.Engine, autoApprove bool) agents.Runner {
 	runner := agents.Runner{
 		Engine: engine,
 		Harness: agents.Harness{
@@ -97,6 +104,12 @@ func (s *Server) aiRunner(c *gin.Context, sess *ai.Session, engine agents.Engine
 		},
 	}
 	runner.Approve = func(_ context.Context, calls []agents.ToolCall) (bool, error) {
+		// A headless run has no human to ask: approve every call and let the
+		// actor's permission grant deny anything it does not cover, inside the
+		// tool. Interactive runs still pause before a state-changing tool.
+		if autoApprove {
+			return true, nil
+		}
 		if !sess.AutoRun {
 			return false, nil
 		}
@@ -282,7 +295,9 @@ func (s *Server) getAISession(c *gin.Context) {
 }
 
 // listAISessions returns the caller's saved sessions (all sessions for an admin),
-// most recent first, so past conversations can be resumed.
+// most recent first, so past conversations can be resumed. An optional agent
+// query parameter narrows the list to one agent's runs, which is how a run
+// history is read from an agent's definition.
 func (s *Server) listAISessions(c *gin.Context) {
 	summaries, err := s.aiSessions.List()
 	if err != nil {
@@ -292,11 +307,16 @@ func (s *Server) listAISessions(c *gin.Context) {
 	actor := auth.GetActorFromContext(c)
 	isAdmin := actor != nil && actor.Role == auth.RoleAdmin
 	mine := sessionActorFrom(c).ID
+	agentFilter := c.Query("agent")
 	out := make([]ai.SessionSummary, 0, len(summaries))
 	for _, sum := range summaries {
-		if isAdmin || sum.CreatedBy.ID == mine {
-			out = append(out, sum)
+		if !isAdmin && sum.CreatedBy.ID != mine {
+			continue
 		}
+		if agentFilter != "" && sum.Agent != agentFilter {
+			continue
+		}
+		out = append(out, sum)
 	}
 	c.JSON(http.StatusOK, gin.H{"sessions": out})
 }
@@ -370,7 +390,7 @@ func (s *Server) approveAISessionTools(c *gin.Context) {
 		decisions = map[string]bool{}
 	}
 	engine := ai.NewCapturingEngine(s.aiProvider)
-	runner := s.aiRunner(c, sess, engine)
+	runner := s.aiRunner(c, sess, engine, false)
 	conv := &agents.Conversation{Messages: ai.MessagesToAgents(sess.Messages)}
 	from := len(conv.Messages)
 	_, err := runner.Resume(c.Request.Context(), conv, decisions)

--- a/internal/api/ai_session_test.go
+++ b/internal/api/ai_session_test.go
@@ -482,3 +482,38 @@ func TestListAISessionsFiltersByActor(t *testing.T) {
 		t.Errorf("an admin should see all sessions, got %d", len(all))
 	}
 }
+
+func TestListAISessionsFiltersByAgent(t *testing.T) {
+	s, _, _ := setupPlanTestServer(t)
+
+	actor := ai.SessionActor{ID: "1", Name: "alice"}
+	run := ai.NewSession(ai.SessionScopeSystem, "", true, actor, "sys")
+	run.Agent = "nightly-audit"
+	run.AddUserMessage("run", "", false)
+	adhoc := ai.NewSession(ai.SessionScopeSystem, "", true, actor, "sys")
+	adhoc.AddUserMessage("chat", "", false)
+	if err := s.aiSessions.Save(run); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.aiSessions.Save(adhoc); err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/ai/sessions?agent=nightly-audit", nil)
+	c.Set(contextkeys.Actor, &auth.ActorContext{User: &auth.User{ID: 1, Username: "alice"}, Role: auth.RoleViewer})
+	s.listAISessions(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d", w.Code)
+	}
+	var body struct {
+		Sessions []map[string]any `json:"sessions"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Sessions) != 1 || body.Sessions[0]["id"] != run.ID {
+		t.Errorf("agent filter should return only that agent's runs, got %v", body.Sessions)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -371,6 +371,7 @@ func New(cfg *config.Config, configPath string) *Server {
 		}
 
 		executor := scheduler.NewExecutor(backupManager, manager)
+		executor.SetAgentRunner(s.runAgentHeadless)
 		schedulerManager, err := scheduler.NewManager(cfg.DeploymentsPath, executor)
 		if err != nil {
 			log.Printf("Warning: Failed to initialize scheduler manager: %v", err)

--- a/internal/observ/alerts.go
+++ b/internal/observ/alerts.go
@@ -62,7 +62,8 @@ func (r AlertRule) forDuration() time.Duration {
 
 func knownMetric(name string) bool {
 	switch name {
-	case MetricCPUUsage, MetricMemoryUsage, MetricMemoryLimit, MetricNetworkRx, MetricNetworkTx:
+	case MetricCPUUsage, MetricMemoryUsage, MetricMemoryLimit, MetricNetworkRx, MetricNetworkTx,
+		MetricHostCPU, MetricHostMemUtil, MetricHostMemUsage, MetricHostMemLimit, MetricHostDisk:
 		return true
 	}
 	return false
@@ -97,9 +98,10 @@ func (e AlertEvent) Message() string {
 
 func formatMetricValue(metric string, v float64) string {
 	switch metric {
-	case MetricCPUUsage:
+	case MetricCPUUsage, MetricHostCPU, MetricHostMemUtil, MetricHostDisk:
 		return fmt.Sprintf("%.1f%%", v)
-	case MetricMemoryUsage, MetricMemoryLimit, MetricNetworkRx, MetricNetworkTx:
+	case MetricMemoryUsage, MetricMemoryLimit, MetricNetworkRx, MetricNetworkTx,
+		MetricHostMemUsage, MetricHostMemLimit:
 		return formatBytes(v)
 	}
 	return fmt.Sprintf("%.2f", v)

--- a/internal/observ/api.go
+++ b/internal/observ/api.go
@@ -3,6 +3,7 @@ package observ
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -84,6 +85,22 @@ func HandlerWithAlerts(store *Store, history *MetricsDB, health healthReporter, 
 			}
 		}
 		writeJSON(w, TimeSeriesResponse{Deployment: deployment, Metrics: buildTimeSeries(chartsFrom(since), deployment, since)})
+	})
+	mux.HandleFunc("/metrics/host", func(w http.ResponseWriter, r *http.Request) {
+		since := time.Now().Add(-15 * time.Minute)
+		if v := r.URL.Query().Get("since"); v != "" {
+			if d, err := time.ParseDuration(v); err == nil {
+				since = time.Now().Add(-d)
+			}
+		}
+		all := buildTimeSeries(chartsFrom(since), "", since)
+		host := make(map[string]MetricSeries, len(all))
+		for metric, series := range all {
+			if strings.HasPrefix(metric, "system.") {
+				host[metric] = series
+			}
+		}
+		writeJSON(w, TimeSeriesResponse{Metrics: host})
 	})
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		if health == nil {

--- a/internal/observ/host_collector.go
+++ b/internal/observ/host_collector.go
@@ -1,0 +1,70 @@
+package observ
+
+import (
+	"context"
+	"time"
+
+	"github.com/flatrun/agent/internal/system"
+)
+
+// HostSource returns the current host-wide reading. Injectable so the collector
+// is testable without reading /proc.
+type HostSource func() (HostSample, error)
+
+// HostCollector periodically records a host reading into the store, giving the
+// system-wide metrics the same time-series treatment as per-container ones.
+type HostCollector struct {
+	store    *Store
+	source   HostSource
+	interval time.Duration
+	now      func() time.Time
+}
+
+func NewHostCollector(store *Store, source HostSource, interval time.Duration) *HostCollector {
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	return &HostCollector{store: store, source: source, interval: interval, now: time.Now}
+}
+
+func (c *HostCollector) collectOnce() error {
+	sample, err := c.source()
+	if err != nil {
+		return err
+	}
+	c.store.RecordHost(sample, c.now())
+	return nil
+}
+
+// Run collects on each tick until ctx is cancelled. A failing read is skipped,
+// not fatal, so a transient error does not stop host collection.
+func (c *HostCollector) Run(ctx context.Context) {
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+	_ = c.collectOnce()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			_ = c.collectOnce()
+		}
+	}
+}
+
+// SystemHostSource reads host CPU, memory and disk from the system package. Its
+// memory figure is working-set (total minus available), which is the number that
+// tells whether the machine is actually under memory pressure.
+func SystemHostSource() (HostSample, error) {
+	stats, err := system.GetSystemStats()
+	if err != nil {
+		return HostSample{}, err
+	}
+	return HostSample{
+		CPUPercent:    stats.CPU.UsagePercent,
+		MemoryUsage:   stats.Memory.Used,
+		MemoryLimit:   stats.Memory.Total,
+		MemoryPercent: stats.Memory.UsagePercent,
+		DiskPercent:   stats.Disk.UsagePercent,
+	}, nil
+}

--- a/internal/observ/host_test.go
+++ b/internal/observ/host_test.go
@@ -1,0 +1,50 @@
+package observ
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHostSeriesRecorded(t *testing.T) {
+	store := NewStore(10)
+	store.RecordHost(HostSample{CPUPercent: 12, MemoryPercent: 40, MemoryUsage: 400, MemoryLimit: 1000, DiskPercent: 55}, time.Now())
+
+	got := map[string]bool{}
+	for _, p := range store.Latest() {
+		if p.Container == HostContainer && p.Deployment == "" {
+			got[p.Metric] = true
+		}
+	}
+	for _, m := range []string{MetricHostCPU, MetricHostMemUtil, MetricHostMemUsage, MetricHostMemLimit, MetricHostDisk} {
+		if !got[m] {
+			t.Errorf("missing host metric %s", m)
+		}
+	}
+}
+
+func TestHostMetricsAreAlertable(t *testing.T) {
+	for _, m := range []string{MetricHostCPU, MetricHostMemUtil, MetricHostMemUsage, MetricHostMemLimit, MetricHostDisk} {
+		if !knownMetric(m) {
+			t.Errorf("host metric %s should be alertable", m)
+		}
+	}
+}
+
+func TestHostAlertFires(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	e, store, fired := engineAt(t, &now)
+	e.SetRules([]AlertRule{{
+		ID: "h1", Name: "Host memory high", Metric: MetricHostMemUtil,
+		Comparison: ComparisonAbove, Threshold: 90, ForSeconds: 0, Enabled: true,
+	}})
+
+	store.RecordHost(HostSample{MemoryPercent: 95, MemoryUsage: 950, MemoryLimit: 1000}, now)
+	e.evaluate()
+
+	if len(*fired) != 1 {
+		t.Fatalf("expected a host memory alert, got %+v", *fired)
+	}
+	if (*fired)[0].Metric != MetricHostMemUtil {
+		t.Errorf("wrong metric fired: %s", (*fired)[0].Metric)
+	}
+}

--- a/internal/observ/plugin.go
+++ b/internal/observ/plugin.go
@@ -116,6 +116,7 @@ func RunPlugin() error {
 	go engine.Run(alertStop, cfg.sampleInterval()*3)
 
 	go collector.Run(ctx)
+	go NewHostCollector(store, SystemHostSource, cfg.sampleInterval()).Run(ctx)
 	go watcher.Run(ctx)
 
 	applyConfig := func(c Config) {

--- a/internal/observ/store.go
+++ b/internal/observ/store.go
@@ -21,6 +21,22 @@ const (
 	MetricNetworkTx   = "container.network.io.tx"
 )
 
+// Host (system-wide) metric names, semconv system.* conventions. These answer
+// "is the machine in trouble", which per-container percentages against a
+// container's own limit cannot. Utilizations are percentages so an alert can
+// target them directly; usage/limit are bytes for charting.
+const (
+	MetricHostCPU      = "system.cpu.utilization"
+	MetricHostMemUtil  = "system.memory.utilization"
+	MetricHostMemUsage = "system.memory.usage"
+	MetricHostMemLimit = "system.memory.limit"
+	MetricHostDisk     = "system.disk.utilization"
+)
+
+// HostContainer is the reserved Container value for host series; their Deployment
+// is empty, so host series never collide with a real container.
+const HostContainer = "host"
+
 // Sample is a single metric reading at a point in time.
 type Sample struct {
 	Time  time.Time `json:"time"`
@@ -100,16 +116,41 @@ func (s *Store) add(key SeriesKey, sample Sample) {
 
 // Record expands a container reading into its semconv series and stores each at t.
 func (s *Store) Record(c ContainerSample, t time.Time) {
-	s.mu.Lock()
-	base := SeriesKey{Deployment: c.Deployment, Container: c.Container}
-	written := make([]LatestPoint, 0, 5)
-	for metric, value := range map[string]float64{
+	s.record(SeriesKey{Deployment: c.Deployment, Container: c.Container}, map[string]float64{
 		MetricCPUUsage:    c.CPUPercent,
 		MetricMemoryUsage: float64(c.MemoryUsage),
 		MetricMemoryLimit: float64(c.MemoryLimit),
 		MetricNetworkRx:   float64(c.NetworkRx),
 		MetricNetworkTx:   float64(c.NetworkTx),
-	} {
+	}, t)
+}
+
+// HostSample is a single host-wide reading.
+type HostSample struct {
+	CPUPercent    float64
+	MemoryUsage   uint64
+	MemoryLimit   uint64
+	MemoryPercent float64
+	DiskPercent   float64
+}
+
+// RecordHost stores a host reading under the reserved host series key.
+func (s *Store) RecordHost(h HostSample, t time.Time) {
+	s.record(SeriesKey{Container: HostContainer}, map[string]float64{
+		MetricHostCPU:      h.CPUPercent,
+		MetricHostMemUtil:  h.MemoryPercent,
+		MetricHostMemUsage: float64(h.MemoryUsage),
+		MetricHostMemLimit: float64(h.MemoryLimit),
+		MetricHostDisk:     h.DiskPercent,
+	}, t)
+}
+
+// record writes each metric of one series at t, then hands the batch to the sink
+// outside the lock so persistence never blocks readers of the live window.
+func (s *Store) record(base SeriesKey, metrics map[string]float64, t time.Time) {
+	s.mu.Lock()
+	written := make([]LatestPoint, 0, len(metrics))
+	for metric, value := range metrics {
 		key := base
 		key.Metric = metric
 		sample := Sample{Time: t, Value: value}
@@ -120,8 +161,6 @@ func (s *Store) Record(c ContainerSample, t time.Time) {
 	sink := s.sink
 	s.mu.Unlock()
 
-	// Outside the lock: persisting writes to disk, and readers of the live window should
-	// not wait on it.
 	if sink != nil {
 		sink(written)
 	}

--- a/internal/scheduler/executor.go
+++ b/internal/scheduler/executor.go
@@ -12,6 +12,9 @@ import (
 type Executor struct {
 	backupManager *backup.Manager
 	dockerManager *docker.Manager
+	// agentRunner runs a scheduled agent headless. It is injected by the API
+	// layer, which owns the AI runtime, so this package stays free of it.
+	agentRunner func(ctx context.Context, agentName string) (string, error)
 }
 
 func NewExecutor(backupManager *backup.Manager, dockerManager *docker.Manager) *Executor {
@@ -19,6 +22,19 @@ func NewExecutor(backupManager *backup.Manager, dockerManager *docker.Manager) *
 		backupManager: backupManager,
 		dockerManager: dockerManager,
 	}
+}
+
+// SetAgentRunner wires the headless agent runner. Until it is set, agent tasks
+// fail rather than run, so a scheduled agent never silently no-ops.
+func (e *Executor) SetAgentRunner(fn func(ctx context.Context, agentName string) (string, error)) {
+	e.agentRunner = fn
+}
+
+func (e *Executor) ExecuteAgent(ctx context.Context, config *AgentTaskConfig) (string, error) {
+	if e.agentRunner == nil {
+		return "", fmt.Errorf("agent runner not available")
+	}
+	return e.agentRunner(ctx, config.AgentName)
 }
 
 func (e *Executor) ExecuteBackup(ctx context.Context, deploymentName string, config *BackupTaskConfig) (string, error) {

--- a/internal/scheduler/executor_test.go
+++ b/internal/scheduler/executor_test.go
@@ -33,6 +33,27 @@ func createTestDeployment(t *testing.T, basePath, name, composeContent string) {
 	}
 }
 
+func TestExecuteAgent_UsesInjectedRunner(t *testing.T) {
+	executor := NewExecutor(nil, nil)
+
+	if _, err := executor.ExecuteAgent(context.Background(), &AgentTaskConfig{AgentName: "x"}); err == nil {
+		t.Fatal("expected an error when no agent runner is wired")
+	}
+
+	var ran string
+	executor.SetAgentRunner(func(_ context.Context, name string) (string, error) {
+		ran = name
+		return "ok", nil
+	})
+	out, err := executor.ExecuteAgent(context.Background(), &AgentTaskConfig{AgentName: "nightly"})
+	if err != nil {
+		t.Fatalf("ExecuteAgent: %v", err)
+	}
+	if ran != "nightly" || out != "ok" {
+		t.Errorf("runner not invoked as expected: ran=%q out=%q", ran, out)
+	}
+}
+
 func TestExecuteCommand_NilDockerManager(t *testing.T) {
 	executor := NewExecutor(nil, nil)
 	_, err := executor.ExecuteCommand(context.Background(), "test", &CommandTaskConfig{

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -13,6 +13,7 @@ import (
 type TaskExecutor interface {
 	ExecuteBackup(ctx context.Context, deploymentName string, config *BackupTaskConfig) (string, error)
 	ExecuteCommand(ctx context.Context, deploymentName string, config *CommandTaskConfig) (string, error)
+	ExecuteAgent(ctx context.Context, config *AgentTaskConfig) (string, error)
 }
 
 type Manager struct {
@@ -135,6 +136,12 @@ func (m *Manager) executeTask(task ScheduledTask) {
 		} else {
 			execErr = fmt.Errorf("command config is nil")
 		}
+	case TaskTypeAgent:
+		if task.Config.AgentConfig != nil {
+			output, execErr = m.executor.ExecuteAgent(ctx, task.Config.AgentConfig)
+		} else {
+			execErr = fmt.Errorf("agent config is nil")
+		}
 	default:
 		execErr = fmt.Errorf("unknown task type: %s", task.Type)
 	}
@@ -238,6 +245,62 @@ func (m *Manager) UpdateTask(id int64, req *UpdateTaskRequest) (*ScheduledTask, 
 
 func (m *Manager) DeleteTask(id int64) error {
 	return m.db.DeleteTask(id)
+}
+
+// findAgentTask returns the scheduled task backing an agent's schedule, or nil.
+// An agent maps to at most one task, keyed by its name in the agent config.
+func (m *Manager) findAgentTask(agentName string) (*ScheduledTask, error) {
+	tasks, err := m.db.GetAllTasks()
+	if err != nil {
+		return nil, err
+	}
+	for i := range tasks {
+		t := tasks[i]
+		if t.Type == TaskTypeAgent && t.Config.AgentConfig != nil && t.Config.AgentConfig.AgentName == agentName {
+			return &t, nil
+		}
+	}
+	return nil, nil
+}
+
+// SyncAgentTask makes the scheduler reflect an agent's schedule: it creates the
+// backing task, updates its cron when it changed, or does nothing when already
+// in sync. Called whenever an agent with a schedule is written.
+func (m *Manager) SyncAgentTask(agentName, cronExpr, deployment string) error {
+	if err := m.ValidateCronExpr(cronExpr); err != nil {
+		return err
+	}
+	existing, err := m.findAgentTask(agentName)
+	if err != nil {
+		return err
+	}
+	enabled := true
+	if existing != nil {
+		if existing.CronExpr == cronExpr && existing.Enabled {
+			return nil
+		}
+		_, err := m.UpdateTask(existing.ID, &UpdateTaskRequest{CronExpr: &cronExpr, Enabled: &enabled})
+		return err
+	}
+	_, err = m.CreateTask(&CreateTaskRequest{
+		Name:           "agent:" + agentName,
+		Type:           TaskTypeAgent,
+		DeploymentName: deployment,
+		CronExpr:       cronExpr,
+		Enabled:        enabled,
+		Config:         TaskConfig{AgentConfig: &AgentTaskConfig{AgentName: agentName}},
+	})
+	return err
+}
+
+// RemoveAgentTask drops an agent's scheduled task, if any. Called when an agent
+// loses its schedule or is deleted.
+func (m *Manager) RemoveAgentTask(agentName string) error {
+	existing, err := m.findAgentTask(agentName)
+	if err != nil || existing == nil {
+		return err
+	}
+	return m.db.DeleteTask(existing.ID)
 }
 
 func (m *Manager) GetTask(id int64) (*ScheduledTask, error) {

--- a/internal/scheduler/types.go
+++ b/internal/scheduler/types.go
@@ -9,6 +9,7 @@ type TaskType string
 const (
 	TaskTypeBackup  TaskType = "backup"
 	TaskTypeCommand TaskType = "command"
+	TaskTypeAgent   TaskType = "agent"
 )
 
 type TaskStatus string
@@ -39,6 +40,12 @@ type TaskConfig struct {
 	BackupConfig *BackupTaskConfig `json:"backup_config,omitempty"`
 	// For command tasks
 	CommandConfig *CommandTaskConfig `json:"command_config,omitempty"`
+	// For agent tasks
+	AgentConfig *AgentTaskConfig `json:"agent_config,omitempty"`
+}
+
+type AgentTaskConfig struct {
+	AgentName string `json:"agent_name"`
 }
 
 type BackupTaskConfig struct {


### PR DESCRIPTION
Follow-up fixes from using the Albacore observability and agents features.

- Observability at scale: host CPU, memory and disk are collected as time series
  and can be alerted on, using working-set memory so the number reflects real
  pressure. Per-container metrics are unchanged; the point is that a saturated
  machine now has a signal, where before there were only per-container
  percentages against each container's own limit.
- Scheduled agents: a schedule in an agent file did nothing, because nothing
  parsed it and the scheduler only knew backup and command tasks. An agent can
  now declare a cron schedule and a permission grant. It runs unattended under an
  actor carrying only those permissions, auto-approving the tools the grant
  covers and denying the rest; no grant means read-only. A scheduled run can
  never quietly do more than it was trusted to, and it fails closed.
- Run history: an agent's runs can be listed on their own, since each run is
  already a session tagged with its agent.