### PR TITLE
feat(observability): Make alerts diagnose, route, and optionally act

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -3198,14 +3198,15 @@ func (s *Server) emitNotification(c *gin.Context) {
 		return
 	}
 	var req struct {
-		Title   string `json:"title"`
-		Message string `json:"message"`
+		Title   string   `json:"title"`
+		Message string   `json:"message"`
+		Targets []string `json:"targets"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
 		return
 	}
-	_ = s.notify.Notify(req.Title, req.Message)
+	_ = s.notify.NotifyTargets(req.Title, req.Message, req.Targets)
 	c.JSON(http.StatusAccepted, gin.H{"status": "queued"})
 }
 

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -112,14 +112,30 @@ func (s *Service) Test(url string) error {
 // Notify delivers title + message to every enabled target. It returns the first delivery
 // error, if any, but attempts all targets.
 func (s *Service) Notify(title, message string) error {
+	return s.NotifyTargets(title, message, nil)
+}
+
+// NotifyTargets delivers to a chosen subset of targets by id. An empty list
+// means every enabled target, which is what plain Notify does.
+func (s *Service) NotifyTargets(title, message string, ids []string) error {
 	cfg := s.Load()
 	body := message
 	if title != "" {
 		body = title + "\n\n" + message
 	}
+	var only map[string]bool
+	if len(ids) > 0 {
+		only = make(map[string]bool, len(ids))
+		for _, id := range ids {
+			only[id] = true
+		}
+	}
 	var firstErr error
 	for _, t := range cfg.Targets {
 		if !t.Enabled || t.URL == "" {
+			continue
+		}
+		if only != nil && !only[t.ID] {
 			continue
 		}
 		if err := s.send(t.URL, body); err != nil && firstErr == nil {

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -74,6 +74,26 @@ func TestServiceRoundTripAndNotify(t *testing.T) {
 	}
 }
 
+func TestNotifyTargetsDeliversToSubset(t *testing.T) {
+	s := NewService(t.TempDir())
+	var sent []string
+	s.send = func(url, msg string) error { sent = append(sent, url); return nil }
+
+	if err := s.Save(Config{Targets: []Target{
+		{ID: "1", Name: "email", URL: "smtp://x", Enabled: true},
+		{ID: "2", Name: "webhook", URL: "generic+https://h", Enabled: true},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.NotifyTargets("Alert", "msg", []string{"2"}); err != nil {
+		t.Fatalf("NotifyTargets = %v", err)
+	}
+	if len(sent) != 1 || sent[0] != "generic+https://h" {
+		t.Fatalf("expected delivery only to target 2, got %v", sent)
+	}
+}
+
 func TestServiceTest(t *testing.T) {
 	s := NewService(t.TempDir())
 	called := ""

--- a/internal/observ/action.go
+++ b/internal/observ/action.go
@@ -1,0 +1,75 @@
+package observ
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// DeploymentRestartFunc restarts a deployment given its directory.
+type DeploymentRestartFunc func(dir string) error
+
+// DockerComposeRestart restarts every service of a deployment by running compose
+// in its directory. It restarts the deployment rather than a single container,
+// which is what an operator means by "restart it".
+func DockerComposeRestart(dir string) error {
+	cmd := exec.Command("docker", "compose", "restart")
+	cmd.Dir = dir
+	return cmd.Run()
+}
+
+// ActionRunner carries out a firing rule's action. It mirrors the health
+// watcher's guardrails so a metric alert cannot turn into a restart loop: only
+// FlatRun-managed deployments are touched, and a deployment is not restarted
+// again until the cooldown has passed.
+type ActionRunner struct {
+	restart  DeploymentRestartFunc
+	managed  func(deployment string) bool
+	cooldown time.Duration
+	dataDir  string
+	now      func() time.Time
+
+	mu   sync.Mutex
+	last map[string]time.Time
+}
+
+func NewActionRunner(restart DeploymentRestartFunc, managed func(string) bool, cooldown time.Duration, dataDir string) *ActionRunner {
+	if cooldown <= 0 {
+		cooldown = 5 * time.Minute
+	}
+	return &ActionRunner{
+		restart:  restart,
+		managed:  managed,
+		cooldown: cooldown,
+		dataDir:  dataDir,
+		now:      time.Now,
+		last:     map[string]time.Time{},
+	}
+}
+
+// Run executes the event's action and returns a short message describing what it
+// did, or "" when it did nothing (not a restart action, no deployment, not
+// managed, still cooling down, or the restart failed).
+func (a *ActionRunner) Run(ev AlertEvent) string {
+	if ev.Action != ActionRestart || ev.Deployment == "" {
+		return ""
+	}
+	if a.managed != nil && !a.managed(ev.Deployment) {
+		return ""
+	}
+
+	a.mu.Lock()
+	if last, ok := a.last[ev.Deployment]; ok && a.now().Sub(last) < a.cooldown {
+		a.mu.Unlock()
+		return ""
+	}
+	a.last[ev.Deployment] = a.now()
+	a.mu.Unlock()
+
+	if err := a.restart(filepath.Join(a.dataDir, ev.Deployment)); err != nil {
+		return ""
+	}
+	return fmt.Sprintf("Restarted %s after %s fired.", ev.Deployment, ev.RuleName)
+}

--- a/internal/observ/action_test.go
+++ b/internal/observ/action_test.go
@@ -1,0 +1,95 @@
+package observ
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTopConsumersRanksContainersExcludingHost(t *testing.T) {
+	latest := []LatestPoint{
+		{SeriesKey: SeriesKey{Deployment: "shop", Container: "web", Metric: MetricMemoryUsage}, Sample: Sample{Value: 300}},
+		{SeriesKey: SeriesKey{Deployment: "shop", Container: "db", Metric: MetricMemoryUsage}, Sample: Sample{Value: 900}},
+		{SeriesKey: SeriesKey{Container: HostContainer, Metric: MetricMemoryUsage}, Sample: Sample{Value: 9999}},
+		{SeriesKey: SeriesKey{Deployment: "blog", Container: "app", Metric: MetricCPUUsage}, Sample: Sample{Value: 50}},
+	}
+	top := topConsumers(latest, MetricMemoryUsage, 5)
+	if len(top) != 2 {
+		t.Fatalf("expected 2 container entries (host excluded), got %v", top)
+	}
+	if top[0].Container != "db" || top[1].Container != "web" {
+		t.Errorf("not sorted highest-first: %v", top)
+	}
+}
+
+func TestHostMemoryAlertSnapshotsContainers(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	e, store, fired := engineAt(t, &now)
+	e.SetRules([]AlertRule{{
+		ID: "h1", Name: "Host memory", Metric: MetricHostMemUtil,
+		Comparison: ComparisonAbove, Threshold: 90, Enabled: true,
+	}})
+	store.Record(ContainerSample{Deployment: "shop", Container: "db", MemoryUsage: 900}, now)
+	store.Record(ContainerSample{Deployment: "shop", Container: "web", MemoryUsage: 100}, now)
+	store.RecordHost(HostSample{MemoryPercent: 95}, now)
+
+	e.evaluate()
+	if len(*fired) != 1 {
+		t.Fatalf("expected a firing event, got %v", *fired)
+	}
+	ev := (*fired)[0]
+	if len(ev.Snapshot) == 0 || ev.Snapshot[0].Container != "db" {
+		t.Errorf("host memory alert should snapshot the top containers by memory: %v", ev.Snapshot)
+	}
+}
+
+func TestActionRunnerRestartsOnceThenCoolsDown(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	var restarted []string
+	runner := &ActionRunner{
+		restart:  func(dir string) error { restarted = append(restarted, dir); return nil },
+		managed:  func(d string) bool { return d == "shop" },
+		cooldown: time.Minute,
+		dataDir:  "/deploys",
+		now:      func() time.Time { return now },
+		last:     map[string]time.Time{},
+	}
+
+	ev := AlertEvent{State: AlertFiring, Action: ActionRestart, Deployment: "shop", RuleName: "mem"}
+	if msg := runner.Run(ev); msg == "" || len(restarted) != 1 {
+		t.Fatalf("first firing should restart: msg=%q restarted=%v", msg, restarted)
+	}
+	// Within the cooldown, a second firing does nothing.
+	if msg := runner.Run(ev); msg != "" || len(restarted) != 1 {
+		t.Errorf("a restart within the cooldown should be skipped: restarted=%v", restarted)
+	}
+	// After the cooldown, it restarts again.
+	now = now.Add(2 * time.Minute)
+	if msg := runner.Run(ev); msg == "" || len(restarted) != 2 {
+		t.Errorf("after cooldown it should restart again: restarted=%v", restarted)
+	}
+}
+
+func TestActionRunnerGuards(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	runner := &ActionRunner{
+		restart:  func(string) error { t.Fatal("must not restart"); return nil },
+		managed:  func(d string) bool { return d == "shop" },
+		cooldown: time.Minute,
+		now:      func() time.Time { return now },
+		last:     map[string]time.Time{},
+	}
+
+	// Not a restart action.
+	runner.Run(AlertEvent{State: AlertFiring, Action: ActionNone, Deployment: "shop"})
+	// Unmanaged deployment.
+	runner.Run(AlertEvent{State: AlertFiring, Action: ActionRestart, Deployment: "stray"})
+	// No deployment (a host alert).
+	runner.Run(AlertEvent{State: AlertFiring, Action: ActionRestart, Deployment: ""})
+}
+
+func TestAlertRuleRejectsUnknownAction(t *testing.T) {
+	err := AlertRule{Name: "x", Metric: MetricCPUUsage, Comparison: ComparisonAbove, Action: "nuke"}.Validate()
+	if err == nil {
+		t.Fatal("an unknown action should be rejected")
+	}
+}

--- a/internal/observ/alerts.go
+++ b/internal/observ/alerts.go
@@ -34,7 +34,19 @@ type AlertRule struct {
 	Threshold  float64 `json:"threshold" yaml:"threshold"`
 	ForSeconds int     `json:"for_seconds" yaml:"for_seconds"`
 	Enabled    bool    `json:"enabled" yaml:"enabled"`
+	// Targets are the notification target ids this rule delivers to. Empty means
+	// every configured target, which is the original behaviour.
+	Targets []string `json:"targets,omitempty" yaml:"targets,omitempty"`
+	// Action is an optional remediation taken when the rule fires. "" is notify
+	// only; ActionRestart restarts the offending deployment.
+	Action string `json:"action,omitempty" yaml:"action,omitempty"`
 }
+
+// Alert actions.
+const (
+	ActionNone    = ""
+	ActionRestart = "restart"
+)
 
 // Validate reports why a rule cannot be used, if it cannot.
 func (r AlertRule) Validate() error {
@@ -49,6 +61,9 @@ func (r AlertRule) Validate() error {
 	}
 	if r.ForSeconds < 0 {
 		return fmt.Errorf("for_seconds cannot be negative")
+	}
+	if r.Action != ActionNone && r.Action != ActionRestart {
+		return fmt.Errorf("unknown action %q", r.Action)
 	}
 	return nil
 }
@@ -81,6 +96,54 @@ type AlertEvent struct {
 	Comparison string    `json:"comparison"`
 	State      string    `json:"state"`
 	At         time.Time `json:"at"`
+	// Targets and Action are copied from the rule so the event is self-contained
+	// for the notification and action sinks.
+	Targets []string `json:"targets,omitempty"`
+	Action  string   `json:"action,omitempty"`
+	// Snapshot is the top consuming containers at the moment a rule fired, so a
+	// notification and the dashboard can show what was using the resource.
+	Snapshot []Consumer `json:"snapshot,omitempty"`
+}
+
+// Consumer is one container's reading in a firing snapshot.
+type Consumer struct {
+	Deployment string  `json:"deployment"`
+	Container  string  `json:"container"`
+	Value      float64 `json:"value"`
+}
+
+// consumerMetric maps an alert metric to the per-container metric to rank by, so
+// a host or container memory alert both surface the containers using the most
+// memory, and likewise for CPU. Metrics with no useful ranking return "".
+func consumerMetric(alertMetric string) string {
+	switch {
+	case strings.Contains(alertMetric, "memory"):
+		return MetricMemoryUsage
+	case strings.Contains(alertMetric, "cpu"):
+		return MetricCPUUsage
+	}
+	return ""
+}
+
+// topConsumers ranks real containers by a metric, highest first, keeping at most
+// n. The host pseudo-container is excluded, since the point is to name the
+// containers responsible for the pressure.
+func topConsumers(latest []LatestPoint, metric string, n int) []Consumer {
+	if metric == "" {
+		return nil
+	}
+	var out []Consumer
+	for _, p := range latest {
+		if p.Metric != metric || p.Container == HostContainer {
+			continue
+		}
+		out = append(out, Consumer{Deployment: p.Deployment, Container: p.Container, Value: p.Value})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Value > out[j].Value })
+	if len(out) > n {
+		out = out[:n]
+	}
+	return out
 }
 
 // Message renders the event the way an operator reads it in a notification.
@@ -92,8 +155,17 @@ func (e AlertEvent) Message() string {
 	if e.State == AlertOK {
 		return fmt.Sprintf("%s is back to normal: %s is %s.", e.RuleName, where, formatMetricValue(e.Metric, e.Value))
 	}
-	return fmt.Sprintf("%s: %s is %s, %s %s.",
+	msg := fmt.Sprintf("%s: %s is %s, %s %s.",
 		e.RuleName, where, formatMetricValue(e.Metric, e.Value), e.Comparison, formatMetricValue(e.Metric, e.Threshold))
+	if len(e.Snapshot) > 0 {
+		metric := consumerMetric(e.Metric)
+		parts := make([]string, 0, len(e.Snapshot))
+		for _, c := range e.Snapshot {
+			parts = append(parts, fmt.Sprintf("%s (%s)", c.Container, formatMetricValue(metric, c.Value)))
+		}
+		msg += "\nTop: " + strings.Join(parts, ", ")
+	}
+	return msg
 }
 
 func formatMetricValue(metric string, v float64) string {
@@ -136,10 +208,11 @@ type AlertEngine struct {
 	now    func() time.Time
 	notify func(AlertEvent)
 
-	mu     sync.Mutex
-	rules  []AlertRule
-	states map[string]seriesState
-	events []AlertEvent
+	mu       sync.Mutex
+	rules    []AlertRule
+	states   map[string]seriesState
+	events   []AlertEvent
+	onAction func(AlertEvent)
 }
 
 // maxAlertEvents bounds retained history the same way recovery events are bounded.
@@ -158,6 +231,13 @@ func (e *AlertEngine) OnAlert(fn func(AlertEvent)) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.notify = fn
+}
+
+// OnAction registers the sink that carries out a firing rule's action.
+func (e *AlertEngine) OnAction(fn func(AlertEvent)) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.onAction = fn
 }
 
 // SetRules replaces the rule set, forgetting the state of rules that no longer exist.
@@ -264,6 +344,8 @@ func (e *AlertEngine) evaluate() {
 				Threshold:  rule.Threshold,
 				Comparison: rule.Comparison,
 				At:         now,
+				Targets:    rule.Targets,
+				Action:     rule.Action,
 			}
 
 			switch {
@@ -275,6 +357,7 @@ func (e *AlertEngine) evaluate() {
 					if now.Sub(prev.since) >= rule.forDuration() {
 						e.states[key] = seriesState{since: prev.since, state: AlertFiring}
 						ev.State = AlertFiring
+						ev.Snapshot = topConsumers(latest, consumerMetric(rule.Metric), 5)
 						fired = append(fired, ev)
 					}
 				default:
@@ -283,6 +366,7 @@ func (e *AlertEngine) evaluate() {
 					if rule.forDuration() == 0 {
 						e.states[key] = seriesState{since: now, state: AlertFiring}
 						ev.State = AlertFiring
+						ev.Snapshot = topConsumers(latest, consumerMetric(rule.Metric), 5)
 						fired = append(fired, ev)
 					} else {
 						e.states[key] = seriesState{since: now, state: AlertPending}
@@ -303,13 +387,19 @@ func (e *AlertEngine) evaluate() {
 	if len(e.events) > maxAlertEvents {
 		e.events = e.events[len(e.events)-maxAlertEvents:]
 	}
+	action := e.onAction
 	e.mu.Unlock()
 
 	// Outside the lock: a notification goes over the network and evaluation should not
 	// hold readers while it does.
-	if notify != nil {
-		for _, ev := range fired {
+	for _, ev := range fired {
+		if notify != nil {
 			notify(ev)
+		}
+		// An action runs only on a firing transition with an action set; the
+		// sink itself enforces cooldown and the managed-deployment guard.
+		if action != nil && ev.State == AlertFiring && ev.Action != ActionNone {
+			action(ev)
 		}
 	}
 }

--- a/internal/observ/plugin.go
+++ b/internal/observ/plugin.go
@@ -45,13 +45,14 @@ func RunPlugin() error {
 	watcher.SetEnabled(cfg.AutoRestart)
 	// A deployment FlatRun manages has a directory under the deployments path; only those are
 	// eligible for auto-restart, so stray host containers are never touched.
-	watcher.SetManaged(func(deployment string) bool {
+	isManaged := func(deployment string) bool {
 		if deployment == "" || dataDir == "" {
 			return false
 		}
 		info, err := os.Stat(filepath.Join(dataDir, deployment))
 		return err == nil && info.IsDir()
-	})
+	}
+	watcher.SetManaged(isManaged)
 
 	watcher.OnRecover(func(ev RecoveryEvent) {
 		emitNotification(
@@ -109,7 +110,15 @@ func RunPlugin() error {
 	engine := NewAlertEngine(store)
 	engine.SetRules(alertStore.Load())
 	engine.OnAlert(func(ev AlertEvent) {
-		emitNotification(ev.RuleName, ev.Message())
+		emitNotificationTo(ev.RuleName, ev.Message(), ev.Targets)
+	})
+	// An opt-in rule action restarts the offending deployment when it fires,
+	// scoped to FlatRun-managed deployments and rate-limited so it cannot flap.
+	actioner := NewActionRunner(DockerComposeRestart, isManaged, cfg.restartCooldown(), dataDir)
+	engine.OnAction(func(ev AlertEvent) {
+		if msg := actioner.Run(ev); msg != "" {
+			emitNotificationTo(ev.RuleName, msg, ev.Targets)
+		}
 	})
 	alertStop := make(chan struct{})
 	defer close(alertStop)
@@ -130,11 +139,16 @@ func RunPlugin() error {
 // emitNotification asks the core to deliver a notification to the operator's configured
 // targets. Delivery config and routing live in the agent, not the plugin.
 func emitNotification(title, message string) {
+	emitNotificationTo(title, message, nil)
+}
+
+// emitNotificationTo delivers to a chosen subset of targets by id; nil means all.
+func emitNotificationTo(title, message string, targets []string) {
 	base, token := pluginsdk.AgentCallback()
 	if base == "" || token == "" {
 		return
 	}
-	body, _ := json.Marshal(map[string]string{"title": title, "message": message})
+	body, _ := json.Marshal(map[string]any{"title": title, "message": message, "targets": targets})
 	req, err := http.NewRequest(http.MethodPost, base+"/internal/notify/emit", bytes.NewReader(body))
 	if err != nil {
 		return


### PR DESCRIPTION
Follows the alerting work: an alert used to only send a bare notification to
every target, which says a line broke but not what caused it, can't be aimed,
and leaves the operator to react by hand.

- A firing alert carries a snapshot of the containers using the most of the
  resource, so the notification (and the stored event) name what was
  responsible. A host memory alert lists the hungriest containers, not just the
  host figure.
- A rule can deliver to a chosen subset of notification targets instead of all.
- A rule can opt into restarting the offending deployment when it fires, reusing
  the self-heal guardrails: managed deployments only, and a cooldown so it can't
  flap into a restart loop. Default is notify-only.