### PR TITLE
feat(templates): Move the application catalog out of the binary

### DIFF
--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -1,0 +1,72 @@
+# App Templates
+
+## What this is
+
+App templates (WordPress, Laravel, Ghost, static sites, and so on) are the
+starting points the deploy flow generates a `docker-compose.yml` from. They no
+longer ship inside the agent binary: the agent fetches the catalog from an
+external source into an on-disk cache and reads it from there. This lets the
+catalog change (fix a template, add a new one) without rebuilding or
+redistributing the agent.
+
+Infrastructure services (databases, the reverse proxy) and the default welcome
+page stay embedded in the binary. They are runtime content locked to the agent
+version, not catalog entries, and are unaffected by everything below.
+
+## Where templates come from
+
+The agent resolves the catalog from the first available source, in order:
+
+1. **Marketplace API** (authoritative) when enabled.
+2. **GitHub** (`flatrun/templates`) as the fallback.
+
+The chosen catalog is written into the on-disk cache at
+`{deployments_path}/.flatrun/templates`. Listing and deploy always read that
+cache, so once a sync succeeds the templates persist across restarts and keep
+working during an outage.
+
+The marketplace source is off by default. Enabling it makes the marketplace
+authoritative ahead of GitHub with no code change.
+
+## Configuration
+
+```yaml
+templates:
+  # Where synced templates are cached; empty uses {deployments_path}/.flatrun/templates.
+  cache_dir: ""
+  # Background resync period in seconds; 0 disables it.
+  sync_interval: 3600
+  github:
+    enabled: true
+    repo: flatrun/templates
+    ref: main
+  marketplace:
+    # Enable once the marketplace API is ready; it then takes priority over GitHub.
+    enabled: false
+    url: ""            # empty uses the agent's default marketplace endpoint
+```
+
+The initial sync runs in the background at startup, so a slow or unreachable
+source never delays the agent. A manual refresh is available through the
+templates refresh endpoint.
+
+## Offline and air-gapped hosts
+
+The on-disk cache is the durable store. Two things follow:
+
+- After the first successful sync, deploys keep working with no network.
+- On a host that never reaches a source, populate the cache by hand. Each
+  template is a directory under `{deployments_path}/.flatrun/templates/` holding a
+  `docker-compose.yml` and an optional `metadata.yml` (plus any files the template
+  ships):
+
+  ```
+  {deployments_path}/.flatrun/templates/
+    wordpress/
+      metadata.yml
+      docker-compose.yml
+  ```
+
+  The agent picks these up the same way it reads synced templates. Set
+  `sync_interval: 0` (or disable both sources) if you want the cache left entirely
+  under manual control.

--- a/internal/api/object_store_list_test.go
+++ b/internal/api/object_store_list_test.go
@@ -13,7 +13,9 @@ import (
 // through the list API, which is what the picker forwards to auto-register it.
 func TestListTemplates_ObjectStoreCarriesContract(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	srv := &Server{config: &config.Config{DeploymentsPath: t.TempDir()}}
+	dir := t.TempDir()
+	srv := &Server{config: &config.Config{DeploymentsPath: dir}}
+	seedRepoTemplate(t, dir, "minio")
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -48,7 +50,9 @@ func TestListTemplates_ObjectStoreCarriesContract(t *testing.T) {
 // default catalog listing, not only under type=all.
 func TestListTemplates_ObjectStoreVisibleInDefault(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	srv := &Server{config: &config.Config{DeploymentsPath: t.TempDir()}}
+	dir := t.TempDir()
+	srv := &Server{config: &config.Config{DeploymentsPath: dir}}
+	seedRepoTemplate(t, dir, "minio")
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -3670,7 +3670,7 @@ func (s *Server) refreshTemplates(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"message": "Templates refreshed",
 		"source":  src,
-		"count":   len(builtinList) + synced,
+		"count":   synced,
 	})
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -49,6 +49,7 @@ import (
 	"github.com/flatrun/agent/internal/source"
 	"github.com/flatrun/agent/internal/ssl"
 	"github.com/flatrun/agent/internal/system"
+	"github.com/flatrun/agent/internal/templatesource"
 	"github.com/flatrun/agent/internal/traffic"
 	"github.com/flatrun/agent/pkg/config"
 	"github.com/flatrun/agent/pkg/models"
@@ -88,6 +89,7 @@ type Server struct {
 	infraManager       *infra.Manager
 	credentialsManager *credentials.Manager
 	sourceRegistry     *source.Registry
+	templateSyncer     *templatesource.Syncer
 	securityManager    *security.Manager
 	trafficManager     *traffic.Manager
 	dashboards         *dashboards.Store
@@ -175,12 +177,14 @@ func New(cfg *config.Config, configPath string) *Server {
 	manager := docker.NewManager(cfg.DeploymentsPath)
 	manager.SetCleanupTimeout(cfg.Cleanup.Timeout)
 
-	// Deploys read template copies from disk, so sync them with the
-	// binary's embedded set before anything can deploy.
+	// Deploys read template copies from disk. Seed the embedded infra and
+	// welcome content, then pull the app catalog from its external source into
+	// the same on-disk cache.
 	builtinTemplatesDir := filepath.Join(cfg.DeploymentsPath, ".flatrun", "templates")
 	if err := os.MkdirAll(builtinTemplatesDir, 0755); err == nil {
 		ensureBuiltinTemplates(builtinTemplatesDir)
 	}
+	templateSyncer := newTemplateSyncer(cfg)
 	certsDiscovery := certs.NewDiscovery(cfg.DeploymentsPath)
 	networksManager := networks.NewManager()
 	pluginsDir := filepath.Join(cfg.DeploymentsPath, ".flatrun", "plugins")
@@ -350,6 +354,7 @@ func New(cfg *config.Config, configPath string) *Server {
 		infraManager:       infraManager,
 		credentialsManager: credentialsManager,
 		sourceRegistry:     source.NewRegistry(source.GitProvider{}),
+		templateSyncer:     templateSyncer,
 		securityManager:    securityManager,
 		trafficManager:     trafficManager,
 		dashboards:         dashboards.NewStore(cfg.DeploymentsPath),
@@ -373,6 +378,8 @@ func New(cfg *config.Config, configPath string) *Server {
 	s.mcpHandler = s.newMCPHandler()
 
 	s.planStore.StartPruneLoop(context.Background(), time.Hour, time.Duration(cfg.Plans.RetentionDays)*24*time.Hour)
+
+	s.startTemplateSyncLoop(context.Background(), time.Duration(cfg.Templates.SyncInterval)*time.Second)
 
 	if provider, aiErr := ai.New(&cfg.AI); aiErr == nil {
 		s.aiProvider = provider
@@ -3257,6 +3264,64 @@ func marketplaceAPIBase() string {
 	return "https://api.flatrun.dev/api/v1"
 }
 
+// newTemplateSyncer builds the app-template catalog syncer from config: the
+// marketplace source first (authoritative when enabled), GitHub as the fallback,
+// writing into the on-disk template cache.
+func newTemplateSyncer(cfg *config.Config) *templatesource.Syncer {
+	cacheDir := cfg.Templates.CacheDir
+	if cacheDir == "" {
+		cacheDir = filepath.Join(cfg.DeploymentsPath, ".flatrun", "templates")
+	}
+	marketplaceURL := cfg.Templates.Marketplace.URL
+	if marketplaceURL == "" {
+		marketplaceURL = marketplaceAPIBase()
+	}
+	githubEnabled := cfg.Templates.GitHub.Enabled == nil || *cfg.Templates.GitHub.Enabled
+
+	resolver := templatesource.NewResolver(
+		templatesource.MarketplaceSource{
+			BaseURL: marketplaceURL,
+			Enabled: cfg.Templates.Marketplace.Enabled,
+		},
+		templatesource.GitHubSource{
+			Repo:    cfg.Templates.GitHub.Repo,
+			Ref:     cfg.Templates.GitHub.Ref,
+			Enabled: githubEnabled,
+		},
+	)
+	return &templatesource.Syncer{Resolver: resolver, CacheDir: cacheDir}
+}
+
+// startTemplateSyncLoop pulls the app catalog once in the background, then, when
+// interval > 0, keeps refreshing it. It runs off the request path so a slow or
+// unreachable source never delays startup; the on-disk cache from the last run
+// keeps serving deploys until the fetch completes.
+func (s *Server) startTemplateSyncLoop(ctx context.Context, interval time.Duration) {
+	sync := func() {
+		if src, n, err := s.templateSyncer.Sync(ctx); err != nil {
+			log.Printf("Warning: template sync failed: %v", err)
+		} else if n > 0 {
+			log.Printf("Synced %d app templates from %s", n, src)
+		}
+	}
+	go func() {
+		sync()
+		if interval <= 0 {
+			return
+		}
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				sync()
+			}
+		}
+	}()
+}
+
 func (s *Server) proxyMarketplace(c *gin.Context) {
 	upstream, err := url.Parse(marketplaceAPIBase())
 	if err != nil {
@@ -3594,9 +3659,18 @@ func (s *Server) refreshTemplates(c *gin.Context) {
 		}
 	}
 
+	src, synced, err := s.templateSyncer.Sync(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{
+			"error": fmt.Sprintf("template sync failed: %v", err),
+		})
+		return
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"message": "Templates refreshed",
-		"count":   len(builtinList),
+		"source":  src,
+		"count":   len(builtinList) + synced,
 	})
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -184,7 +184,7 @@ func New(cfg *config.Config, configPath string) *Server {
 	if err := os.MkdirAll(builtinTemplatesDir, 0755); err == nil {
 		ensureBuiltinTemplates(builtinTemplatesDir)
 	}
-	templateSyncer := newTemplateSyncer(cfg)
+	templateSyncer := newTemplateSyncer(cfg, builtinTemplatesDir)
 	certsDiscovery := certs.NewDiscovery(cfg.DeploymentsPath)
 	networksManager := networks.NewManager()
 	pluginsDir := filepath.Join(cfg.DeploymentsPath, ".flatrun", "plugins")
@@ -379,7 +379,11 @@ func New(cfg *config.Config, configPath string) *Server {
 
 	s.planStore.StartPruneLoop(context.Background(), time.Hour, time.Duration(cfg.Plans.RetentionDays)*24*time.Hour)
 
-	s.startTemplateSyncLoop(context.Background(), time.Duration(cfg.Templates.SyncInterval)*time.Second)
+	syncInterval := 3600
+	if cfg.Templates.SyncInterval != nil {
+		syncInterval = *cfg.Templates.SyncInterval
+	}
+	s.startTemplateSyncLoop(context.Background(), time.Duration(syncInterval)*time.Second)
 
 	if provider, aiErr := ai.New(&cfg.AI); aiErr == nil {
 		s.aiProvider = provider
@@ -3267,11 +3271,7 @@ func marketplaceAPIBase() string {
 // newTemplateSyncer builds the app-template catalog syncer from config: the
 // marketplace source first (authoritative when enabled), GitHub as the fallback,
 // writing into the on-disk template cache.
-func newTemplateSyncer(cfg *config.Config) *templatesource.Syncer {
-	cacheDir := cfg.Templates.CacheDir
-	if cacheDir == "" {
-		cacheDir = filepath.Join(cfg.DeploymentsPath, ".flatrun", "templates")
-	}
+func newTemplateSyncer(cfg *config.Config, cacheDir string) *templatesource.Syncer {
 	marketplaceURL := cfg.Templates.Marketplace.URL
 	if marketplaceURL == "" {
 		marketplaceURL = marketplaceAPIBase()

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -918,6 +918,7 @@ func TestGenerateDeploymentComposePreservesDefaultTemplate(t *testing.T) {
 		},
 	}
 	s := &Server{config: cfg}
+	seedRepoTemplate(t, cfg.DeploymentsPath, "static")
 
 	result, err := s.generateDeploymentCompose("default-app", "", "", 0, false, "", nil)
 	if err != nil {

--- a/internal/api/templates_seed_test.go
+++ b/internal/api/templates_seed_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// seedRepoTemplate copies a template shipped in the repo's templates/ directory
+// into a deployment's on-disk template cache, mirroring what the template syncer
+// does at runtime. App templates are no longer embedded, so a test exercising one
+// must place it in the cache first.
+func seedRepoTemplate(t *testing.T, deploymentsPath, id string) {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve caller path")
+	}
+	src := filepath.Join(filepath.Dir(thisFile), "..", "..", "templates", id)
+	dest := filepath.Join(deploymentsPath, ".flatrun", "templates", id)
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		t.Fatalf("read repo template %q: %v", id, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(src, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dest, e.Name()), data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/internal/templatesource/github.go
+++ b/internal/templatesource/github.go
@@ -1,0 +1,176 @@
+package templatesource
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"sort"
+	"strings"
+	"time"
+)
+
+// maxTemplateFileBytes caps a single file read from the tarball. Templates are a
+// few KB; the cap bounds a hostile or corrupt archive.
+const maxTemplateFileBytes = 2 << 20 // 2 MiB
+
+// GitHubSource delivers the catalog from a GitHub repository (flatrun/templates)
+// by downloading its tarball and reading each directory that contains a
+// docker-compose.yml as one template. It shells out to nothing: the fetch is a
+// single HTTPS request extracted with the standard library, so the fetch
+// mechanism is private to this source and swappable without touching callers.
+type GitHubSource struct {
+	// Repo is "owner/name", e.g. "flatrun/templates".
+	Repo string
+	// Ref is a branch, tag, or commit; "main" when empty.
+	Ref string
+	// Enabled gates the source from config.
+	Enabled bool
+	// BaseURL overrides the codeload host; tests point it at an httptest server.
+	BaseURL string
+	// Client is the HTTP client; a default with a timeout is used when nil.
+	Client *http.Client
+}
+
+func (g GitHubSource) Name() string { return "github" }
+
+func (g GitHubSource) Available(ctx context.Context) bool {
+	return g.Enabled && g.Repo != ""
+}
+
+func (g GitHubSource) ref() string {
+	if g.Ref != "" {
+		return g.Ref
+	}
+	return "main"
+}
+
+func (g GitHubSource) client() *http.Client {
+	if g.Client != nil {
+		return g.Client
+	}
+	return &http.Client{Timeout: 60 * time.Second}
+}
+
+func (g GitHubSource) tarballURL() string {
+	base := g.BaseURL
+	if base == "" {
+		base = "https://codeload.github.com"
+	}
+	return fmt.Sprintf("%s/%s/tar.gz/%s", strings.TrimRight(base, "/"), g.Repo, g.ref())
+}
+
+func (g GitHubSource) List(ctx context.Context) ([]Template, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, g.tarballURL(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := g.client().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch %s: status %d", g.Repo, resp.StatusCode)
+	}
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("gzip: %w", err)
+	}
+	defer gz.Close()
+
+	// Read every regular file into a flat map keyed by its path with the
+	// tarball's top directory (<name>-<ref>/) stripped.
+	files := map[string][]byte{}
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("tar: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		name := stripTopDir(hdr.Name)
+		if name == "" || path.Dir(name) == "." {
+			// Repo-root files (README, LICENSE, ...) are not template content.
+			continue
+		}
+		if hdr.Size > maxTemplateFileBytes {
+			continue
+		}
+		data, err := io.ReadAll(io.LimitReader(tr, maxTemplateFileBytes))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", name, err)
+		}
+		files[name] = data
+	}
+
+	return templatesFromFiles(files), nil
+}
+
+// stripTopDir removes the leading "<something>/" component that GitHub tarballs
+// wrap every entry in.
+func stripTopDir(name string) string {
+	name = strings.TrimPrefix(name, "./")
+	i := strings.IndexByte(name, '/')
+	if i < 0 {
+		return ""
+	}
+	return name[i+1:]
+}
+
+// templatesFromFiles groups a flat file map into templates. A template is any
+// directory holding a docker-compose.yml; every file beneath it (including files
+// in subdirectories) is attached with a path relative to that directory. When
+// templates nest, a file is assigned to its most specific (longest) root.
+func templatesFromFiles(files map[string][]byte) []Template {
+	var roots []string
+	for name := range files {
+		if path.Base(name) == "docker-compose.yml" {
+			roots = append(roots, path.Dir(name))
+		}
+	}
+	sort.Slice(roots, func(i, j int) bool { return len(roots[i]) > len(roots[j]) })
+
+	grouped := make(map[string]map[string][]byte, len(roots))
+	for _, r := range roots {
+		grouped[r] = map[string][]byte{}
+	}
+	for name, data := range files {
+		for _, root := range roots { // longest first
+			prefix := root + "/"
+			if strings.HasPrefix(name, prefix) {
+				grouped[root][name[len(prefix):]] = data
+				break
+			}
+		}
+	}
+
+	out := make([]Template, 0, len(roots))
+	for _, root := range roots {
+		g := grouped[root]
+		compose := g["docker-compose.yml"]
+		if len(compose) == 0 {
+			continue
+		}
+		t := Template{ID: root, Compose: compose, Metadata: g["metadata.yml"], Files: map[string][]byte{}}
+		for name, data := range g {
+			if name == "docker-compose.yml" || name == "metadata.yml" {
+				continue
+			}
+			t.Files[name] = data
+		}
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}

--- a/internal/templatesource/github.go
+++ b/internal/templatesource/github.go
@@ -17,6 +17,10 @@ import (
 // few KB; the cap bounds a hostile or corrupt archive.
 const maxTemplateFileBytes = 2 << 20 // 2 MiB
 
+// maxCatalogBytes caps the whole extracted catalog, so a repository with a huge
+// number of small files cannot exhaust memory.
+const maxCatalogBytes = 100 << 20 // 100 MiB
+
 // GitHubSource delivers the catalog from a GitHub repository (flatrun/templates)
 // by downloading its tarball and reading each directory that contains a
 // docker-compose.yml as one template. It shells out to nothing: the fetch is a
@@ -88,6 +92,7 @@ func (g GitHubSource) List(ctx context.Context) ([]Template, error) {
 	// tarball's top directory (<name>-<ref>/) stripped.
 	files := map[string][]byte{}
 	tr := tar.NewReader(gz)
+	var total int64
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -104,13 +109,14 @@ func (g GitHubSource) List(ctx context.Context) ([]Template, error) {
 			// Repo-root files (README, LICENSE, ...) are not template content.
 			continue
 		}
-		if hdr.Size > maxTemplateFileBytes {
+		if hdr.Size > maxTemplateFileBytes || total+hdr.Size > maxCatalogBytes {
 			continue
 		}
 		data, err := io.ReadAll(io.LimitReader(tr, maxTemplateFileBytes))
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", name, err)
 		}
+		total += int64(len(data))
 		files[name] = data
 	}
 

--- a/internal/templatesource/github_test.go
+++ b/internal/templatesource/github_test.go
@@ -1,0 +1,113 @@
+package templatesource
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// tarball builds a gzipped tar shaped like a GitHub codeload archive: every
+// entry is wrapped in a top-level "<name>/" directory.
+func tarball(t *testing.T, top string, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		full := top + "/" + name
+		if err := tw.WriteHeader(&tar.Header{Name: full, Mode: 0o644, Size: int64(len(content)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestGitHubSourceListExtractsTemplates(t *testing.T) {
+	archive := tarball(t, "templates-main", map[string]string{
+		"README.md":                    "# templates",
+		"wordpress/metadata.yml":       "name: WordPress\npriority: 100\n",
+		"wordpress/docker-compose.yml": "name: ${NAME}\nservices:\n  wordpress:\n",
+		"static/docker-compose.yml":    "name: ${NAME}\nservices:\n  web:\n",
+		"static/html/index.html":       "<h1>${NAME}</h1>",
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	src := GitHubSource{Repo: "flatrun/templates", Ref: "main", Enabled: true, BaseURL: srv.URL}
+	got, err := src.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	byID := map[string]Template{}
+	for _, tpl := range got {
+		byID[tpl.ID] = tpl
+	}
+
+	if len(byID) != 2 {
+		t.Fatalf("got %d templates, want 2 (wordpress, static); README must be ignored", len(byID))
+	}
+
+	wp, ok := byID["wordpress"]
+	if !ok {
+		t.Fatal("missing wordpress template")
+	}
+	if !bytes.Contains(wp.Metadata, []byte("WordPress")) {
+		t.Errorf("wordpress metadata not captured: %q", wp.Metadata)
+	}
+	if !bytes.Contains(wp.Compose, []byte("wordpress:")) {
+		t.Errorf("wordpress compose not captured: %q", wp.Compose)
+	}
+
+	static, ok := byID["static"]
+	if !ok {
+		t.Fatal("missing static template")
+	}
+	if len(static.Metadata) != 0 {
+		t.Errorf("static should have no metadata, got %q", static.Metadata)
+	}
+	if got := static.Files["html/index.html"]; string(got) != "<h1>${NAME}</h1>" {
+		t.Errorf("static nested file not captured under relative path, got %q", got)
+	}
+}
+
+func TestGitHubSourceListErrorsOnNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	src := GitHubSource{Repo: "flatrun/templates", Enabled: true, BaseURL: srv.URL}
+	if _, err := src.List(context.Background()); err == nil {
+		t.Fatal("expected error on 404")
+	}
+}
+
+func TestGitHubSourceAvailable(t *testing.T) {
+	if (GitHubSource{Enabled: false, Repo: "flatrun/templates"}).Available(context.Background()) {
+		t.Error("disabled source must not be available")
+	}
+	if (GitHubSource{Enabled: true, Repo: ""}).Available(context.Background()) {
+		t.Error("source without a repo must not be available")
+	}
+	if !(GitHubSource{Enabled: true, Repo: "flatrun/templates"}).Available(context.Background()) {
+		t.Error("configured source should be available")
+	}
+}

--- a/internal/templatesource/marketplace.go
+++ b/internal/templatesource/marketplace.go
@@ -1,0 +1,106 @@
+package templatesource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MarketplaceSource delivers the catalog from the FlatRun marketplace agent-sync
+// API (GET {base}/agent/templates). The marketplace stores compose and metadata
+// inline, so a template arrives fully formed. Entries whose compose is empty are
+// backed by an external git repo on the marketplace side and are skipped here;
+// resolving those is a follow-up. This source is gated off by default until the
+// marketplace API is declared ready; flipping the config flag makes it
+// authoritative ahead of GitHub with no code change.
+type MarketplaceSource struct {
+	// BaseURL is the marketplace API root, e.g. "https://api.flatrun.dev/api/v1".
+	BaseURL string
+	// Enabled gates the source from config.
+	Enabled bool
+	// Client is the HTTP client; a default with a timeout is used when nil.
+	Client *http.Client
+}
+
+func (m MarketplaceSource) Name() string { return "marketplace" }
+
+func (m MarketplaceSource) Available(ctx context.Context) bool {
+	return m.Enabled && m.BaseURL != ""
+}
+
+func (m MarketplaceSource) client() *http.Client {
+	if m.Client != nil {
+		return m.Client
+	}
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+// agentTemplate mirrors the marketplace AgentTemplateResource. mounts and files
+// are passed through untouched into the reconstructed metadata.yml, so this
+// source needs no knowledge of their inner shape.
+type agentTemplate struct {
+	ID            string      `json:"id" yaml:"-"`
+	Name          string      `json:"name" yaml:"name"`
+	Description   string      `json:"description" yaml:"description,omitempty"`
+	Icon          string      `json:"icon" yaml:"icon,omitempty"`
+	Logo          string      `json:"logo" yaml:"logo,omitempty"`
+	Category      string      `json:"category" yaml:"category,omitempty"`
+	Priority      int         `json:"priority" yaml:"priority,omitempty"`
+	ContainerPort int         `json:"container_port" yaml:"container_port,omitempty"`
+	Mounts        interface{} `json:"mounts" yaml:"mounts,omitempty"`
+	Files         interface{} `json:"files" yaml:"files,omitempty"`
+	Content       string      `json:"content" yaml:"-"`
+	Version       string      `json:"version" yaml:"-"`
+}
+
+func (m MarketplaceSource) List(ctx context.Context) ([]Template, error) {
+	url := strings.TrimRight(m.BaseURL, "/") + "/agent/templates"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := m.client().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("agent/templates: status %d", resp.StatusCode)
+	}
+
+	// Laravel resource collections wrap the array in "data".
+	var payload struct {
+		Data []agentTemplate `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+
+	out := make([]Template, 0, len(payload.Data))
+	for _, at := range payload.Data {
+		if at.ID == "" || at.Content == "" {
+			// Empty content means the template is backed by an external repo on
+			// the marketplace; skip until repo-backed entries are supported.
+			continue
+		}
+		metadata, err := yaml.Marshal(at)
+		if err != nil {
+			continue
+		}
+		out = append(out, Template{
+			ID:       at.ID,
+			Version:  at.Version,
+			Metadata: metadata,
+			Compose:  []byte(at.Content),
+		})
+	}
+	return out, nil
+}

--- a/internal/templatesource/marketplace_test.go
+++ b/internal/templatesource/marketplace_test.go
@@ -1,0 +1,108 @@
+package templatesource
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// realAgentTemplatesResponse is the AgentTemplateResource collection shape from
+// marketplace-webservice (app/Http/Resources/Api/V1/Agent/AgentTemplateResource.php):
+// a Laravel resource collection wrapped in "data", each item carrying inline
+// compose in "content". The github/gitlab-backed entry has empty content.
+const realAgentTemplatesResponse = `{
+  "data": [
+    {
+      "id": "wordpress",
+      "name": "WordPress",
+      "description": "WordPress with MySQL",
+      "icon": "pi pi-wordpress",
+      "logo": "https://cdn.flatrun.dev/wordpress.svg",
+      "category": "application",
+      "priority": 100,
+      "container_port": 80,
+      "mounts": [
+        {"id": "content", "name": "Content", "container_path": "/var/www/html/wp-content", "type": "directory"}
+      ],
+      "files": [],
+      "content": "name: ${NAME}\nservices:\n  wordpress:\n    image: wordpress:latest\n"
+    },
+    {
+      "id": "external-app",
+      "name": "External App",
+      "description": "Backed by a git repo",
+      "icon": "pi pi-box",
+      "logo": "",
+      "category": "application",
+      "priority": 10,
+      "container_port": 3000,
+      "mounts": [],
+      "files": [],
+      "content": ""
+    }
+  ]
+}`
+
+func TestMarketplaceSourceListParsesRealShape(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(realAgentTemplatesResponse))
+	}))
+	defer srv.Close()
+
+	src := MarketplaceSource{BaseURL: srv.URL + "/api/v1", Enabled: true}
+	got, err := src.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if gotPath != "/api/v1/agent/templates" {
+		t.Errorf("requested %q, want /api/v1/agent/templates", gotPath)
+	}
+
+	// The empty-content (repo-backed) entry is skipped.
+	if len(got) != 1 {
+		t.Fatalf("got %d templates, want 1 (repo-backed entry skipped)", len(got))
+	}
+
+	wp := got[0]
+	if wp.ID != "wordpress" {
+		t.Fatalf("id = %q, want wordpress", wp.ID)
+	}
+	if !strings.Contains(string(wp.Compose), "image: wordpress:latest") {
+		t.Errorf("compose not taken from content: %q", wp.Compose)
+	}
+
+	// Metadata is reconstructed as YAML the on-disk read path can parse back.
+	var meta struct {
+		Name          string        `yaml:"name"`
+		Category      string        `yaml:"category"`
+		Priority      int           `yaml:"priority"`
+		ContainerPort int           `yaml:"container_port"`
+		Mounts        []interface{} `yaml:"mounts"`
+	}
+	if err := yaml.Unmarshal(wp.Metadata, &meta); err != nil {
+		t.Fatalf("reconstructed metadata is not valid yaml: %v\n%s", err, wp.Metadata)
+	}
+	if meta.Name != "WordPress" || meta.Priority != 100 || meta.ContainerPort != 80 {
+		t.Errorf("metadata fields lost: %+v", meta)
+	}
+	if len(meta.Mounts) != 1 {
+		t.Errorf("mounts passthrough lost: %+v", meta.Mounts)
+	}
+}
+
+func TestMarketplaceSourceAvailable(t *testing.T) {
+	if (MarketplaceSource{Enabled: false, BaseURL: "http://x"}).Available(context.Background()) {
+		t.Error("disabled marketplace must not be available")
+	}
+	if (MarketplaceSource{Enabled: true, BaseURL: ""}).Available(context.Background()) {
+		t.Error("marketplace without a url must not be available")
+	}
+}

--- a/internal/templatesource/source.go
+++ b/internal/templatesource/source.go
@@ -1,0 +1,71 @@
+// Package templatesource delivers the app template catalog to the agent from an
+// external origin, so the catalog can change without rebuilding the binary. A
+// Source produces the catalog in one uniform shape regardless of where it lives
+// (the marketplace API today gated off, a GitHub repo as the working default); a
+// Resolver picks the first available Source in priority order; a Syncer writes
+// the chosen catalog into the on-disk template cache the deploy and listing paths
+// already read. Infra and welcome content stays embedded in the binary and does
+// not flow through here.
+package templatesource
+
+import (
+	"context"
+	"fmt"
+)
+
+// Template is one catalog entry in the shape the on-disk cache stores: a
+// metadata.yml, a docker-compose.yml, and any extra files the template ships,
+// keyed by their path relative to the template directory.
+type Template struct {
+	ID       string
+	Version  string
+	Metadata []byte
+	Compose  []byte
+	Files    map[string][]byte
+}
+
+// Source produces the app template catalog from one origin. Available reports
+// whether the source is configured and worth trying; List returns the full
+// catalog. A source that is configured but unreachable should return an error
+// from List rather than reporting false from Available, so the Resolver can fall
+// through to the next source.
+type Source interface {
+	Name() string
+	Available(ctx context.Context) bool
+	List(ctx context.Context) ([]Template, error)
+}
+
+// Resolver holds sources in priority order (authoritative first, fallbacks
+// after) and returns the catalog from the first one that succeeds.
+type Resolver struct {
+	sources []Source
+}
+
+// NewResolver keeps the sources in the given order; earlier sources win.
+func NewResolver(sources ...Source) *Resolver {
+	return &Resolver{sources: sources}
+}
+
+// Resolve returns the catalog from the first available source that lists
+// successfully, along with that source's name. An available source that errors
+// is skipped so a broken authoritative source still falls back to the next one;
+// the first such error is returned only when every available source failed. When
+// no source is available it returns (nil, "", nil) so the caller can keep
+// whatever is already cached.
+func (r *Resolver) Resolve(ctx context.Context) ([]Template, string, error) {
+	var firstErr error
+	for _, s := range r.sources {
+		if !s.Available(ctx) {
+			continue
+		}
+		templates, err := s.List(ctx)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: %w", s.Name(), err)
+			}
+			continue
+		}
+		return templates, s.Name(), nil
+	}
+	return nil, "", firstErr
+}

--- a/internal/templatesource/source_test.go
+++ b/internal/templatesource/source_test.go
@@ -1,0 +1,79 @@
+package templatesource
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type stubSource struct {
+	name      string
+	available bool
+	templates []Template
+	err       error
+}
+
+func (s stubSource) Name() string                   { return s.name }
+func (s stubSource) Available(context.Context) bool { return s.available }
+func (s stubSource) List(context.Context) ([]Template, error) {
+	return s.templates, s.err
+}
+
+func TestResolverPrefersFirstAvailable(t *testing.T) {
+	first := stubSource{name: "marketplace", available: true, templates: []Template{{ID: "a", Compose: []byte("x")}}}
+	second := stubSource{name: "github", available: true, templates: []Template{{ID: "b", Compose: []byte("y")}}}
+
+	got, src, err := NewResolver(first, second).Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src != "marketplace" {
+		t.Fatalf("source = %q, want marketplace", src)
+	}
+	if len(got) != 1 || got[0].ID != "a" {
+		t.Fatalf("got %+v, want the first source's catalog", got)
+	}
+}
+
+func TestResolverSkipsUnavailable(t *testing.T) {
+	first := stubSource{name: "marketplace", available: false}
+	second := stubSource{name: "github", available: true, templates: []Template{{ID: "b", Compose: []byte("y")}}}
+
+	got, src, err := NewResolver(first, second).Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src != "github" || len(got) != 1 || got[0].ID != "b" {
+		t.Fatalf("got src=%q %+v, want github catalog", src, got)
+	}
+}
+
+func TestResolverFallsThroughOnError(t *testing.T) {
+	first := stubSource{name: "marketplace", available: true, err: errors.New("boom")}
+	second := stubSource{name: "github", available: true, templates: []Template{{ID: "b", Compose: []byte("y")}}}
+
+	got, src, err := NewResolver(first, second).Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src != "github" || len(got) != 1 || got[0].ID != "b" {
+		t.Fatalf("expected fallback to github, got src=%q %+v", src, got)
+	}
+}
+
+func TestResolverReturnsErrorWhenAllAvailableFail(t *testing.T) {
+	first := stubSource{name: "marketplace", available: true, err: errors.New("boom")}
+	second := stubSource{name: "github", available: true, err: errors.New("bang")}
+
+	_, _, err := NewResolver(first, second).Resolve(context.Background())
+	if err == nil {
+		t.Fatal("expected error when every available source fails")
+	}
+}
+
+func TestResolverEmptyWhenNoneAvailable(t *testing.T) {
+	got, src, err := NewResolver(stubSource{name: "github", available: false}).Resolve(context.Background())
+	if err != nil || got != nil || src != "" {
+		t.Fatalf("got (%v, %q, %v), want (nil, \"\", nil)", got, src, err)
+	}
+}

--- a/internal/templatesource/sync.go
+++ b/internal/templatesource/sync.go
@@ -1,0 +1,91 @@
+package templatesource
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Syncer resolves the catalog and writes it into the on-disk template cache the
+// deploy and listing paths read from. The cache is the durable store: once
+// written it survives restarts and outages, and an operator can populate it by
+// hand on an air-gapped host.
+type Syncer struct {
+	Resolver *Resolver
+	CacheDir string
+}
+
+// Sync resolves the catalog and materializes it into CacheDir. It returns the
+// source used and the number of templates written. When no source is available
+// it leaves the cache untouched and returns ("", 0, nil) so a previously synced
+// catalog survives an outage. Per-template write failures are skipped rather
+// than aborting the whole sync.
+func (s *Syncer) Sync(ctx context.Context) (string, int, error) {
+	templates, src, err := s.Resolver.Resolve(ctx)
+	if err != nil {
+		return src, 0, err
+	}
+	if templates == nil {
+		return "", 0, nil
+	}
+	if err := os.MkdirAll(s.CacheDir, 0o755); err != nil {
+		return src, 0, err
+	}
+
+	written := 0
+	for _, t := range templates {
+		if err := s.write(t); err != nil {
+			continue
+		}
+		written++
+	}
+	return src, written, nil
+}
+
+func (s *Syncer) write(t Template) error {
+	if t.ID == "" || len(t.Compose) == 0 {
+		return fmt.Errorf("template %q: missing id or compose", t.ID)
+	}
+	dir, err := safeJoin(s.CacheDir, t.ID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	if len(t.Metadata) > 0 {
+		if err := os.WriteFile(filepath.Join(dir, "metadata.yml"), t.Metadata, 0o644); err != nil {
+			return err
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), t.Compose, 0o644); err != nil {
+		return err
+	}
+	for name, data := range t.Files {
+		fpath, err := safeJoin(dir, name)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(fpath), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(fpath, data, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// safeJoin joins rel onto base and guarantees the result stays within base, so a
+// hostile template id or file path from a remote source cannot escape the cache
+// directory. Cleaning against a root neutralizes any leading "..".
+func safeJoin(base, rel string) (string, error) {
+	clean := filepath.Clean("/" + strings.ReplaceAll(rel, "\\", "/"))
+	joined := filepath.Join(base, clean)
+	if joined != base && !strings.HasPrefix(joined, base+string(os.PathSeparator)) {
+		return "", fmt.Errorf("unsafe path %q", rel)
+	}
+	return joined, nil
+}

--- a/internal/templatesource/sync.go
+++ b/internal/templatesource/sync.go
@@ -50,8 +50,16 @@ func (s *Syncer) write(t Template) error {
 	if t.ID == "" || len(t.Compose) == 0 {
 		return fmt.Errorf("template %q: missing id or compose", t.ID)
 	}
+	if isReservedID(t.ID) {
+		return fmt.Errorf("template %q: reserved id", t.ID)
+	}
 	dir, err := safeJoin(s.CacheDir, t.ID)
 	if err != nil {
+		return err
+	}
+	// Replace the directory wholesale so a file dropped upstream between versions
+	// does not linger in the cache.
+	if err := os.RemoveAll(dir); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -78,6 +86,14 @@ func (s *Syncer) write(t Template) error {
 		}
 	}
 	return nil
+}
+
+// isReservedID rejects catalog ids that collide with the embedded infra and
+// welcome content, so an external source cannot overwrite files the agent keeps
+// locked to its own version.
+func isReservedID(id string) bool {
+	return id == "infra" || strings.HasPrefix(id, "infra/") ||
+		id == "welcome" || strings.HasPrefix(id, "welcome/")
 }
 
 // safeJoin joins rel onto base and guarantees the result stays within base, so a

--- a/internal/templatesource/sync.go
+++ b/internal/templatesource/sync.go
@@ -3,6 +3,7 @@ package templatesource
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,6 +38,7 @@ func (s *Syncer) Sync(ctx context.Context) (string, int, error) {
 	written := 0
 	for _, t := range templates {
 		if err := s.write(t); err != nil {
+			log.Printf("templatesource: skipping template %q: %v", t.ID, err)
 			continue
 		}
 		written++

--- a/internal/templatesource/sync_test.go
+++ b/internal/templatesource/sync_test.go
@@ -66,6 +66,63 @@ func TestSyncerLeavesCacheOnNoSource(t *testing.T) {
 	}
 }
 
+func TestSyncerRejectsReservedIDs(t *testing.T) {
+	cache := t.TempDir()
+	// An embedded-style infra template the sync must never clobber.
+	infra := filepath.Join(cache, "infra", "nginx")
+	if err := os.MkdirAll(infra, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(infra, "docker-compose.yml"), []byte("embedded"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	src := stubSource{name: "github", available: true, templates: []Template{
+		{ID: "infra/nginx", Compose: []byte("hijacked")},
+		{ID: "welcome", Compose: []byte("hijacked")},
+		{ID: "wordpress", Compose: []byte("ok")},
+	}}
+	s := &Syncer{Resolver: NewResolver(src), CacheDir: cache}
+
+	_, n, err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("wrote %d templates, want 1 (reserved ids skipped)", n)
+	}
+	got, err := os.ReadFile(filepath.Join(infra, "docker-compose.yml"))
+	if err != nil || string(got) != "embedded" {
+		t.Fatalf("reserved infra template was overwritten: %q %v", got, err)
+	}
+}
+
+func TestSyncerReplacesStaleFiles(t *testing.T) {
+	cache := t.TempDir()
+	dir := filepath.Join(cache, "wordpress")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "stale.txt"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	src := stubSource{name: "github", available: true, templates: []Template{
+		{ID: "wordpress", Compose: []byte("services:\n"), Files: map[string][]byte{"fresh.txt": []byte("new")}},
+	}}
+	s := &Syncer{Resolver: NewResolver(src), CacheDir: cache}
+	if _, _, err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "stale.txt")); !os.IsNotExist(err) {
+		t.Error("a file removed upstream should not linger in the cache")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "fresh.txt")); err != nil {
+		t.Errorf("the new file should be written: %v", err)
+	}
+}
+
 func TestSyncerRejectsPathTraversal(t *testing.T) {
 	cache := t.TempDir()
 	src := stubSource{name: "github", available: true, templates: []Template{

--- a/internal/templatesource/sync_test.go
+++ b/internal/templatesource/sync_test.go
@@ -1,0 +1,82 @@
+package templatesource
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSyncerWritesCatalogToCache(t *testing.T) {
+	cache := t.TempDir()
+	src := stubSource{name: "github", available: true, templates: []Template{
+		{
+			ID:       "wordpress",
+			Metadata: []byte("name: WordPress\n"),
+			Compose:  []byte("services:\n  wordpress:\n"),
+			Files:    map[string][]byte{"html/index.html": []byte("<h1>hi</h1>")},
+		},
+	}}
+	s := &Syncer{Resolver: NewResolver(src), CacheDir: cache}
+
+	name, n, err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if name != "github" || n != 1 {
+		t.Fatalf("got (%q, %d), want (github, 1)", name, n)
+	}
+
+	for rel, want := range map[string]string{
+		"wordpress/metadata.yml":       "name: WordPress\n",
+		"wordpress/docker-compose.yml": "services:\n  wordpress:\n",
+		"wordpress/html/index.html":    "<h1>hi</h1>",
+	} {
+		got, err := os.ReadFile(filepath.Join(cache, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if string(got) != want {
+			t.Errorf("%s = %q, want %q", rel, got, want)
+		}
+	}
+}
+
+func TestSyncerLeavesCacheOnNoSource(t *testing.T) {
+	cache := t.TempDir()
+	existing := filepath.Join(cache, "wordpress")
+	if err := os.MkdirAll(existing, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	compose := filepath.Join(existing, "docker-compose.yml")
+	if err := os.WriteFile(compose, []byte("cached"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No available source: the cache must be untouched.
+	s := &Syncer{Resolver: NewResolver(stubSource{name: "github", available: false}), CacheDir: cache}
+	name, n, err := s.Sync(context.Background())
+	if err != nil || name != "" || n != 0 {
+		t.Fatalf("got (%q, %d, %v), want (\"\", 0, nil)", name, n, err)
+	}
+
+	got, err := os.ReadFile(compose)
+	if err != nil || string(got) != "cached" {
+		t.Fatalf("cached template was disturbed: %q %v", got, err)
+	}
+}
+
+func TestSyncerRejectsPathTraversal(t *testing.T) {
+	cache := t.TempDir()
+	src := stubSource{name: "github", available: true, templates: []Template{
+		{ID: "../escape", Compose: []byte("x")},
+	}}
+	s := &Syncer{Resolver: NewResolver(src), CacheDir: cache}
+
+	if _, _, err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync should skip the bad template, not error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(cache), "escape")); err == nil {
+		t.Fatal("path traversal escaped the cache dir")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,39 @@ type Config struct {
 	MCP             MCPConfig            `yaml:"mcp"`
 	Files           FilesConfig          `yaml:"files"`
 	Backup          BackupConfig         `yaml:"backup"`
+	Templates       TemplatesConfig      `yaml:"templates"`
+}
+
+// TemplatesConfig controls where the app template catalog is fetched from. The
+// catalog lives outside the binary: it is synced from a source into an on-disk
+// cache that the deploy and listing paths read. Infra and welcome content stay
+// embedded and are unaffected.
+type TemplatesConfig struct {
+	// CacheDir is where synced templates are stored; empty means
+	// {deployments_path}/.flatrun/templates.
+	CacheDir string `yaml:"cache_dir" json:"cache_dir"`
+	// SyncInterval is the background resync period in seconds; 0 disables it.
+	SyncInterval int                        `yaml:"sync_interval" json:"sync_interval"`
+	GitHub       TemplatesGitHubConfig      `yaml:"github" json:"github"`
+	Marketplace  TemplatesMarketplaceConfig `yaml:"marketplace" json:"marketplace"`
+}
+
+// TemplatesGitHubConfig is the GitHub-repo source, the working default today.
+type TemplatesGitHubConfig struct {
+	// Enabled defaults to true when unset; an explicit false is honored.
+	Enabled *bool  `yaml:"enabled" json:"enabled"`
+	Repo    string `yaml:"repo" json:"repo"`
+	Ref     string `yaml:"ref" json:"ref"`
+}
+
+// TemplatesMarketplaceConfig is the marketplace-API source. Disabled by default
+// until the API is declared ready; enabling it makes the marketplace
+// authoritative ahead of GitHub with no code change.
+type TemplatesMarketplaceConfig struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// URL is the marketplace API root; empty falls back to the agent's default
+	// marketplace endpoint.
+	URL string `yaml:"url" json:"url"`
 }
 
 // MCPConfig controls the built-in MCP server that exposes the assistant's tool
@@ -382,6 +415,19 @@ func setDefaults(cfg *Config) {
 	}
 	if cfg.Infrastructure.Redis.Port == 0 && cfg.Infrastructure.Redis.Enabled {
 		cfg.Infrastructure.Redis.Port = 6379
+	}
+	if cfg.Templates.GitHub.Enabled == nil {
+		enabled := true
+		cfg.Templates.GitHub.Enabled = &enabled
+	}
+	if cfg.Templates.GitHub.Repo == "" {
+		cfg.Templates.GitHub.Repo = "flatrun/templates"
+	}
+	if cfg.Templates.GitHub.Ref == "" {
+		cfg.Templates.GitHub.Ref = "main"
+	}
+	if cfg.Templates.SyncInterval == 0 {
+		cfg.Templates.SyncInterval = 3600
 	}
 	if cfg.Nginx.Image == "" {
 		cfg.Nginx.Image = "nginx:alpine"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,11 +52,9 @@ type Config struct {
 // cache that the deploy and listing paths read. Infra and welcome content stay
 // embedded and are unaffected.
 type TemplatesConfig struct {
-	// CacheDir is where synced templates are stored; empty means
-	// {deployments_path}/.flatrun/templates.
-	CacheDir string `yaml:"cache_dir" json:"cache_dir"`
-	// SyncInterval is the background resync period in seconds; 0 disables it.
-	SyncInterval int                        `yaml:"sync_interval" json:"sync_interval"`
+	// SyncInterval is the background resync period in seconds. A pointer so an
+	// explicit 0, which disables the resync loop, is distinct from unset.
+	SyncInterval *int                       `yaml:"sync_interval" json:"sync_interval"`
 	GitHub       TemplatesGitHubConfig      `yaml:"github" json:"github"`
 	Marketplace  TemplatesMarketplaceConfig `yaml:"marketplace" json:"marketplace"`
 }
@@ -426,8 +424,9 @@ func setDefaults(cfg *Config) {
 	if cfg.Templates.GitHub.Ref == "" {
 		cfg.Templates.GitHub.Ref = "main"
 	}
-	if cfg.Templates.SyncInterval == 0 {
-		cfg.Templates.SyncInterval = 3600
+	if cfg.Templates.SyncInterval == nil {
+		defaultInterval := 3600
+		cfg.Templates.SyncInterval = &defaultInterval
 	}
 	if cfg.Nginx.Image == "" {
 		cfg.Nginx.Image = "nginx:alpine"

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -13,7 +13,6 @@ import (
 	"text/template"
 )
 
-//go:embed */metadata.yml */docker-compose.yml
 //go:embed infra/*/metadata.yml infra/*/docker-compose.yml
 //go:embed infra/nginx/nginx.conf infra/nginx/nginx.lua.conf infra/nginx/default.conf infra/nginx/lua/*
 //go:embed welcome/index.html

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -13,19 +13,21 @@ func TestList(t *testing.T) {
 		t.Fatalf("List() error = %v", err)
 	}
 
-	if len(templates) == 0 {
-		t.Fatal("List() returned empty list, expected at least one template")
-	}
-
-	expectedTemplates := []string{"static", "wordpress", "laravel", "ghost", "nextjs", "astro", "node", "php"}
 	templateMap := make(map[string]bool)
 	for _, tmpl := range templates {
 		templateMap[tmpl] = true
 	}
 
-	for _, expected := range expectedTemplates {
+	for _, expected := range []string{"infra/postgres", "infra/mysql", "infra/mariadb", "infra/redis", "infra/nginx"} {
 		if !templateMap[expected] {
-			t.Errorf("List() missing expected template %q", expected)
+			t.Errorf("List() missing expected infra template %q", expected)
+		}
+	}
+
+	// App templates now live outside the binary and must not be embedded.
+	for _, gone := range []string{"wordpress", "laravel", "static", "ghost"} {
+		if templateMap[gone] {
+			t.Errorf("List() unexpectedly still embeds app template %q", gone)
 		}
 	}
 }
@@ -39,25 +41,21 @@ func TestGetMetadata(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name:         "static template",
-			templateID:   "static",
-			wantName:     "Static Site",
-			wantPriority: 100,
-			wantErr:      false,
-		},
-		{
-			name:         "wordpress template",
-			templateID:   "wordpress",
-			wantName:     "WordPress",
-			wantPriority: 100,
-			wantErr:      false,
-		},
-		{
-			name:         "laravel template",
-			templateID:   "laravel",
-			wantName:     "Laravel",
+			name:         "postgres infra template",
+			templateID:   "infra/postgres",
+			wantName:     "PostgreSQL",
 			wantPriority: 80,
-			wantErr:      false,
+		},
+		{
+			name:         "nginx infra template",
+			templateID:   "infra/nginx",
+			wantName:     "Nginx",
+			wantPriority: 100,
+		},
+		{
+			name:       "app template no longer embedded",
+			templateID: "wordpress",
+			wantErr:    true,
 		},
 		{
 			name:       "non-existent template",
@@ -73,7 +71,6 @@ func TestGetMetadata(t *testing.T) {
 				t.Errorf("GetMetadata() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-
 			if tt.wantErr {
 				return
 			}
@@ -85,11 +82,9 @@ func TestGetMetadata(t *testing.T) {
 			if err := yaml.Unmarshal(data, &metadata); err != nil {
 				t.Fatalf("Failed to parse metadata: %v", err)
 			}
-
 			if metadata.Name != tt.wantName {
 				t.Errorf("GetMetadata() name = %q, want %q", metadata.Name, tt.wantName)
 			}
-
 			if metadata.Priority != tt.wantPriority {
 				t.Errorf("GetMetadata() priority = %d, want %d", metadata.Priority, tt.wantPriority)
 			}
@@ -99,38 +94,24 @@ func TestGetMetadata(t *testing.T) {
 
 func TestGetCompose(t *testing.T) {
 	tests := []struct {
-		name           string
-		templateID     string
-		wantContains   []string
-		wantNotContain []string
-		wantErr        bool
+		name         string
+		templateID   string
+		wantContains []string
+		wantErr      bool
 	}{
 		{
-			name:       "static template",
-			templateID: "static",
+			name:       "postgres infra template",
+			templateID: "infra/postgres",
 			wantContains: []string{
 				"name: ${NAME}",
-				"nginx:alpine",
-				"expose:",
+				"postgres:",
 				"networks:",
-				"proxy:",
 			},
-			wantNotContain: []string{
-				"ports:",
-			},
-			wantErr: false,
 		},
 		{
-			name:       "wordpress template",
+			name:       "app template no longer embedded",
 			templateID: "wordpress",
-			wantContains: []string{
-				"name: ${NAME}",
-				"wordpress:",
-				"WORDPRESS_DB_HOST",
-				"expose:",
-				"networks:",
-			},
-			wantErr: false,
+			wantErr:    true,
 		},
 		{
 			name:       "non-existent template",
@@ -146,7 +127,6 @@ func TestGetCompose(t *testing.T) {
 				t.Errorf("GetCompose() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-
 			if tt.wantErr {
 				return
 			}
@@ -157,51 +137,16 @@ func TestGetCompose(t *testing.T) {
 					t.Errorf("GetCompose() content missing %q", want)
 				}
 			}
-
-			for _, notWant := range tt.wantNotContain {
-				if strings.Contains(content, notWant) {
-					t.Errorf("GetCompose() content should not contain %q", notWant)
-				}
-			}
 		})
 	}
 }
 
-func TestStaticTemplateHasFiles(t *testing.T) {
-	data, err := GetMetadata("static")
+func TestGetWelcomePage(t *testing.T) {
+	data, err := GetWelcomePage()
 	if err != nil {
-		t.Fatalf("GetMetadata() error = %v", err)
+		t.Fatalf("GetWelcomePage() error = %v", err)
 	}
-
-	var metadata struct {
-		Files []struct {
-			Path    string `yaml:"path"`
-			Content string `yaml:"content"`
-		} `yaml:"files"`
-	}
-
-	if err := yaml.Unmarshal(data, &metadata); err != nil {
-		t.Fatalf("Failed to parse metadata: %v", err)
-	}
-
-	if len(metadata.Files) == 0 {
-		t.Fatal("Static template should have files defined")
-	}
-
-	foundIndex := false
-	for _, f := range metadata.Files {
-		if f.Path == "html/index.html" {
-			foundIndex = true
-			if !strings.Contains(f.Content, "${NAME}") {
-				t.Error("index.html should contain ${NAME} placeholder")
-			}
-			if !strings.Contains(f.Content, "flatrun") {
-				t.Error("index.html should contain FlatRun branding")
-			}
-		}
-	}
-
-	if !foundIndex {
-		t.Error("Static template should have html/index.html file")
+	if len(data) == 0 {
+		t.Fatal("GetWelcomePage() returned empty content")
 	}
 }


### PR DESCRIPTION
Application templates were compiled into the agent, so changing one meant shipping a new agent. They now come from outside the binary: the agent syncs the catalog into the on-disk cache that deploys and listings already read, from the marketplace API when enabled, otherwise from [`flatrun/templates`](https://github.com/flatrun/templates). Infrastructure services and the welcome page stay embedded.

Part of #158.
