### PR TITLE
docs(config): Document templates block and cover sync-interval

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -147,3 +147,14 @@ backup:
     #     credential_id: <s3-credential-id>
     #     use_path_style: false
     #     enabled: true
+templates:
+    # Background resync period in seconds; 0 disables the resync loop.
+    sync_interval: 3600
+    github:
+        enabled: true
+        repo: flatrun/templates
+        ref: main
+    marketplace:
+        # Enable once the marketplace API is ready; it then takes priority over GitHub.
+        enabled: false
+        url: ""

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -1,0 +1,31 @@
+package config
+
+import "testing"
+
+func TestTemplatesSyncIntervalDefault(t *testing.T) {
+	var cfg Config
+	setDefaults(&cfg)
+	if cfg.Templates.SyncInterval == nil || *cfg.Templates.SyncInterval != 3600 {
+		t.Fatalf("unset sync_interval should default to 3600, got %v", cfg.Templates.SyncInterval)
+	}
+}
+
+func TestTemplatesSyncIntervalZeroDisablesAndSurvives(t *testing.T) {
+	zero := 0
+	cfg := Config{Templates: TemplatesConfig{SyncInterval: &zero}}
+	setDefaults(&cfg)
+	if cfg.Templates.SyncInterval == nil || *cfg.Templates.SyncInterval != 0 {
+		t.Fatalf("an explicit 0 must be preserved so the resync loop can be disabled, got %v", cfg.Templates.SyncInterval)
+	}
+}
+
+func TestTemplatesGitHubDefaults(t *testing.T) {
+	var cfg Config
+	setDefaults(&cfg)
+	if cfg.Templates.GitHub.Enabled == nil || !*cfg.Templates.GitHub.Enabled {
+		t.Error("github source should default to enabled")
+	}
+	if cfg.Templates.GitHub.Repo != "flatrun/templates" || cfg.Templates.GitHub.Ref != "main" {
+		t.Errorf("unexpected github defaults: %+v", cfg.Templates.GitHub)
+	}
+}

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -5,8 +5,11 @@ import "testing"
 func TestTemplatesSyncIntervalDefault(t *testing.T) {
 	var cfg Config
 	setDefaults(&cfg)
-	if cfg.Templates.SyncInterval == nil || *cfg.Templates.SyncInterval != 3600 {
-		t.Fatalf("unset sync_interval should default to 3600, got %v", cfg.Templates.SyncInterval)
+	if cfg.Templates.SyncInterval == nil {
+		t.Fatal("unset sync_interval should default to 3600, got nil")
+	}
+	if *cfg.Templates.SyncInterval != 3600 {
+		t.Fatalf("unset sync_interval should default to 3600, got %d", *cfg.Templates.SyncInterval)
 	}
 }
 
@@ -14,8 +17,11 @@ func TestTemplatesSyncIntervalZeroDisablesAndSurvives(t *testing.T) {
 	zero := 0
 	cfg := Config{Templates: TemplatesConfig{SyncInterval: &zero}}
 	setDefaults(&cfg)
-	if cfg.Templates.SyncInterval == nil || *cfg.Templates.SyncInterval != 0 {
-		t.Fatalf("an explicit 0 must be preserved so the resync loop can be disabled, got %v", cfg.Templates.SyncInterval)
+	if cfg.Templates.SyncInterval == nil {
+		t.Fatal("an explicit 0 must be preserved so the resync loop can be disabled, got nil")
+	}
+	if *cfg.Templates.SyncInterval != 0 {
+		t.Fatalf("an explicit 0 must be preserved, got %d", *cfg.Templates.SyncInterval)
 	}
 }
 


### PR DESCRIPTION
Two loose ends from #200: the `templates:` config block was missing from the example file, and a unit test for the sync-interval default (and the `0` disable path) didn't make it into that PR.

Closes #202.
