### PR TITLE
feat(logs): System logs, log rules, and AI triage

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -126,6 +126,9 @@ ai:
     api_key: your-gemini-api-key-here
     model: gemini-2.5-flash
     timeout: 1m0s
+    # Ceiling on log incidents the assistant may be asked to explain in a day.
+    # Unattended work is the only kind that can run up a bill unwatched.
+    triage_daily_cap: 25
 mcp:
     # Exposes the assistant's tool set to external MCP clients at /api/mcp. Every
     # call is authenticated and permission-gated exactly as the assistant is.

--- a/internal/api/internal_logs.go
+++ b/internal/api/internal_logs.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/flatrun/agent/pkg/models"
+	"github.com/gin-gonic/gin"
+)
+
+// streamInternalLogs hands a deployment's log lines to a built-in app as newline-delimited
+// JSON. The user-facing stream is a websocket because a browser cannot set headers; an app
+// can, so it gets the simpler transport and the same reader, which keeps log sources, the
+// service filter and level parsing in one implementation.
+func (s *Server) streamInternalLogs(c *gin.Context) {
+	if s.pluginToken == "" || c.GetHeader("X-Plugin-Token") != s.pluginToken {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	name := c.Query("deployment")
+	if name == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "deployment required"})
+		return
+	}
+
+	deployment, err := s.manager.GetDeployment(name)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Deployment not found"})
+		return
+	}
+
+	source, ok := resolveLogSource(deployment.Metadata, c.Query("source"))
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown log source"})
+		return
+	}
+
+	services, err := s.resolveLogServices(name, c.Query("service"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Replaying a day of history on every reconnect would re-raise handled incidents.
+	tail := 0
+	if v := c.Query("tail"); v != "" {
+		if n, parseErr := strconv.Atoi(v); parseErr == nil && n >= 0 {
+			tail = n
+		}
+	}
+
+	c.Writer.Header().Set("Content-Type", "application/x-ndjson")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.WriteHeader(http.StatusOK)
+	c.Writer.Flush()
+
+	ctx := c.Request.Context()
+	encoder := json.NewEncoder(c.Writer)
+
+	sink := func(line string) {
+		record := parseLogRecord(line)
+		if source.Type == models.LogSourceFile && record.Service == "" {
+			record.Service = source.Name
+		}
+		if err := encoder.Encode(logLine{Type: "log", Line: line, Record: record}); err != nil {
+			return
+		}
+		c.Writer.Flush()
+	}
+
+	if source.Type == models.LogSourceFile {
+		path, pathErr := resolveLogFilePath(deployment.Path, source.Path)
+		if pathErr != nil {
+			return
+		}
+		_ = streamFileLogs(ctx, path, tail, sink)
+		return
+	}
+	_ = s.manager.StreamDeploymentLogs(ctx, name, deployment.Path, tail, sink, services...)
+}

--- a/internal/api/internal_logs.go
+++ b/internal/api/internal_logs.go
@@ -51,6 +51,17 @@ func (s *Server) streamInternalLogs(c *gin.Context) {
 		}
 	}
 
+	// Everything that can fail is resolved before the status goes out, since a 200 followed by
+	// silence is indistinguishable from a stream that has nothing to say yet.
+	var filePath string
+	if source.Type == models.LogSourceFile {
+		filePath, err = resolveLogFilePath(deployment.Path, source.Path)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
 	c.Writer.Header().Set("Content-Type", "application/x-ndjson")
 	c.Writer.Header().Set("Cache-Control", "no-cache")
 	c.Writer.WriteHeader(http.StatusOK)
@@ -71,11 +82,7 @@ func (s *Server) streamInternalLogs(c *gin.Context) {
 	}
 
 	if source.Type == models.LogSourceFile {
-		path, pathErr := resolveLogFilePath(deployment.Path, source.Path)
-		if pathErr != nil {
-			return
-		}
-		_ = streamFileLogs(ctx, path, tail, sink)
+		_ = streamFileLogs(ctx, filePath, tail, sink)
 		return
 	}
 	_ = s.manager.StreamDeploymentLogs(ctx, name, deployment.Path, tail, sink, services...)

--- a/internal/api/internal_logs_stream_test.go
+++ b/internal/api/internal_logs_stream_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/flatrun/agent/internal/docker"
+	"github.com/gin-gonic/gin"
+)
+
+// A stream that answers 200 and then says nothing looks identical to one that has nothing to
+// report yet, so a source that cannot be read has to fail before the status goes out.
+func TestInternalLogStreamFailsBeforeAnsweringOK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	base, name := writeLogFilterDeployment(t)
+
+	metadata := "log_sources:\n  - id: escape\n    name: Escape\n    type: file\n    path: ../outside.log\n"
+	if err := os.WriteFile(filepath.Join(base, name, "service.yml"), []byte(metadata), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	server := &Server{manager: docker.NewManager(base), pluginToken: "plugin-secret"}
+	router := gin.New()
+	router.GET("/internal/logs/stream", server.streamInternalLogs)
+
+	req := httptest.NewRequest(http.MethodGet, "/internal/logs/stream?deployment="+name+"&source=escape", nil)
+	req.Header.Set("X-Plugin-Token", "plugin-secret")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/internal_logs_test.go
+++ b/internal/api/internal_logs_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The observability app reads this envelope to decide what is an incident. It is a wire
+// contract between two packages that are compiled together but talk over HTTP, so the shape
+// is pinned here and the app's watcher test decodes the same literal from the other side.
+func TestInternalLogEnvelopeShape(t *testing.T) {
+	raw := "web-1  | 2026-08-06T12:00:31.123456Z ERROR connection refused talking to redis"
+
+	encoded, err := json.Marshal(logLine{Type: "log", Line: raw, Record: parseLogRecord(raw)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded struct {
+		Type   string `json:"type"`
+		Line   string `json:"line"`
+		Record struct {
+			Timestamp string `json:"timestamp"`
+			Service   string `json:"service"`
+			Level     string `json:"level"`
+			Message   string `json:"message"`
+		} `json:"record"`
+	}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("the envelope must decode into the shape the watcher expects: %v", err)
+	}
+
+	if decoded.Type != "log" {
+		t.Errorf("type = %q, want log", decoded.Type)
+	}
+	if decoded.Line != raw {
+		t.Errorf("line should be the untouched original, got %q", decoded.Line)
+	}
+	if decoded.Record.Service != "web-1" {
+		t.Errorf("service should come from the compose prefix, got %q", decoded.Record.Service)
+	}
+	if decoded.Record.Level != "error" {
+		t.Errorf("level should be parsed to a canonical name, got %q", decoded.Record.Level)
+	}
+	// The compose prefix and the leading timestamp are stripped; the level word stays in the
+	// message, which is what the app fingerprints on.
+	if decoded.Record.Message != "ERROR connection refused talking to redis" {
+		t.Errorf("message should be the line without the compose prefix or timestamp, got %q", decoded.Record.Message)
+	}
+	if decoded.Record.Timestamp != "2026-08-06T12:00:31.123456Z" {
+		t.Errorf("timestamp should be lifted out of the line, got %q", decoded.Record.Timestamp)
+	}
+}

--- a/internal/api/internal_triage.go
+++ b/internal/api/internal_triage.go
@@ -1,0 +1,218 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/flatrun/agent/internal/ai"
+	"github.com/gin-gonic/gin"
+)
+
+// What one triage may cost. The app's funnel should keep it far below these; they exist so a
+// bug in the funnel cannot become a bill.
+const (
+	maxTriageContextLines = 40
+	maxTriageContextChars = 8000
+	maxTriageOutputTokens = 400
+	defaultTriageDailyCap = 25
+)
+
+// triageBudget counts triages against a daily ceiling. In-memory on purpose: this bounds a
+// runaway, and a restart clearing the count costs less than persisting a counter for it.
+type triageBudget struct {
+	mu    sync.Mutex
+	day   string
+	spent int
+	cap   int
+}
+
+func newTriageBudget(dailyCap int) *triageBudget {
+	if dailyCap <= 0 {
+		dailyCap = defaultTriageDailyCap
+	}
+	return &triageBudget{cap: dailyCap}
+}
+
+func (b *triageBudget) take(now time.Time) (int, int, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	today := now.UTC().Format("2006-01-02")
+	if b.day != today {
+		b.day = today
+		b.spent = 0
+	}
+	if b.spent >= b.cap {
+		return b.spent, b.cap, false
+	}
+	b.spent++
+	return b.spent, b.cap, true
+}
+
+type triageRequest struct {
+	RuleName   string   `json:"rule_name"`
+	Deployment string   `json:"deployment"`
+	Service    string   `json:"service"`
+	Level      string   `json:"level"`
+	Count      int      `json:"count"`
+	Sample     string   `json:"sample"`
+	Context    []string `json:"context"`
+}
+
+type triageResponse struct {
+	Summary    string `json:"summary,omitempty"`
+	Cause      string `json:"cause,omitempty"`
+	NextStep   string `json:"next_step,omitempty"`
+	Severity   string `json:"severity,omitempty"`
+	Confidence string `json:"confidence,omitempty"`
+}
+
+const triageSystemPrompt = `You triage one recurring error from a container's logs on a self-hosted server.
+
+You are given the failing line, a little of the output around it, and how often it has just occurred. You are not given the application's source, and you cannot run anything. Say what the evidence supports and no more.
+
+Reply with JSON only, no prose and no code fence, with these keys:
+  summary    one sentence an operator can read at 3am
+  cause      the most likely cause, or "" if the lines do not say
+  next_step  the single most useful thing to do next
+  severity   one of: low, medium, high
+  confidence one of: low, medium, high
+
+If the lines are not enough to tell what is wrong, say so in summary, leave cause empty, and set confidence to low. A wrong confident answer is worse than an honest empty one.`
+
+// triageLogIncident explains one log incident for a built-in app. The app's funnel decides
+// what is worth asking; this decides what the asking may cost.
+func (s *Server) triageLogIncident(c *gin.Context) {
+	if s.pluginToken == "" || c.GetHeader("X-Plugin-Token") != s.pluginToken {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	if s.aiProvider == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "the assistant is not configured"})
+		return
+	}
+
+	var req triageRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+	if strings.TrimSpace(req.Sample) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "nothing to triage"})
+		return
+	}
+
+	spent, cap, ok := s.triageBudget.take(time.Now())
+	if !ok {
+		// The ceiling lives here so it holds whatever asks for a triage.
+		c.JSON(http.StatusTooManyRequests, gin.H{
+			"error": fmt.Sprintf("daily triage budget spent (%d of %d)", spent, cap),
+		})
+		return
+	}
+
+	prompt := buildTriagePrompt(req, s.redactorFor(req.Deployment))
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 40*time.Second)
+	defer cancel()
+
+	resp, err := s.aiProvider.Complete(ctx, ai.Request{
+		Messages: []ai.Message{
+			{Role: "system", Content: triageSystemPrompt},
+			{Role: "user", Content: prompt},
+		},
+		MaxTokens:   maxTriageOutputTokens,
+		Temperature: 0,
+	})
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+
+	verdict, err := parseTriageVerdict(resp.Content)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"triage": verdict,
+		"usage":  resp.Usage,
+		"budget": gin.H{"spent": spent, "cap": cap},
+	})
+}
+
+func (s *Server) redactorFor(deployment string) *ai.Redactor {
+	secrets := s.systemSecretValues()
+	if deployment != "" {
+		secrets = s.deploymentSecretValues(deployment)
+	}
+	return ai.NewRedactor(secrets)
+}
+
+// buildTriagePrompt caps by line count and by total size, since one line of a base64 payload
+// can be larger than forty ordinary ones.
+func buildTriagePrompt(req triageRequest, redactor *ai.Redactor) string {
+	lines := req.Context
+	if len(lines) > maxTriageContextLines {
+		lines = lines[len(lines)-maxTriageContextLines:]
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Deployment: %s\n", req.Deployment)
+	if req.Service != "" {
+		fmt.Fprintf(&b, "Service: %s\n", req.Service)
+	}
+	if req.RuleName != "" {
+		fmt.Fprintf(&b, "Rule: %s\n", req.RuleName)
+	}
+	fmt.Fprintf(&b, "Level: %s\nOccurrences just now: %d\n\nFailing line:\n%s\n", req.Level, req.Count, req.Sample)
+	if len(lines) > 0 {
+		b.WriteString("\nSurrounding output:\n")
+		b.WriteString(strings.Join(lines, "\n"))
+	}
+
+	text := b.String()
+	if len(text) > maxTriageContextChars {
+		// The head carries the deployment, the rule and the failing line.
+		text = text[:maxTriageContextChars] + "\n[truncated]"
+	}
+	if redactor != nil {
+		text, _ = redactor.Redact(text)
+	}
+	return text
+}
+
+// parseTriageVerdict tolerates a code fence, the usual way a model ignores "JSON only".
+func parseTriageVerdict(content string) (triageResponse, error) {
+	text := strings.TrimSpace(content)
+	if fence := strings.Index(text, "```"); fence >= 0 {
+		rest := text[fence+3:]
+		if nl := strings.IndexByte(rest, '\n'); nl >= 0 {
+			rest = rest[nl+1:]
+		}
+		if end := strings.Index(rest, "```"); end >= 0 {
+			rest = rest[:end]
+		}
+		text = strings.TrimSpace(rest)
+	}
+	start := strings.IndexByte(text, '{')
+	end := strings.LastIndexByte(text, '}')
+	if start < 0 || end <= start {
+		return triageResponse{}, fmt.Errorf("the assistant did not answer with a verdict")
+	}
+
+	var verdict triageResponse
+	if err := json.Unmarshal([]byte(text[start:end+1]), &verdict); err != nil {
+		return triageResponse{}, fmt.Errorf("the assistant's verdict could not be read: %w", err)
+	}
+	if strings.TrimSpace(verdict.Summary) == "" {
+		return triageResponse{}, fmt.Errorf("the assistant's verdict had no summary")
+	}
+	return verdict, nil
+}

--- a/internal/api/internal_triage.go
+++ b/internal/api/internal_triage.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/flatrun/agent/internal/ai"
 	"github.com/gin-gonic/gin"
@@ -179,8 +180,13 @@ func buildTriagePrompt(req triageRequest, redactor *ai.Redactor) string {
 
 	text := b.String()
 	if len(text) > maxTriageContextChars {
-		// The head carries the deployment, the rule and the failing line.
-		text = text[:maxTriageContextChars] + "\n[truncated]"
+		// The head carries the deployment, the rule and the failing line. The cut walks back to
+		// a rune boundary so a log line in any language cannot end in half a character.
+		cut := maxTriageContextChars
+		for cut > 0 && !utf8.RuneStart(text[cut]) {
+			cut--
+		}
+		text = text[:cut] + "\n[truncated]"
 	}
 	if redactor != nil {
 		text, _ = redactor.Redact(text)

--- a/internal/api/internal_triage_test.go
+++ b/internal/api/internal_triage_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/flatrun/agent/internal/ai"
 	"github.com/flatrun/agent/pkg/config"
@@ -135,6 +136,30 @@ func TestTriagePromptIsCappedBySizeAndLines(t *testing.T) {
 	}
 	if len(provider.lastUser) > maxTriageContextChars+64 {
 		t.Errorf("prompt should be capped near %d chars, got %d", maxTriageContextChars, len(provider.lastUser))
+	}
+}
+
+// Logs are not all ASCII, and a prompt cut mid-character is not valid UTF-8.
+func TestTriagePromptCutsOnACharacterBoundary(t *testing.T) {
+	provider := &countingProvider{reply: `{"summary":"ok"}`}
+	router, _ := triageServer(t, provider, 10)
+
+	context := make([]string, 40)
+	for i := range context {
+		context[i] = strings.Repeat("é", 500)
+	}
+
+	w := triagePost(t, router, "plugin-secret", map[string]any{
+		"deployment": "shop",
+		"sample":     "boom",
+		"count":      3,
+		"context":    context,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !utf8.ValidString(provider.lastUser) {
+		t.Error("the truncated prompt is not valid UTF-8")
 	}
 }
 

--- a/internal/api/internal_triage_test.go
+++ b/internal/api/internal_triage_test.go
@@ -1,0 +1,202 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flatrun/agent/internal/ai"
+	"github.com/flatrun/agent/pkg/config"
+	"github.com/gin-gonic/gin"
+)
+
+// countingProvider stands in for the model so the tests exercise the budget, the caps and the
+// parsing rather than a network call. The package already has a stub for request shape; this
+// one counts calls, which is what the budget assertions turn on.
+type countingProvider struct {
+	calls    int
+	lastUser string
+	reply    string
+	err      error
+}
+
+func (p *countingProvider) Name() string { return "counting" }
+
+func (p *countingProvider) Complete(_ context.Context, req ai.Request) (*ai.Response, error) {
+	p.calls++
+	for _, m := range req.Messages {
+		if m.Role == "user" {
+			p.lastUser = m.Content
+		}
+	}
+	if p.err != nil {
+		return nil, p.err
+	}
+	return &ai.Response{Content: p.reply}, nil
+}
+
+func triageServer(t *testing.T, provider ai.Provider, dailyCap int) (*gin.Engine, *Server) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	server := &Server{
+		pluginToken:  "plugin-secret",
+		aiProvider:   provider,
+		triageBudget: newTriageBudget(dailyCap),
+		config:       &config.Config{},
+	}
+	router := gin.New()
+	router.POST("/internal/ai/triage", server.triageLogIncident)
+	return router, server
+}
+
+func triagePost(t *testing.T, router *gin.Engine, token string, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/internal/ai/triage", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("X-Plugin-Token", token)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// The daily ceiling is what stops a bug in the funnel becoming a bill, so it has to hold at
+// the endpoint rather than only in the app that calls it.
+func TestTriageRefusesOnceTheDailyBudgetIsSpent(t *testing.T) {
+	provider := &countingProvider{reply: `{"summary":"redis is unreachable","severity":"high","confidence":"medium"}`}
+	router, _ := triageServer(t, provider, 2)
+
+	body := map[string]any{"deployment": "shop", "sample": "connection refused", "count": 5}
+
+	for i := 0; i < 2; i++ {
+		if w := triagePost(t, router, "plugin-secret", body); w.Code != http.StatusOK {
+			t.Fatalf("call %d should be allowed, got %d: %s", i+1, w.Code, w.Body.String())
+		}
+	}
+
+	w := triagePost(t, router, "plugin-secret", body)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("the third call should be refused, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "budget") {
+		t.Errorf("the refusal should say why, got %s", w.Body.String())
+	}
+	if provider.calls != 2 {
+		t.Errorf("a refused triage must not reach the model, got %d calls", provider.calls)
+	}
+}
+
+func TestTriageRequiresThePluginToken(t *testing.T) {
+	provider := &countingProvider{reply: `{"summary":"x"}`}
+	router, _ := triageServer(t, provider, 10)
+
+	if w := triagePost(t, router, "", map[string]any{"sample": "x"}); w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without a token, got %d", w.Code)
+	}
+	if w := triagePost(t, router, "wrong", map[string]any{"sample": "x"}); w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with the wrong token, got %d", w.Code)
+	}
+	if provider.calls != 0 {
+		t.Errorf("an unauthorized call must not reach the model")
+	}
+}
+
+// One line of a base64 payload can be bigger than forty ordinary ones, so the prompt is
+// capped by size as well as by line count.
+func TestTriagePromptIsCappedBySizeAndLines(t *testing.T) {
+	provider := &countingProvider{reply: `{"summary":"ok"}`}
+	router, _ := triageServer(t, provider, 10)
+
+	context := make([]string, 500)
+	for i := range context {
+		context[i] = strings.Repeat("x", 500)
+	}
+
+	w := triagePost(t, router, "plugin-secret", map[string]any{
+		"deployment": "shop",
+		"sample":     "boom",
+		"count":      3,
+		"context":    context,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(provider.lastUser) > maxTriageContextChars+64 {
+		t.Errorf("prompt should be capped near %d chars, got %d", maxTriageContextChars, len(provider.lastUser))
+	}
+}
+
+// A model that wraps its JSON in a code fence is the common case, not an error.
+func TestTriageReadsAFencedVerdict(t *testing.T) {
+	provider := &countingProvider{reply: "```json\n{\"summary\":\"disk is full\",\"next_step\":\"free space\"}\n```"}
+	router, _ := triageServer(t, provider, 10)
+
+	w := triagePost(t, router, "plugin-secret", map[string]any{"deployment": "shop", "sample": "no space left"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Triage triageResponse `json:"triage"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Triage.Summary != "disk is full" {
+		t.Errorf("expected the fenced verdict to be read, got %+v", resp.Triage)
+	}
+}
+
+// A reply that is not a verdict is an error, not an incident annotated with prose.
+func TestTriageRejectsANonVerdictReply(t *testing.T) {
+	provider := &countingProvider{reply: "I would need to see the source code to say."}
+	router, _ := triageServer(t, provider, 10)
+
+	w := triagePost(t, router, "plugin-secret", map[string]any{"deployment": "shop", "sample": "boom"})
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502 for an unusable reply, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestTriageWithoutAProviderIsUnavailable(t *testing.T) {
+	router, _ := triageServer(t, nil, 10)
+	if w := triagePost(t, router, "plugin-secret", map[string]any{"sample": "x"}); w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when the assistant is not configured, got %d", w.Code)
+	}
+}
+
+// The budget rolls over rather than being spent forever.
+func TestTriageBudgetResetsDaily(t *testing.T) {
+	b := newTriageBudget(1)
+	day1 := time.Date(2026, 8, 6, 23, 59, 0, 0, time.UTC)
+	if _, _, ok := b.take(day1); !ok {
+		t.Fatal("the first call of the day should be allowed")
+	}
+	if _, _, ok := b.take(day1); ok {
+		t.Fatal("the second call should be refused")
+	}
+	day2 := time.Date(2026, 8, 7, 0, 1, 0, 0, time.UTC)
+	if _, _, ok := b.take(day2); !ok {
+		t.Fatal("the next day should start fresh")
+	}
+}
+
+func TestParseTriageVerdictRequiresASummary(t *testing.T) {
+	if _, err := parseTriageVerdict(`{"cause":"something"}`); err == nil {
+		t.Fatal("a verdict with no summary is not usable")
+	}
+	if _, err := parseTriageVerdict(fmt.Sprintf(`{"summary":%q}`, "ok")); err != nil {
+		t.Fatalf("a verdict with a summary should parse, got %v", err)
+	}
+}

--- a/internal/api/log_service_filter_test.go
+++ b/internal/api/log_service_filter_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/flatrun/agent/internal/docker"
+	"github.com/gin-gonic/gin"
+)
+
+func writeLogFilterDeployment(t *testing.T) (base string, name string) {
+	t.Helper()
+
+	base = t.TempDir()
+	name = "log-filter-app"
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	compose := "name: " + name + `
+services:
+  web:
+    image: nginx:alpine
+  worker:
+    image: alpine:latest
+`
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(compose), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return base, name
+}
+
+// A service name reaches compose as an argument, so it is checked against the compose file
+// before it gets there rather than passed through.
+func TestDeploymentLogsRejectUnknownService(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	base, name := writeLogFilterDeployment(t)
+	server := &Server{manager: docker.NewManager(base)}
+	router := gin.New()
+	router.GET("/deployments/:name/logs", server.getDeploymentLogs)
+
+	req := httptest.NewRequest(http.MethodGet, "/deployments/"+name+"/logs?service=--rm", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for an unknown service, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	for _, want := range []string{"web", "worker"} {
+		if !strings.Contains(resp.Error, want) {
+			t.Errorf("error should name the available service %q, got %q", want, resp.Error)
+		}
+	}
+}
+
+// A file source is one file the deployment writes, so asking for a service alongside it is
+// not an error: there is simply nothing per-service to narrow.
+func TestDeploymentLogsAcceptServiceAlongsideFileSource(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	base, name := writeLogFilterDeployment(t)
+	logPath := filepath.Join(base, name, "app.log")
+	if err := os.WriteFile(logPath, []byte("first line\nsecond line\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	metadata := `log_sources:
+  - id: app-file
+    name: App file
+    type: file
+    path: app.log
+`
+	if err := os.WriteFile(filepath.Join(base, name, "service.yml"), []byte(metadata), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	server := &Server{manager: docker.NewManager(base)}
+	router := gin.New()
+	router.GET("/deployments/:name/logs", server.getDeploymentLogs)
+
+	req := httptest.NewRequest(http.MethodGet, "/deployments/"+name+"/logs?source=app-file&service=web", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Logs string `json:"logs"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !strings.Contains(resp.Logs, "second line") {
+		t.Errorf("expected the file's contents, got %q", resp.Logs)
+	}
+}

--- a/internal/api/log_stream.go
+++ b/internal/api/log_stream.go
@@ -104,6 +104,14 @@ func (s *Server) streamDeploymentLogs(c *gin.Context) {
 		return
 	}
 
+	// A file source is one file the deployment writes, so there is nothing per-service to
+	// narrow it to; the filter only applies to container output.
+	services, err := s.resolveLogServices(name, c.Query("service"))
+	if err != nil {
+		sendError(conn, err.Error())
+		return
+	}
+
 	// The stream ends when the viewer disconnects, which is what stops the compose process
 	// rather than leaving it attached for the life of the agent.
 	ctx := c.Request.Context()
@@ -145,7 +153,7 @@ func (s *Server) streamDeploymentLogs(c *gin.Context) {
 			return
 		}
 	} else {
-		err = s.manager.StreamDeploymentLogs(ctx, name, deployment.Path, tail, sink)
+		err = s.manager.StreamDeploymentLogs(ctx, name, deployment.Path, tail, sink, services...)
 		if err != nil && ctx.Err() == nil {
 			sendError(conn, err.Error())
 			return

--- a/internal/api/log_truncate.go
+++ b/internal/api/log_truncate.go
@@ -58,6 +58,14 @@ func (s *Server) deleteDeploymentLogs(c *gin.Context) {
 		return
 	}
 
+	// Checked against the compose file for the same reason reading is: a name that matches
+	// nothing would otherwise report success while emptying nothing.
+	wantedServices, err := s.resolveLogServices(name, c.Query("service"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
 	if source.Type == models.LogSourceFile {
 		path, pathErr := resolveLogFilePath(deployment.Path, source.Path)
 		if pathErr != nil {
@@ -78,11 +86,10 @@ func (s *Server) deleteDeploymentLogs(c *gin.Context) {
 		return
 	}
 
-	wanted := c.Query("service")
 	var failures []string
 	cleared := 0
 	for _, svc := range services {
-		if wanted != "" && wanted != "all" && svc.Name != wanted {
+		if len(wantedServices) > 0 && wantedServices[0] != svc.Name {
 			continue
 		}
 		if svc.ContainerID == "" {

--- a/internal/api/log_truncate.go
+++ b/internal/api/log_truncate.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/flatrun/agent/internal/infra"
+	"github.com/flatrun/agent/pkg/models"
+	"github.com/gin-gonic/gin"
+)
+
+// truncateContainerLog empties what Docker has stored for a container.
+//
+// Docker keeps the log itself, so there is nothing to delete through the API: the file behind
+// LogPath is truncated in place. That keeps the container running and its file descriptor
+// valid, which deleting the file would not.
+func truncateContainerLog(container string) error {
+	if strings.TrimSpace(container) == "" {
+		return fmt.Errorf("no container to clear")
+	}
+
+	out, err := exec.Command("docker", "inspect", "--format", "{{.LogPath}}", container).Output()
+	if err != nil {
+		return fmt.Errorf("could not find the log for %s: %w", container, err)
+	}
+
+	path := strings.TrimSpace(string(out))
+	if path == "" {
+		// A container on journald, syslog or a remote driver has no file here to empty, and
+		// clearing whatever it does write is that system's business, not FlatRun's.
+		return fmt.Errorf("%s does not log to a file Docker owns, so there is nothing here to clear", container)
+	}
+	if err := os.Truncate(path, 0); err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("the agent is not allowed to clear %s: %w", path, err)
+		}
+		return err
+	}
+	return nil
+}
+
+// deleteDeploymentLogs empties the log the viewer is reading: the file for a file source, or
+// what Docker holds for the containers behind container output.
+func (s *Server) deleteDeploymentLogs(c *gin.Context) {
+	name := c.Param("name")
+
+	deployment, err := s.manager.GetDeployment(name)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Deployment not found"})
+		return
+	}
+
+	source, ok := resolveLogSource(deployment.Metadata, c.Query("source"))
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown log source"})
+		return
+	}
+
+	if source.Type == models.LogSourceFile {
+		path, pathErr := resolveLogFilePath(deployment.Path, source.Path)
+		if pathErr != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": pathErr.Error()})
+			return
+		}
+		if truncErr := os.Truncate(path, 0); truncErr != nil && !os.IsNotExist(truncErr) {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": truncErr.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"message": "Log cleared", "source": source.ID})
+		return
+	}
+
+	services, err := s.manager.GetComposeServices(name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	wanted := c.Query("service")
+	var failures []string
+	cleared := 0
+	for _, svc := range services {
+		if wanted != "" && wanted != "all" && svc.Name != wanted {
+			continue
+		}
+		if svc.ContainerID == "" {
+			continue
+		}
+		if truncErr := truncateContainerLog(svc.ContainerID); truncErr != nil {
+			failures = append(failures, truncErr.Error())
+			continue
+		}
+		cleared++
+	}
+
+	if cleared == 0 && len(failures) > 0 {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": strings.Join(failures, "; ")})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"message":  "Log cleared",
+		"source":   source.ID,
+		"cleared":  cleared,
+		"warnings": failures,
+	})
+}
+
+// deleteSystemLogs empties what Docker holds for a system service's container.
+func (s *Server) deleteSystemLogs(c *gin.Context) {
+	if s.infraManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Infrastructure not available"})
+		return
+	}
+
+	src, ok := s.resolveSystemLogSource(c.Query("source"))
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown log source"})
+		return
+	}
+
+	container := s.infraManager.ContainerName(src.Service)
+	if container == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown service"})
+		return
+	}
+
+	// Access and error share one container, so clearing either clears both. Saying so is
+	// better than quietly emptying more than was asked for.
+	if err := truncateContainerLog(container); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	message := "Log cleared"
+	if src.Stream != infra.LogStreamAll {
+		message = "Log cleared, including the other stream from the same container"
+	}
+	c.JSON(http.StatusOK, gin.H{"message": message, "source": src.ID})
+}

--- a/internal/api/log_truncate.go
+++ b/internal/api/log_truncate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/flatrun/agent/internal/infra"
@@ -17,17 +16,17 @@ import (
 // Docker keeps the log itself, so there is nothing to delete through the API: the file behind
 // LogPath is truncated in place. That keeps the container running and its file descriptor
 // valid, which deleting the file would not.
-func truncateContainerLog(container string) error {
+func (s *Server) truncateContainerLog(container string) error {
 	if strings.TrimSpace(container) == "" {
 		return fmt.Errorf("no container to clear")
 	}
 
-	out, err := exec.Command("docker", "inspect", "--format", "{{.LogPath}}", container).Output()
+	path, err := s.manager.ContainerLogPath(container)
 	if err != nil {
 		return fmt.Errorf("could not find the log for %s: %w", container, err)
 	}
 
-	path := strings.TrimSpace(string(out))
+	path = strings.TrimSpace(path)
 	if path == "" {
 		// A container on journald, syslog or a remote driver has no file here to empty, and
 		// clearing whatever it does write is that system's business, not FlatRun's.
@@ -89,7 +88,7 @@ func (s *Server) deleteDeploymentLogs(c *gin.Context) {
 		if svc.ContainerID == "" {
 			continue
 		}
-		if truncErr := truncateContainerLog(svc.ContainerID); truncErr != nil {
+		if truncErr := s.truncateContainerLog(svc.ContainerID); truncErr != nil {
 			failures = append(failures, truncErr.Error())
 			continue
 		}
@@ -129,7 +128,7 @@ func (s *Server) deleteSystemLogs(c *gin.Context) {
 
 	// Access and error share one container, so clearing either clears both. Saying so is
 	// better than quietly emptying more than was asked for.
-	if err := truncateContainerLog(container); err != nil {
+	if err := s.truncateContainerLog(container); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/api/log_truncate_test.go
+++ b/internal/api/log_truncate_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/flatrun/agent/internal/docker"
@@ -75,6 +76,23 @@ func TestDeleteDeploymentLogsRefusesAnEscapingPath(t *testing.T) {
 	}
 	if info, err := os.Stat(outside); err != nil || info.Size() == 0 {
 		t.Errorf("the file outside the deployment must be untouched")
+	}
+}
+
+// Emptying nothing at all should not read as success, which is what a mistyped service used to
+// get: 200 with a count of zero.
+func TestDeleteDeploymentLogsRejectsAnUnknownService(t *testing.T) {
+	base, name := writeLogFilterDeployment(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/deployments/"+name+"/logs?source=stdout&service=nope", nil)
+	w := httptest.NewRecorder()
+	truncateRouter(t, base).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "web") {
+		t.Errorf("the error should name the services that do exist, got %s", w.Body.String())
 	}
 }
 

--- a/internal/api/log_truncate_test.go
+++ b/internal/api/log_truncate_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/flatrun/agent/internal/docker"
+	"github.com/gin-gonic/gin"
+)
+
+func truncateRouter(t *testing.T, base string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	server := &Server{manager: docker.NewManager(base)}
+	router := gin.New()
+	router.DELETE("/deployments/:name/logs", server.deleteDeploymentLogs)
+	return router
+}
+
+func TestDeleteDeploymentLogsEmptiesTheFile(t *testing.T) {
+	base, name := writeLogFilterDeployment(t)
+	logPath := filepath.Join(base, name, "app.log")
+	if err := os.WriteFile(logPath, []byte("first line\nsecond line\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	metadata := `log_sources:
+  - id: app-file
+    name: App file
+    type: file
+    path: app.log
+`
+	if err := os.WriteFile(filepath.Join(base, name, "service.yml"), []byte(metadata), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/deployments/"+name+"/logs?source=app-file", nil)
+	w := httptest.NewRecorder()
+	truncateRouter(t, base).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("the file should still exist so the application keeps writing to it: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Errorf("expected an empty file, got %d bytes", info.Size())
+	}
+}
+
+// A source pointing outside the deployment is refused here as it is on read, so a crafted
+// source cannot turn this into "truncate any file on the host".
+func TestDeleteDeploymentLogsRefusesAnEscapingPath(t *testing.T) {
+	base, name := writeLogFilterDeployment(t)
+	outside := filepath.Join(base, "outside.log")
+	if err := os.WriteFile(outside, []byte("not yours\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	metadata := "log_sources:\n  - id: escape\n    name: Escape\n    type: file\n    path: ../outside.log\n"
+	if err := os.WriteFile(filepath.Join(base, name, "service.yml"), []byte(metadata), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/deployments/"+name+"/logs?source=escape", nil)
+	w := httptest.NewRecorder()
+	truncateRouter(t, base).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if info, err := os.Stat(outside); err != nil || info.Size() == 0 {
+		t.Errorf("the file outside the deployment must be untouched")
+	}
+}
+
+func TestDeleteDeploymentLogsRejectsAnUnknownSource(t *testing.T) {
+	base, name := writeLogFilterDeployment(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/deployments/"+name+"/logs?source=nope", nil)
+	w := httptest.NewRecorder()
+	truncateRouter(t, base).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/logfile.go
+++ b/internal/api/logfile.go
@@ -25,6 +25,25 @@ func resolveLogSource(meta *models.ServiceMetadata, id string) (models.LogSource
 	return meta.FindLogSource(id)
 }
 
+// resolveLogServices turns the requested service into the compose service list to read logs
+// from: none for "" or "all", meaning every service. The name is checked against the compose
+// file rather than passed through, so a caller cannot smuggle arguments into compose.
+func (s *Server) resolveLogServices(name, service string) ([]string, error) {
+	if service == "" || service == "all" {
+		return nil, nil
+	}
+	names, err := s.manager.GetComposeServiceNames(name)
+	if err != nil {
+		return nil, err
+	}
+	for _, sn := range names {
+		if sn == service {
+			return []string{service}, nil
+		}
+	}
+	return nil, fmt.Errorf("service '%s' not found in compose file, available: %s", service, strings.Join(names, ", "))
+}
+
 var errLogPathEscapes = errors.New("log source path escapes the deployment directory")
 
 // readAllCap bounds how much a tail<=0 ("all") read pulls into memory.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -104,6 +104,7 @@ type Server struct {
 	certRenewer        *ssl.Renewer
 	planStore          *plan.Store
 	aiProvider         ai.Provider
+	triageBudget       *triageBudget
 	aiSessions         *ai.SessionStore
 	aiAgents           *ai.AgentStore
 	mcpHandler         http.Handler
@@ -390,6 +391,7 @@ func New(cfg *config.Config, configPath string) *Server {
 	} else if aiErr != ai.ErrDisabled {
 		log.Printf("Warning: failed to initialize AI provider: %v", aiErr)
 	}
+	s.triageBudget = newTriageBudget(cfg.AI.TriageDailyCap)
 
 	if backupManager != nil {
 		if err := s.applyBackupDestinations(); err != nil {
@@ -874,6 +876,10 @@ func (s *Server) setupRoutes() {
 
 		// Plugin-emitted notifications (authenticated by the per-run plugin token).
 		api.POST("/internal/notify/emit", s.emitNotification)
+		// Log lines and triage for built-in apps, on the same plugin token. Both keep one
+		// implementation in the agent rather than a second one inside every app.
+		api.GET("/internal/logs/stream", s.streamInternalLogs)
+		api.POST("/internal/ai/triage", s.triageLogIncident)
 
 		// Ingest endpoints (no auth - called by nginx Lua)
 		api.POST("/security/events/ingest", s.ingestSecurityEvent)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2505,6 +2505,14 @@ func (s *Server) getDeploymentLogs(c *gin.Context) {
 		return
 	}
 
+	// A file source is one file the deployment writes, so there is nothing per-service to
+	// narrow it to; the filter only applies to container output.
+	services, err := s.resolveLogServices(name, c.Query("service"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
 	var logs string
 	if source.Type == models.LogSourceFile {
 		path, err := resolveLogFilePath(deployment.Path, source.Path)
@@ -2518,7 +2526,7 @@ func (s *Server) getDeploymentLogs(c *gin.Context) {
 			return
 		}
 	} else {
-		logs, err = s.manager.GetDeploymentLogs(name, tail)
+		logs, err = s.manager.GetDeploymentLogs(name, tail, services...)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
@@ -2530,6 +2538,7 @@ func (s *Server) getDeploymentLogs(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"name":    name,
 		"source":  source.ID,
+		"service": strings.Join(services, ","),
 		"logs":    logs,
 		"records": parseLogRecords(logs),
 	})

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -470,6 +470,7 @@ func (s *Server) setupRoutes() {
 			protected.GET("/deployments/:name/jobs/:jobId", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelRead), s.getDeploymentJob)
 			protected.POST("/deployments/:name/actions/:actionId", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.executeQuickAction)
 			protected.GET("/deployments/:name/logs", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelRead), s.getDeploymentLogs)
+			protected.DELETE("/deployments/:name/logs", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.deleteDeploymentLogs)
 			protected.GET("/deployments/:name/log-sources", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelRead), s.getDeploymentLogSources)
 			protected.PUT("/deployments/:name/log-sources", s.authMiddleware.RequirePermission(auth.PermDeploymentsWrite), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelWrite), s.updateDeploymentLogSources)
 			protected.GET("/deployments/:name/compose", s.authMiddleware.RequirePermission(auth.PermDeploymentsRead), s.authMiddleware.RequireDeploymentAccess(auth.AccessLevelRead), s.getDeploymentCompose)
@@ -681,6 +682,7 @@ func (s *Server) setupRoutes() {
 			protected.GET("/infrastructure/:name/logs", s.authMiddleware.RequirePermission(auth.PermInfrastructureRead), s.getInfraServiceLogs)
 			protected.GET("/system/logs/sources", s.authMiddleware.RequirePermission(auth.PermInfrastructureRead), s.listSystemLogSources)
 			protected.GET("/system/logs", s.authMiddleware.RequirePermission(auth.PermInfrastructureRead), s.getSystemLogs)
+			protected.DELETE("/system/logs", s.authMiddleware.RequirePermission(auth.PermInfrastructureWrite), s.deleteSystemLogs)
 			protected.POST("/infrastructure/migrate/:name", s.authMiddleware.RequirePermission(auth.PermInfrastructureWrite), s.migrateToInfrastructure)
 
 			// Registry endpoints

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -426,6 +426,7 @@ func (s *Server) setupRoutes() {
 		api.GET("/system/terminal/interactive", s.systemTerminalInteractive)
 		api.GET("/deployments/:name/jobs/:jobId/stream", s.streamDeploymentJob)
 		api.GET("/deployments/:name/logs/stream", s.streamDeploymentLogs)
+		api.GET("/system/logs/stream", s.streamSystemLogs)
 
 		// Setup endpoints (public, gated by setup state)
 		setupGroup := api.Group("/setup")
@@ -678,6 +679,8 @@ func (s *Server) setupRoutes() {
 			protected.POST("/infrastructure/:name/stop", s.authMiddleware.RequirePermission(auth.PermInfrastructureWrite), s.stopInfraService)
 			protected.POST("/infrastructure/:name/restart", s.authMiddleware.RequirePermission(auth.PermInfrastructureWrite), s.restartInfraService)
 			protected.GET("/infrastructure/:name/logs", s.authMiddleware.RequirePermission(auth.PermInfrastructureRead), s.getInfraServiceLogs)
+			protected.GET("/system/logs/sources", s.authMiddleware.RequirePermission(auth.PermInfrastructureRead), s.listSystemLogSources)
+			protected.GET("/system/logs", s.authMiddleware.RequirePermission(auth.PermInfrastructureRead), s.getSystemLogs)
 			protected.POST("/infrastructure/migrate/:name", s.authMiddleware.RequirePermission(auth.PermInfrastructureWrite), s.migrateToInfrastructure)
 
 			// Registry endpoints

--- a/internal/api/system_logs.go
+++ b/internal/api/system_logs.go
@@ -1,0 +1,337 @@
+package api
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/flatrun/agent/internal/auth"
+	"github.com/flatrun/agent/internal/contextkeys"
+	"github.com/flatrun/agent/internal/infra"
+	"github.com/flatrun/agent/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+// systemLogSource is one place the host itself writes logs, as opposed to a deployment: the
+// proxy's access and error logs, and whatever shared infrastructure is running.
+type systemLogSource struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Service string `json:"service"`
+	Stream  string `json:"stream"`
+	// ByDeployment says whether lines carry which deployment they belong to, which only the
+	// proxy's access log does.
+	ByDeployment bool `json:"by_deployment"`
+}
+
+func systemLogSourcesFor(services []models.InfraService) []systemLogSource {
+	var sources []systemLogSource
+	for _, svc := range services {
+		switch svc.Type {
+		case models.InfraTypeNginx:
+			sources = append(sources,
+				systemLogSource{ID: "nginx-access", Name: "nginx access", Service: svc.Name, Stream: infra.LogStreamStdout, ByDeployment: true},
+				systemLogSource{ID: "nginx-error", Name: "nginx error", Service: svc.Name, Stream: infra.LogStreamStderr},
+			)
+		default:
+			sources = append(sources, systemLogSource{
+				ID:      svc.Name,
+				Name:    svc.Name,
+				Service: svc.Name,
+				Stream:  infra.LogStreamAll,
+			})
+		}
+	}
+	return sources
+}
+
+func (s *Server) systemLogSources() ([]systemLogSource, error) {
+	services, err := s.infraManager.ListServices()
+	if err != nil {
+		return nil, err
+	}
+	return systemLogSourcesFor(services), nil
+}
+
+func (s *Server) resolveSystemLogSource(id string) (systemLogSource, bool) {
+	sources, err := s.systemLogSources()
+	if err != nil {
+		return systemLogSource{}, false
+	}
+	if id == "" && len(sources) > 0 {
+		return sources[0], true
+	}
+	for _, src := range sources {
+		if src.ID == id {
+			return src, true
+		}
+	}
+	return systemLogSource{}, false
+}
+
+func (s *Server) listSystemLogSources(c *gin.Context) {
+	sources, err := s.systemLogSources()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if sources == nil {
+		sources = []systemLogSource{}
+	}
+	c.JSON(http.StatusOK, gin.H{"sources": sources})
+}
+
+// deploymentHostMatcher keeps only the access lines belonging to one deployment, by matching
+// the host the request asked for against the domains that deployment serves. The host is a
+// field of its own in the access log, so this never matches a domain that merely appears in a
+// referer or a user agent.
+func (s *Server) deploymentHostMatcher(name string) (func(string) bool, error) {
+	deployment, err := s.manager.GetDeployment(name)
+	if err != nil {
+		return nil, err
+	}
+
+	hosts := map[string]struct{}{}
+	if deployment.Metadata != nil {
+		for _, d := range deployment.Metadata.GetDomains() {
+			if d.Domain != "" {
+				hosts[strings.ToLower(d.Domain)] = struct{}{}
+			}
+		}
+	}
+	if len(hosts) == 0 {
+		// Nothing is served for this deployment, so no access line can belong to it.
+		return func(string) bool { return false }, nil
+	}
+
+	return func(line string) bool {
+		// Lines arrive with docker's timestamp ahead of nginx's own fields, so the host is
+		// one of the first two fields depending on whether that prefix is present.
+		fields := strings.Fields(line)
+		for i := 0; i < len(fields) && i < 2; i++ {
+			host := strings.ToLower(strings.TrimSuffix(fields[i], ":443"))
+			host = strings.TrimSuffix(host, ":80")
+			if _, ok := hosts[host]; ok {
+				return true
+			}
+		}
+		return false
+	}, nil
+}
+
+// systemLogLineFilter combines every reason to drop a line into one test.
+func (s *Server) systemLogLineFilter(c *gin.Context, src systemLogSource) (func(string) bool, bool) {
+	filter := strings.ToLower(c.Query("filter"))
+	deployment := c.Query("deployment")
+
+	var matchesDeployment func(string) bool
+	if deployment != "" {
+		if !src.ByDeployment {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "this log source does not say which deployment a line belongs to"})
+			return nil, false
+		}
+		if !s.requireDeploymentAccess(c, deployment, auth.AccessLevelRead) {
+			return nil, false
+		}
+		matcher, err := s.deploymentHostMatcher(deployment)
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Deployment not found"})
+			return nil, false
+		}
+		matchesDeployment = matcher
+	}
+
+	return func(line string) bool {
+		if filter != "" && !strings.Contains(strings.ToLower(line), filter) {
+			return false
+		}
+		if matchesDeployment != nil && !matchesDeployment(line) {
+			return false
+		}
+		return true
+	}, true
+}
+
+func (s *Server) getSystemLogs(c *gin.Context) {
+	if s.infraManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Infrastructure not available"})
+		return
+	}
+
+	src, ok := s.resolveSystemLogSource(c.Query("source"))
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown log source"})
+		return
+	}
+
+	tail, err := strconv.Atoi(c.DefaultQuery("tail", "100"))
+	if err != nil {
+		tail = 100
+	}
+
+	keep, ok := s.systemLogLineFilter(c, src)
+	if !ok {
+		return
+	}
+
+	logs, err := s.infraManager.ServiceLogs(src.Service, tail, src.Stream)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	kept := make([]string, 0)
+	for _, line := range strings.Split(strings.TrimRight(logs, "\n"), "\n") {
+		if line == "" || !keep(line) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	text := strings.Join(kept, "\n")
+
+	records := parseLogRecords(text)
+	for i := range records {
+		if records[i].Service == "" {
+			records[i].Service = src.Name
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"source":  src.ID,
+		"logs":    text,
+		"records": records,
+	})
+}
+
+// streamSystemLogs follows a system log source over a websocket until the viewer goes away,
+// the same way a deployment's logs are followed.
+func (s *Server) streamSystemLogs(c *gin.Context) {
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		log.Printf("system log stream: websocket upgrade failed: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	// The browser cannot set headers on a websocket, so the token arrives as the first
+	// message, the same way the terminal does it.
+	if s.authMiddleware.IsAuthEnabled() {
+		_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			sendError(conn, "Authentication timeout")
+			return
+		}
+
+		var incoming authMessage
+		if err := json.Unmarshal(message, &incoming); err != nil || incoming.Type != "auth" {
+			sendError(conn, "Invalid auth message format")
+			return
+		}
+
+		actor, err := s.authMiddleware.ActorForTokenString(incoming.Token, c.ClientIP())
+		if err != nil {
+			sendError(conn, "Invalid or expired token")
+			return
+		}
+		c.Set(contextkeys.Actor, actor)
+		_ = conn.SetReadDeadline(time.Time{})
+	} else {
+		c.Set(contextkeys.Actor, &auth.ActorContext{Type: "anonymous", Role: auth.RoleAdmin})
+	}
+
+	actor := auth.GetActorFromContext(c)
+	if actor == nil || !actor.HasPermission(auth.PermInfrastructureRead) {
+		sendError(conn, "Permission denied: infrastructure:read required")
+		return
+	}
+
+	if s.authMiddleware.IsAuthEnabled() {
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"auth_success"}`)); err != nil {
+			return
+		}
+	}
+
+	if s.infraManager == nil {
+		sendError(conn, "Infrastructure not available")
+		return
+	}
+
+	src, ok := s.resolveSystemLogSource(c.Query("source"))
+	if !ok {
+		sendError(conn, "Unknown log source")
+		return
+	}
+
+	tail := 100
+	if v := c.Query("tail"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			tail = n
+		}
+	}
+
+	// A deployment's own domains decide which access lines it may see, so the same check the
+	// snapshot makes applies here; the socket carries no body to report it in.
+	deployment := c.Query("deployment")
+	var matchesDeployment func(string) bool
+	if deployment != "" {
+		if !src.ByDeployment {
+			sendError(conn, "This log source does not say which deployment a line belongs to")
+			return
+		}
+		if actor.Role != auth.RoleAdmin && !actor.CanAccessDeployment(deployment, auth.AccessLevelRead) {
+			sendError(conn, "No access to this deployment")
+			return
+		}
+		matcher, err := s.deploymentHostMatcher(deployment)
+		if err != nil {
+			sendError(conn, "Deployment not found")
+			return
+		}
+		matchesDeployment = matcher
+	}
+
+	filter := strings.ToLower(c.Query("filter"))
+
+	ctx := c.Request.Context()
+
+	// Nothing is expected from the viewer, but reading is how a closed socket is noticed.
+	go func() {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				conn.Close()
+				return
+			}
+		}
+	}()
+
+	sink := func(line string) {
+		if filter != "" && !strings.Contains(strings.ToLower(line), filter) {
+			return
+		}
+		if matchesDeployment != nil && !matchesDeployment(line) {
+			return
+		}
+		record := parseLogRecord(line)
+		if record.Service == "" {
+			record.Service = src.Name
+		}
+		payload, err := json.Marshal(logLine{Type: "log", Line: line, Record: record})
+		if err != nil {
+			return
+		}
+		_ = conn.WriteMessage(websocket.TextMessage, payload)
+	}
+
+	if err := s.infraManager.StreamServiceLogs(ctx, src.Service, tail, src.Stream, sink); err != nil && ctx.Err() == nil {
+		sendError(conn, err.Error())
+		return
+	}
+
+	_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"end"}`))
+}

--- a/internal/api/system_logs_integration_test.go
+++ b/internal/api/system_logs_integration_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/flatrun/agent/internal/docker"
+	"github.com/flatrun/agent/templates"
+)
+
+// TestNginxAccessLineNamesItsDeployment runs the real base config in nginx, makes a real
+// request through it, and matches the line it wrote. Reading the proxy's log per deployment
+// only works if the host survives into the line, which is a property of nginx's own
+// formatting rather than anything this package can assert on its own.
+func TestNginxAccessLineNamesItsDeployment(t *testing.T) {
+	if testing.Short() {
+		t.Skip("starts a real container")
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker unavailable")
+	}
+	if err := exec.Command("docker", "info").Run(); err != nil {
+		t.Skipf("docker daemon unreachable: %v", err)
+	}
+
+	conf, err := templates.GetNginxConfigWithData(false, templates.NginxConfigData{})
+	if err != nil {
+		t.Fatalf("rendering the base config failed: %v", err)
+	}
+
+	confDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(confDir, "nginx.conf"), conf, 0644); err != nil {
+		t.Fatal(err)
+	}
+	siteDir := filepath.Join(confDir, "conf.d")
+	if err := os.MkdirAll(siteDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// The base config includes a rate limit file and whatever vhosts exist, so both have to
+	// be there for nginx to start at all.
+	if err := os.WriteFile(filepath.Join(siteDir, "rate_limits.conf"), []byte("# none\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	site := `server {
+    listen 80 default_server;
+    server_name _;
+    location / { return 200 "ok"; }
+}
+`
+	if err := os.WriteFile(filepath.Join(siteDir, "site.conf"), []byte(site), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	const container = "flatrun-accesslog-integration"
+	_ = exec.Command("docker", "rm", "-f", container).Run()
+	run := exec.Command("docker", "run", "-d", "--name", container,
+		"-v", filepath.Join(confDir, "nginx.conf")+":/etc/nginx/nginx.conf:ro",
+		"-v", siteDir+":/etc/nginx/conf.d:ro",
+		"nginx:alpine")
+	if out, err := run.CombinedOutput(); err != nil {
+		t.Fatalf("starting nginx failed: %v: %s", err, out)
+	}
+	t.Cleanup(func() {
+		if out, err := exec.Command("docker", "rm", "-f", container).CombinedOutput(); err != nil {
+			t.Logf("cleanup: %v: %s", err, out)
+		}
+	})
+
+	const domain = "shop.example.test"
+	req := exec.Command("docker", "exec", container,
+		"wget", "-qO-", "--header", "Host: "+domain, "http://127.0.0.1/")
+	if out, err := req.CombinedOutput(); err != nil {
+		logs, _ := exec.Command("docker", "logs", container).CombinedOutput()
+		t.Fatalf("request through nginx failed: %v: %s (container: %s)", err, out, logs)
+	}
+
+	// The access log is buffered and flushed on a timer, so the line is not there the moment
+	// the request returns. The agent reads these logs with docker's timestamps in front, so
+	// that is the shape the matcher has to cope with.
+	readAccessLine := func(args ...string) string {
+		var last []byte
+		for attempt := 0; attempt < 20; attempt++ {
+			out, err := exec.Command("docker", append([]string{"logs"}, append(args, container)...)...).CombinedOutput()
+			if err != nil {
+				t.Fatalf("reading nginx logs failed: %v: %s", err, out)
+			}
+			last = out
+			for _, line := range strings.Split(string(out), "\n") {
+				if strings.Contains(line, "GET /") {
+					return line
+				}
+			}
+			time.Sleep(time.Second)
+		}
+		t.Fatalf("nginx wrote no access line: %s", last)
+		return ""
+	}
+
+	stamped := readAccessLine("--timestamps")
+	accessLine := readAccessLine()
+
+	// A deployment serving that domain, as the agent reads it off disk.
+	base := t.TempDir()
+	dir := filepath.Join(base, "shop")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte("name: shop\nservices:\n  web:\n    image: nginx:alpine\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	metadata := "domains:\n  - domain: " + domain + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "service.yml"), []byte(metadata), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	server := &Server{manager: docker.NewManager(base)}
+	matches, err := server.deploymentHostMatcher("shop")
+	if err != nil {
+		t.Fatalf("building the matcher failed: %v", err)
+	}
+	if !matches(accessLine) {
+		t.Errorf("the deployment's own access line was filtered out: %q", accessLine)
+	}
+	if !matches(stamped) {
+		t.Errorf("the deployment's own access line was filtered out once timestamped: %q", stamped)
+	}
+
+	// A second deployment on another domain must not see it.
+	other := filepath.Join(base, "blog")
+	if err := os.MkdirAll(other, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(other, "docker-compose.yml"), []byte("name: blog\nservices:\n  web:\n    image: nginx:alpine\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(other, "service.yml"), []byte("domains:\n  - domain: blog.example.test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	blogMatches, err := server.deploymentHostMatcher("blog")
+	if err != nil {
+		t.Fatalf("building the matcher failed: %v", err)
+	}
+	if blogMatches(accessLine) || blogMatches(stamped) {
+		t.Errorf("another deployment's access line was let through: %q", accessLine)
+	}
+}

--- a/internal/api/system_logs_integration_test.go
+++ b/internal/api/system_logs_integration_test.go
@@ -70,12 +70,22 @@ func TestNginxAccessLineNamesItsDeployment(t *testing.T) {
 		}
 	})
 
+	// docker run returns as soon as the container is created, which is before nginx has
+	// finished its entrypoint and bound the port, so the request is retried until it answers.
 	const domain = "shop.example.test"
-	req := exec.Command("docker", "exec", container,
-		"wget", "-qO-", "--header", "Host: "+domain, "http://127.0.0.1/")
-	if out, err := req.CombinedOutput(); err != nil {
+	var reqOut []byte
+	var reqErr error
+	for attempt := 0; attempt < 30; attempt++ {
+		req := exec.Command("docker", "exec", container,
+			"wget", "-qO-", "--header", "Host: "+domain, "http://127.0.0.1/")
+		if reqOut, reqErr = req.CombinedOutput(); reqErr == nil {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if reqErr != nil {
 		logs, _ := exec.Command("docker", "logs", container).CombinedOutput()
-		t.Fatalf("request through nginx failed: %v: %s (container: %s)", err, out, logs)
+		t.Fatalf("request through nginx failed: %v: %s (container: %s)", reqErr, reqOut, logs)
 	}
 
 	// The access log is buffered and flushed on a timer, so the line is not there the moment

--- a/internal/api/system_logs_test.go
+++ b/internal/api/system_logs_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/flatrun/agent/internal/infra"
+	"github.com/flatrun/agent/pkg/config"
+	"github.com/gin-gonic/gin"
+)
+
+func systemLogsRouter(cfg *config.Config, register func(*gin.Engine, *Server)) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	server := &Server{infraManager: infra.NewManager(cfg)}
+	router := gin.New()
+	register(router, server)
+	return router
+}
+
+// The proxy writes its access log to stdout and its error log to stderr, so the two are
+// offered apart; only the access log carries the host a request asked for, which is the one
+// thing that can be matched back to a deployment.
+func TestSystemLogSourcesSplitNginxAccessFromError(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Nginx.Enabled = true
+	cfg.Nginx.ContainerName = "flatrun-nginx"
+	cfg.Infrastructure.Redis.Enabled = true
+	cfg.Infrastructure.Redis.Container = "flatrun-redis"
+
+	router := systemLogsRouter(cfg, func(r *gin.Engine, s *Server) {
+		r.GET("/system/logs/sources", s.listSystemLogSources)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/system/logs/sources", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Sources []systemLogSource `json:"sources"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	byID := map[string]systemLogSource{}
+	for _, src := range resp.Sources {
+		byID[src.ID] = src
+	}
+
+	access, ok := byID["nginx-access"]
+	if !ok {
+		t.Fatalf("no access log source offered: %+v", resp.Sources)
+	}
+	if access.Stream != infra.LogStreamStdout || !access.ByDeployment {
+		t.Errorf("the access log should be readable per deployment from stdout, got %+v", access)
+	}
+
+	errSrc, ok := byID["nginx-error"]
+	if !ok {
+		t.Fatalf("no error log source offered: %+v", resp.Sources)
+	}
+	if errSrc.Stream != infra.LogStreamStderr || errSrc.ByDeployment {
+		t.Errorf("the error log says nothing about which deployment a line is from, got %+v", errSrc)
+	}
+
+	if _, ok := byID["redis"]; !ok {
+		t.Errorf("shared infrastructure should be readable too: %+v", resp.Sources)
+	}
+}
+
+// Asking to see one deployment's requests in a log that never records the host would hand
+// back an arbitrary subset, so it is refused rather than silently ignored.
+func TestSystemLogsRejectDeploymentFilterOnASourceThatCannotAnswerIt(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Nginx.Enabled = true
+	cfg.Nginx.ContainerName = "flatrun-nginx"
+
+	router := systemLogsRouter(cfg, func(r *gin.Engine, s *Server) {
+		r.GET("/system/logs", s.getSystemLogs)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/system/logs?source=nginx-error&deployment=shop", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestSystemLogsRejectUnknownSource(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Nginx.Enabled = true
+	cfg.Nginx.ContainerName = "flatrun-nginx"
+
+	router := systemLogsRouter(cfg, func(r *gin.Engine, s *Server) {
+		r.GET("/system/logs", s.getSystemLogs)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/system/logs?source=not-a-source", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/auth/models.go
+++ b/internal/auth/models.go
@@ -21,7 +21,6 @@ const (
 	AccessLevelAdmin = "admin"
 )
 
-
 func ValidAccessLevel(level string) bool {
 	return level == AccessLevelRead || level == AccessLevelWrite || level == AccessLevelAdmin
 }
@@ -88,21 +87,21 @@ func (d *DeploymentAccess) UnmarshalJSON(data []byte) error {
 }
 
 type APIKey struct {
-	ID          int64             `json:"id"`
-	KeyID       string            `json:"key_id"`
-	UserID      int64             `json:"user_id"`
-	Name        string            `json:"name"`
-	Description string            `json:"description,omitempty"`
-	KeyHash     string            `json:"-"`
-	KeyPrefix   string            `json:"key_prefix"`
-	Role        Role              `json:"role,omitempty"`
-	Permissions []string          `json:"permissions,omitempty"`
-	Deployments DeploymentAccess  `json:"deployments,omitempty"`
-	ExpiresAt   time.Time         `json:"expires_at,omitempty"`
-	LastUsedAt  time.Time         `json:"last_used_at,omitempty"`
-	LastUsedIP  string            `json:"last_used_ip,omitempty"`
-	IsActive    bool              `json:"is_active"`
-	CreatedAt   time.Time         `json:"created_at"`
+	ID          int64            `json:"id"`
+	KeyID       string           `json:"key_id"`
+	UserID      int64            `json:"user_id"`
+	Name        string           `json:"name"`
+	Description string           `json:"description,omitempty"`
+	KeyHash     string           `json:"-"`
+	KeyPrefix   string           `json:"key_prefix"`
+	Role        Role             `json:"role,omitempty"`
+	Permissions []string         `json:"permissions,omitempty"`
+	Deployments DeploymentAccess `json:"deployments,omitempty"`
+	ExpiresAt   time.Time        `json:"expires_at,omitempty"`
+	LastUsedAt  time.Time        `json:"last_used_at,omitempty"`
+	LastUsedIP  string           `json:"last_used_ip,omitempty"`
+	IsActive    bool             `json:"is_active"`
+	CreatedAt   time.Time        `json:"created_at"`
 }
 
 type Session struct {
@@ -127,13 +126,13 @@ type UserDeployment struct {
 }
 
 type ActorContext struct {
-	Type        string             `json:"type"`
-	UserID      int64              `json:"user_id,omitempty"`
-	User        *User              `json:"user,omitempty"`
-	APIKey      *APIKey            `json:"api_key,omitempty"`
-	Role        Role               `json:"role"`
-	Permissions []string           `json:"permissions,omitempty"`
-	Deployments map[string]string  `json:"deployments,omitempty"`
+	Type        string            `json:"type"`
+	UserID      int64             `json:"user_id,omitempty"`
+	User        *User             `json:"user,omitempty"`
+	APIKey      *APIKey           `json:"api_key,omitempty"`
+	Role        Role              `json:"role"`
+	Permissions []string          `json:"permissions,omitempty"`
+	Deployments map[string]string `json:"deployments,omitempty"`
 }
 
 func (a *ActorContext) HasPermission(p Permission) bool {

--- a/internal/docker/api.go
+++ b/internal/docker/api.go
@@ -58,6 +58,16 @@ func (a *APIClient) FindContainer(ctx context.Context, project, service string) 
 	return containers[0].ID, nil
 }
 
+// ContainerLogPath is the file Docker keeps a container's output in, or "" when its logging
+// driver keeps it somewhere Docker does not own, such as journald or a remote collector.
+func (a *APIClient) ContainerLogPath(ctx context.Context, ref string) (string, error) {
+	info, err := a.cli.ContainerInspect(ctx, ref)
+	if err != nil {
+		return "", err
+	}
+	return info.LogPath, nil
+}
+
 // ContainerPrimaryIP returns the IP address of a project's first running
 // container on the given docker network. The agent runs on the host, so a
 // service that only exposes ports on an internal compose network (a self-hosted

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -192,8 +192,11 @@ func (c *ComposeExecutor) PullService(deploymentPath, service string, opts ...Ru
 	return c.runCompose(deploymentPath, opts, "pull", "--ignore-buildable", "--policy", "always", service)
 }
 
-func (c *ComposeExecutor) Logs(deploymentPath string, tail int) (string, error) {
-	return c.runCompose(deploymentPath, nil, "logs", "--no-color", "--timestamps", "--tail", tailArg(tail))
+// Logs returns a tail of the deployment's output. Naming services narrows it to those
+// containers; naming none returns every service, which is what compose does by default.
+func (c *ComposeExecutor) Logs(deploymentPath string, tail int, services ...string) (string, error) {
+	args := append([]string{"logs", "--no-color", "--timestamps", "--tail", tailArg(tail)}, services...)
+	return c.runCompose(deploymentPath, nil, args...)
 }
 
 // tailArg is the compose --tail value: a count, or "all" for tail <= 0, since "0" shows no lines.
@@ -461,8 +464,9 @@ func (c *ComposeExecutor) runCompose(deploymentPath string, opts []RunOption, ar
 // a user watching a container start reloads to see the next line. Following gives them the
 // line when the container writes it, and cancelling ctx stops the process rather than
 // leaving it attached for the life of the agent.
-func (c *ComposeExecutor) StreamLogs(ctx context.Context, deploymentPath string, tail int, sink func(string)) error {
-	cmd, err := c.composeCommand(ctx, deploymentPath, "logs", "--follow", "--no-color", "--timestamps", "--tail", tailArg(tail))
+func (c *ComposeExecutor) StreamLogs(ctx context.Context, deploymentPath string, tail int, sink func(string), services ...string) error {
+	args := append([]string{"logs", "--follow", "--no-color", "--timestamps", "--tail", tailArg(tail)}, services...)
+	cmd, err := c.composeCommand(ctx, deploymentPath, args...)
 	if err != nil {
 		return err
 	}

--- a/internal/docker/log_service_integration_test.go
+++ b/internal/docker/log_service_integration_test.go
@@ -1,0 +1,75 @@
+package docker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLogsNarrowToOneService is the point of the service filter: a deployment with two noisy
+// containers hands back only the one the viewer picked.
+func TestLogsNarrowToOneService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("starts real containers")
+	}
+
+	const name = "flatrun-logservice-integration"
+	base := t.TempDir()
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	compose := "name: " + name + `
+services:
+  web:
+    image: alpine:latest
+    entrypoint: ["/bin/sh", "-c", "echo web-speaking; sleep 300"]
+  worker:
+    image: alpine:latest
+    entrypoint: ["/bin/sh", "-c", "echo worker-speaking; sleep 300"]
+`
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte(compose), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(base)
+	if m.apiClient == nil {
+		t.Skip("docker api client unavailable")
+	}
+	probe, cancelProbe := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancelProbe()
+	if _, err := m.apiClient.ListLiveComposeContainers(probe); err != nil {
+		t.Skipf("docker daemon unreachable: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := m.executor.Down(dir); err != nil {
+			t.Logf("cleanup: %v", err)
+		}
+	})
+	if out, err := m.StartDeployment(name); err != nil {
+		t.Fatalf("start failed: %v (%s)", err, out)
+	}
+
+	all, err := m.GetDeploymentLogs(name, 100)
+	if err != nil {
+		t.Fatalf("reading every service failed: %v", err)
+	}
+	if !strings.Contains(all, "web-speaking") || !strings.Contains(all, "worker-speaking") {
+		t.Fatalf("expected both services without a filter, got: %s", all)
+	}
+
+	only, err := m.GetDeploymentLogs(name, 100, "worker")
+	if err != nil {
+		t.Fatalf("reading one service failed: %v", err)
+	}
+	if !strings.Contains(only, "worker-speaking") {
+		t.Errorf("expected the picked service's output, got: %s", only)
+	}
+	if strings.Contains(only, "web-speaking") {
+		t.Errorf("expected no output from the other service, got: %s", only)
+	}
+}

--- a/internal/docker/manager.go
+++ b/internal/docker/manager.go
@@ -54,6 +54,16 @@ func (m *Manager) indexContainersByProject(ctx context.Context) (containerIndex,
 	return index, nil
 }
 
+// ContainerLogPath is the file Docker keeps a container's output in, by container id or name.
+func (m *Manager) ContainerLogPath(ref string) (string, error) {
+	if m.apiClient == nil {
+		return "", fmt.Errorf("docker api client unavailable")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), statusReadTimeout)
+	defer cancel()
+	return m.apiClient.ContainerLogPath(ctx, ref)
+}
+
 // ContainerPrimaryIP returns the first running container's address for a
 // deployment on the given docker network. A flatrun deploy names its compose
 // project after the deployment, so the project name is the deployment name.

--- a/internal/docker/manager.go
+++ b/internal/docker/manager.go
@@ -275,8 +275,8 @@ func (m *Manager) ListDeployments() ([]models.Deployment, error) {
 // The deployment path is passed in rather than looked up again: the caller has already read
 // the deployment, and following holds for as long as someone is watching, which is far too
 // long to hold the manager's lock.
-func (m *Manager) StreamDeploymentLogs(ctx context.Context, name, path string, tail int, sink func(string)) error {
-	return m.executor.StreamLogs(ctx, path, tail, sink)
+func (m *Manager) StreamDeploymentLogs(ctx context.Context, name, path string, tail int, sink func(string), services ...string) error {
+	return m.executor.StreamLogs(ctx, path, tail, sink, services...)
 }
 
 // FindDeployments returns deployments built from their on-disk metadata alone,
@@ -856,7 +856,7 @@ func (m *Manager) ComposeExec(ctx context.Context, name string, service string, 
 	return m.apiClient.ExecInService(ctx, project, service, command)
 }
 
-func (m *Manager) GetDeploymentLogs(name string, tail int) (string, error) {
+func (m *Manager) GetDeploymentLogs(name string, tail int, services ...string) (string, error) {
 	m.mu.RLock()
 	deployment, err := m.discovery.GetDeployment(name)
 	m.mu.RUnlock()
@@ -865,7 +865,7 @@ func (m *Manager) GetDeploymentLogs(name string, tail int) (string, error) {
 		return "", err
 	}
 
-	return m.executor.Logs(deployment.Path, tail)
+	return m.executor.Logs(deployment.Path, tail, services...)
 }
 
 func (m *Manager) UpdateDeployment(name string, composeContent string) error {

--- a/internal/docker/manager_test.go
+++ b/internal/docker/manager_test.go
@@ -407,10 +407,10 @@ func TestResolveServiceNotFound(t *testing.T) {
 
 func TestGetComposeServiceNames(t *testing.T) {
 	tests := []struct {
-		name           string
-		compose        string
-		wantNames      []string
-		wantErr        bool
+		name      string
+		compose   string
+		wantNames []string
+		wantErr   bool
 	}{
 		{
 			name: "single service",

--- a/internal/docker/resources.go
+++ b/internal/docker/resources.go
@@ -24,10 +24,10 @@ type ResourceUpdate struct {
 }
 
 type hostConfig struct {
-	Memory     int64  `json:"Memory"`
-	MemorySwap int64  `json:"MemorySwap"`
-	NanoCpus   int64  `json:"NanoCpus"`
-	CpuShares  int64  `json:"CpuShares"`
+	Memory        int64                `json:"Memory"`
+	MemorySwap    int64                `json:"MemorySwap"`
+	NanoCpus      int64                `json:"NanoCpus"`
+	CpuShares     int64                `json:"CpuShares"`
 	RestartPolicy restartPolicyInspect `json:"RestartPolicy"`
 }
 

--- a/internal/infra/log_stream_integration_test.go
+++ b/internal/infra/log_stream_integration_test.go
@@ -1,0 +1,130 @@
+package infra
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/flatrun/agent/pkg/config"
+)
+
+func startTalkingContainer(t *testing.T, name, command string) {
+	t.Helper()
+
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker unavailable")
+	}
+	if err := exec.Command("docker", "info").Run(); err != nil {
+		t.Skipf("docker daemon unreachable: %v", err)
+	}
+
+	_ = exec.Command("docker", "rm", "-f", name).Run()
+	out, err := exec.Command("docker", "run", "-d", "--name", name, "alpine:latest", "/bin/sh", "-c", command).CombinedOutput()
+	if err != nil {
+		t.Fatalf("starting the container failed: %v: %s", err, out)
+	}
+	t.Cleanup(func() {
+		if out, err := exec.Command("docker", "rm", "-f", name).CombinedOutput(); err != nil {
+			t.Logf("cleanup: %v: %s", err, out)
+		}
+	})
+}
+
+// Splitting a container's two outputs is what lets the proxy's access log and error log be
+// read apart, so it has to hold against a real container rather than in principle.
+func TestServiceLogsReadEachOutputApart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("starts a real container")
+	}
+
+	const name = "flatrun-infra-logsplit"
+	startTalkingContainer(t, name, "echo an-access-line; echo an-error-line >&2; sleep 60")
+
+	m := NewManager(&config.Config{})
+
+	var all string
+	for attempt := 0; attempt < 15; attempt++ {
+		var err error
+		all, err = m.ServiceLogs(name, 100, LogStreamAll)
+		if err != nil {
+			t.Fatalf("reading logs failed: %v", err)
+		}
+		if strings.Contains(all, "an-access-line") && strings.Contains(all, "an-error-line") {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if !strings.Contains(all, "an-access-line") || !strings.Contains(all, "an-error-line") {
+		t.Fatalf("expected both outputs together, got: %s", all)
+	}
+
+	stdout, err := m.ServiceLogs(name, 100, LogStreamStdout)
+	if err != nil {
+		t.Fatalf("reading stdout failed: %v", err)
+	}
+	if !strings.Contains(stdout, "an-access-line") || strings.Contains(stdout, "an-error-line") {
+		t.Errorf("stdout should carry only what the container printed there, got: %s", stdout)
+	}
+
+	stderr, err := m.ServiceLogs(name, 100, LogStreamStderr)
+	if err != nil {
+		t.Fatalf("reading stderr failed: %v", err)
+	}
+	if !strings.Contains(stderr, "an-error-line") || strings.Contains(stderr, "an-access-line") {
+		t.Errorf("stderr should carry only what the container printed there, got: %s", stderr)
+	}
+}
+
+// Following one output has to keep delivering, which is what the viewer's Follow depends on.
+func TestStreamServiceLogsFollowsOneOutput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("starts a real container")
+	}
+
+	const name = "flatrun-infra-logfollow"
+	startTalkingContainer(t, name, "i=0; while true; do i=$((i+1)); echo out-$i; echo err-$i >&2; sleep 1; done")
+
+	m := NewManager(&config.Config{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var (
+		mu    sync.Mutex
+		lines []string
+	)
+	got := make(chan struct{})
+	var once sync.Once
+
+	go func() {
+		_ = m.StreamServiceLogs(ctx, name, 10, LogStreamStdout, func(line string) {
+			mu.Lock()
+			lines = append(lines, line)
+			n := len(lines)
+			mu.Unlock()
+			// Wait for a few, so this cannot pass on the backlog alone.
+			if n >= 3 {
+				once.Do(func() { close(got) })
+			}
+		})
+	}()
+
+	select {
+	case <-got:
+	case <-ctx.Done():
+		mu.Lock()
+		defer mu.Unlock()
+		t.Fatalf("only received %d lines while following: %v", len(lines), lines)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, line := range lines {
+		if strings.Contains(line, "err-") {
+			t.Errorf("following stdout delivered a line from the other output: %q", line)
+		}
+	}
+}

--- a/internal/infra/manager.go
+++ b/internal/infra/manager.go
@@ -1,9 +1,12 @@
 package infra
 
 import (
+	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -113,24 +116,117 @@ func (m *Manager) RestartService(name string) error {
 	return nil
 }
 
+// A container writes two separate outputs and nginx uses both: the access log goes to stdout
+// and the error log to stderr, so the two are readable apart without configuring a file.
+const (
+	LogStreamAll    = "all"
+	LogStreamStdout = "stdout"
+	LogStreamStderr = "stderr"
+)
+
 func (m *Manager) GetServiceLogs(name string, tail int) (string, error) {
+	return m.ServiceLogs(name, tail, LogStreamAll)
+}
+
+func (m *Manager) ServiceLogs(name string, tail int, stream string) (string, error) {
 	containerName := m.resolveContainerName(name)
 	if containerName == "" {
 		return "", fmt.Errorf("unknown service: %s", name)
 	}
 
-	args := []string{"logs"}
+	cmd := exec.Command("docker", dockerLogArgs(containerName, tail, false)...)
+	var out, errOut bytes.Buffer
+	switch stream {
+	case LogStreamStdout, LogStreamStderr:
+		cmd.Stdout, cmd.Stderr = &out, &errOut
+	default:
+		// One buffer for both keeps the two outputs in the order they were written.
+		cmd.Stdout, cmd.Stderr = &out, &out
+	}
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to get logs for %s: %w: %s", name, err, strings.TrimSpace(errOut.String()+out.String()))
+	}
+
+	if stream == LogStreamStderr {
+		return errOut.String(), nil
+	}
+	return out.String(), nil
+}
+
+// StreamServiceLogs follows an infrastructure container's output until ctx is done, handing
+// each line to sink as it is written.
+func (m *Manager) StreamServiceLogs(ctx context.Context, name string, tail int, stream string, sink func(string)) error {
+	containerName := m.resolveContainerName(name)
+	if containerName == "" {
+		return fmt.Errorf("unknown service: %s", name)
+	}
+
+	cmd := exec.CommandContext(ctx, "docker", dockerLogArgs(containerName, tail, true)...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	follow := func(r io.Reader) {
+		defer wg.Done()
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			// Both outputs feed one viewer, so a line is handed over whole.
+			mu.Lock()
+			sink(line)
+			mu.Unlock()
+		}
+	}
+
+	if stream != LogStreamStderr {
+		wg.Add(1)
+		go follow(stdout)
+	} else {
+		go io.Copy(io.Discard, stdout)
+	}
+	if stream != LogStreamStdout {
+		wg.Add(1)
+		go follow(stderr)
+	} else {
+		go io.Copy(io.Discard, stderr)
+	}
+	wg.Wait()
+
+	// A cancelled follow is the viewer leaving, not a failure.
+	if err := cmd.Wait(); err != nil && ctx.Err() == nil {
+		return err
+	}
+	return nil
+}
+
+func dockerLogArgs(containerName string, tail int, follow bool) []string {
+	args := []string{"logs", "--timestamps"}
+	if follow {
+		args = append(args, "--follow")
+	}
 	if tail > 0 {
 		args = append(args, "--tail", fmt.Sprintf("%d", tail))
 	}
-	args = append(args, containerName)
+	return append(args, containerName)
+}
 
-	cmd := exec.Command("docker", args...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("failed to get logs for %s: %w", name, err)
-	}
-	return string(output), nil
+// ContainerName is the container behind an infrastructure service, or "" if there is none.
+func (m *Manager) ContainerName(name string) string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.resolveContainerName(name)
 }
 
 func (m *Manager) resolveContainerName(name string) string {

--- a/internal/observ/api.go
+++ b/internal/observ/api.go
@@ -39,10 +39,24 @@ type alertPersistence interface {
 	Save([]AlertRule) error
 }
 
+// logRuleAccess is the slice of the log engine the API needs; nil-safe.
+type logRuleAccess interface {
+	Rules() []LogRule
+	SetRules([]LogRule)
+	Incidents() []Incident
+}
+
+type logRulePersistence interface {
+	Load() []LogRule
+	Save([]LogRule) error
+}
+
 // alerts is optional wiring for the rule endpoints.
 type alerts struct {
-	engine alertAccess
-	store  alertPersistence
+	engine    alertAccess
+	store     alertPersistence
+	logEngine logRuleAccess
+	logStore  logRulePersistence
 }
 
 func Handler(store *Store, history *MetricsDB, health healthReporter, cfg configAccess, apply func(Config)) http.Handler {
@@ -150,6 +164,46 @@ func HandlerWithAlerts(store *Store, history *MetricsDB, health healthReporter, 
 			al.engine.SetRules(al.store.Load())
 		}
 		writeJSON(w, al.engine.Rules())
+	})
+	mux.HandleFunc("/alerts/log-rules", func(w http.ResponseWriter, r *http.Request) {
+		if al.logEngine == nil || al.logStore == nil {
+			writeJSON(w, []LogRule{})
+			return
+		}
+		if r.Method == http.MethodPut {
+			var incoming []LogRule
+			if err := json.NewDecoder(r.Body).Decode(&incoming); err != nil {
+				http.Error(w, "invalid rules", http.StatusBadRequest)
+				return
+			}
+			// Saving assigns ids and rejects a rule that would match everything.
+			if err := al.logStore.Save(incoming); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			al.logEngine.SetRules(al.logStore.Load())
+		}
+		writeJSON(w, al.logEngine.Rules())
+	})
+	mux.HandleFunc("/alerts/incidents", func(w http.ResponseWriter, r *http.Request) {
+		if al.logEngine == nil {
+			writeJSON(w, []Incident{})
+			return
+		}
+		incidents := al.logEngine.Incidents()
+		if deployment := r.URL.Query().Get("deployment"); deployment != "" {
+			filtered := make([]Incident, 0, len(incidents))
+			for _, in := range incidents {
+				if in.Deployment == deployment {
+					filtered = append(filtered, in)
+				}
+			}
+			incidents = filtered
+		}
+		writeJSON(w, incidents)
+	})
+	mux.HandleFunc("/alerts/responders", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, KnownResponders())
 	})
 	mux.HandleFunc("/alerts/firing", func(w http.ResponseWriter, _ *http.Request) {
 		if al.engine == nil {

--- a/internal/observ/config.go
+++ b/internal/observ/config.go
@@ -23,6 +23,20 @@ type Config struct {
 	// OTEL_EXPORTER_OTLP_ENDPOINT environment variable is honoured instead, and with
 	// neither set nothing is pushed and the metrics are still there to scrape.
 	OTLPEndpoint string `yaml:"otlp_endpoint,omitempty" json:"otlp_endpoint,omitempty"`
+	// Off unless turned on here, and still opt-in per rule after that.
+	LogTriage bool `yaml:"log_triage" json:"log_triage"`
+	// Bounds what an incident carries, and so the most a triage can be asked to read.
+	TriageContextLines int `yaml:"triage_context_lines,omitempty" json:"triage_context_lines,omitempty"`
+}
+
+func (c Config) triageContextLines() int {
+	if c.TriageContextLines <= 0 {
+		return 12
+	}
+	if c.TriageContextLines > maxLogContextLines {
+		return maxLogContextLines
+	}
+	return c.TriageContextLines
 }
 
 // DefaultConfig returns the built-in defaults.
@@ -93,4 +107,6 @@ var ConfigSchema = map[string]any{
 	"restart_cooldown_seconds": map[string]any{"type": "number", "label": "Restart cooldown (seconds)", "default": 120, "min": 10},
 	"retention_days":           map[string]any{"type": "number", "label": "Keep history for (days)", "default": 7, "min": 1},
 	"otlp_endpoint":            map[string]any{"type": "string", "label": "OTLP endpoint", "placeholder": "http://localhost:4318", "help": "Push metrics to an OpenTelemetry backend. Leave empty to only serve them for scraping."},
+	"log_triage":               map[string]any{"type": "boolean", "label": "Let log rules ask the assistant", "default": false, "help": "Log rules that opt in can have the assistant explain an incident. Bounded by the agent's daily triage cap."},
+	"triage_context_lines":     map[string]any{"type": "number", "label": "Lines of context per incident", "default": 12, "min": 1, "max": 40},
 }

--- a/internal/observ/fingerprint.go
+++ b/internal/observ/fingerprint.go
@@ -1,0 +1,53 @@
+package observ
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+var (
+	fpHex  = regexp.MustCompile(`\b(?:0x)?[0-9a-fA-F]{8,}\b`)
+	fpUUID = regexp.MustCompile(`\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b`)
+	// Case-insensitive: normalization lowercases first, turning the ISO "T" into a "t".
+	fpTimestamp = regexp.MustCompile(`(?i)\b\d{4}-\d{2}-\d{2}[t ]\d{2}:\d{2}:\d{2}(?:\.\d+)?z?\b`)
+	fpDuration  = regexp.MustCompile(`\b\d+(?:\.\d+)?(?:ms|s|m|h|us|µs|ns)\b`)
+	fpIPPort    = regexp.MustCompile(`\b\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?\b`)
+	fpQuoted    = regexp.MustCompile(`"[^"]*"|'[^']*'`)
+	fpPath      = regexp.MustCompile(`(?:/[\w.\-@+]+){2,}`)
+	fpNumber    = regexp.MustCompile(`\b\d+\b`)
+	fpSpace     = regexp.MustCompile(`\s+`)
+)
+
+// fingerprint reduces a message to what stays the same across occurrences of one fault.
+//
+// It errs toward collapsing: two faults sharing a fingerprint costs one missed notification,
+// while one fault spread across many costs a notification and a triage per line written.
+func fingerprint(message string) string {
+	normalized := normalizeMessage(message)
+	sum := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(sum[:8])
+}
+
+func normalizeMessage(message string) string {
+	s := strings.ToLower(message)
+	// Specific shapes first, or the hex rule eats UUIDs and the number rule eats timestamps.
+	s = fpUUID.ReplaceAllString(s, "<id>")
+	s = fpTimestamp.ReplaceAllString(s, "<time>")
+	s = fpIPPort.ReplaceAllString(s, "<addr>")
+	s = fpDuration.ReplaceAllString(s, "<dur>")
+	s = fpHex.ReplaceAllString(s, "<hex>")
+	s = fpQuoted.ReplaceAllString(s, "<str>")
+	s = fpPath.ReplaceAllString(s, "<path>")
+	s = fpNumber.ReplaceAllString(s, "<n>")
+	s = fpSpace.ReplaceAllString(s, " ")
+	s = strings.TrimSpace(s)
+
+	// In a stack trace or a dump, the opening identifies the fault and the tail varies.
+	const fingerprintPrefix = 300
+	if len(s) > fingerprintPrefix {
+		s = s[:fingerprintPrefix]
+	}
+	return s
+}

--- a/internal/observ/logengine.go
+++ b/internal/observ/logengine.go
@@ -185,10 +185,11 @@ func (e *LogEngine) Incidents() []Incident {
 	return append(make([]Incident, 0, len(e.recent)), e.recent...)
 }
 
-// Offer runs one line through the funnel, returning what it raised. The caller acts; the
-// engine only decides.
+// Offer runs one line through the funnel, returning what it raised. It never leaves the machine,
+// so it is cheap enough to call for every line read.
 func (e *LogEngine) Offer(line LogLine) []Incident {
 	e.mu.Lock()
+	defer e.mu.Unlock()
 
 	if line.At.IsZero() {
 		line.At = e.now()
@@ -207,30 +208,30 @@ func (e *LogEngine) Offer(line LogLine) []Incident {
 			raised = append(raised, *incident)
 		}
 	}
+	return raised
+}
+
+// Explain records what the model makes of an incident. It waits on a network call, so it must
+// not be called from the path that reads log lines.
+func (e *LogEngine) Explain(incident Incident) *Triage {
+	e.mu.Lock()
 	triage := e.triage
 	e.mu.Unlock()
 
-	// Outside the lock: this reaches a model, and holding the engine would stall every
-	// other line on the host.
-	for i := range raised {
-		if raised[i].Triage != nil || triage == nil {
-			continue
-		}
-		if !e.ruleWantsTriage(raised[i].RuleID) {
-			continue
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
-		verdict, err := triage(ctx, raised[i])
-		cancel()
-		if err != nil {
-			verdict = &Triage{Skipped: err.Error(), At: e.now()}
-		}
-		if verdict != nil {
-			raised[i].Triage = verdict
-			e.attachTriage(raised[i].ID, verdict)
-		}
+	if triage == nil || incident.Triage != nil || !e.ruleWantsTriage(incident.RuleID) {
+		return nil
 	}
-	return raised
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	verdict, err := triage(ctx, incident)
+	cancel()
+	if err != nil {
+		verdict = &Triage{Skipped: err.Error(), At: e.now()}
+	}
+	if verdict != nil {
+		e.attachTriage(incident.ID, verdict)
+	}
+	return verdict
 }
 
 func (e *LogEngine) ruleWantsTriage(ruleID string) bool {

--- a/internal/observ/logengine.go
+++ b/internal/observ/logengine.go
@@ -92,6 +92,15 @@ type window struct {
 	times     []time.Time
 	lastFired time.Time
 	incident  *Incident
+	lastSeen  time.Time
+	// Past its own window and cooldown a window holds no live state, so that is how long it
+	// has to be quiet before it can be dropped.
+	ttl time.Duration
+}
+
+type streamLines struct {
+	lines    []string
+	lastSeen time.Time
 }
 
 // LogEngine runs the funnel: level, pattern, burst, fingerprint cooldown, then whatever the
@@ -108,16 +117,23 @@ type LogEngine struct {
 	// Nil means incidents are raised untriaged rather than not raised.
 	triage       func(ctx context.Context, incident Incident) (*Triage, error)
 	contextLines int
-	recentLines  map[string][]string
+	recentLines  map[string]*streamLines
+	lastSweep    time.Time
 }
 
-const maxRecentIncidents = 200
+const (
+	maxRecentIncidents = 200
+	sweepInterval      = 5 * time.Minute
+	// Context is only worth keeping for a stream still writing; one that has gone quiet this
+	// long can rebuild it from the lines before its next incident.
+	streamIdleTTL = time.Hour
+)
 
 func NewLogEngine() *LogEngine {
 	return &LogEngine{
 		patterns:     map[string]*regexp.Regexp{},
 		windows:      map[string]*window{},
-		recentLines:  map[string][]string{},
+		recentLines:  map[string]*streamLines{},
 		now:          func() time.Time { return time.Now().UTC() },
 		contextLines: 12,
 	}
@@ -195,6 +211,7 @@ func (e *LogEngine) Offer(line LogLine) []Incident {
 		line.At = e.now()
 	}
 	e.rememberLine(line)
+	e.sweep(line.At)
 
 	var raised []Incident
 	for _, rule := range e.rules {
@@ -298,6 +315,8 @@ func (e *LogEngine) record(rule LogRule, line LogLine) *Incident {
 		w = &window{}
 		e.windows[key] = w
 	}
+	w.lastSeen = line.At
+	w.ttl = time.Duration(rule.WindowSeconds+rule.CooldownSeconds) * time.Second
 
 	cutoff := line.At.Add(-time.Duration(rule.WindowSeconds) * time.Second)
 	kept := w.times[:0]
@@ -365,17 +384,46 @@ func (e *LogEngine) streamKey(line LogLine) string {
 
 func (e *LogEngine) rememberLine(line LogLine) {
 	key := e.streamKey(line)
-	tail := append(e.recentLines[key], line.Raw)
-	if len(tail) > maxLogContextLines {
-		tail = tail[len(tail)-maxLogContextLines:]
+	buf := e.recentLines[key]
+	if buf == nil {
+		buf = &streamLines{}
+		e.recentLines[key] = buf
 	}
-	e.recentLines[key] = tail
+	buf.lines = append(buf.lines, line.Raw)
+	if len(buf.lines) > maxLogContextLines {
+		buf.lines = buf.lines[len(buf.lines)-maxLogContextLines:]
+	}
+	buf.lastSeen = line.At
 }
 
 func (e *LogEngine) contextFor(line LogLine) []string {
-	tail := e.recentLines[e.streamKey(line)]
-	if len(tail) <= e.contextLines {
-		return append([]string(nil), tail...)
+	buf := e.recentLines[e.streamKey(line)]
+	if buf == nil {
+		return nil
 	}
-	return append([]string(nil), tail[len(tail)-e.contextLines:]...)
+	if len(buf.lines) <= e.contextLines {
+		return append([]string(nil), buf.lines...)
+	}
+	return append([]string(nil), buf.lines[len(buf.lines)-e.contextLines:]...)
+}
+
+// sweep drops what the funnel is no longer counting on. The agent runs for months, and both maps
+// are keyed by things that come and go: a stream by deployment and service, a window by the shape
+// of a message. Without this, every container that ever wrote a line stays in memory.
+func (e *LogEngine) sweep(now time.Time) {
+	if now.Sub(e.lastSweep) < sweepInterval {
+		return
+	}
+	e.lastSweep = now
+
+	for key, w := range e.windows {
+		if now.Sub(w.lastSeen) > w.ttl {
+			delete(e.windows, key)
+		}
+	}
+	for key, buf := range e.recentLines {
+		if now.Sub(buf.lastSeen) > streamIdleTTL {
+			delete(e.recentLines, key)
+		}
+	}
 }

--- a/internal/observ/logengine.go
+++ b/internal/observ/logengine.go
@@ -1,0 +1,380 @@
+package observ
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// LogLine is one parsed line, in the shape the agent's log stream already produces.
+type LogLine struct {
+	Deployment string
+	Service    string
+	Source     string
+	Level      string
+	Message    string
+	Raw        string
+	At         time.Time
+}
+
+// Triage is what the assistant concluded. Every field is optional: an incident that was
+// never triaged is still a complete incident.
+type Triage struct {
+	Summary    string    `json:"summary,omitempty"`
+	Cause      string    `json:"cause,omitempty"`
+	NextStep   string    `json:"next_step,omitempty"`
+	Severity   string    `json:"severity,omitempty"`
+	Confidence string    `json:"confidence,omitempty"`
+	Skipped    string    `json:"skipped,omitempty"`
+	At         time.Time `json:"at,omitempty"`
+}
+
+// Incident is one distinct fault, seen enough times to be worth raising.
+type Incident struct {
+	ID          string            `json:"id"`
+	RuleID      string            `json:"rule_id"`
+	RuleName    string            `json:"rule_name"`
+	Deployment  string            `json:"deployment"`
+	Service     string            `json:"service,omitempty"`
+	Source      string            `json:"source,omitempty"`
+	Level       string            `json:"level"`
+	Fingerprint string            `json:"fingerprint"`
+	Sample      string            `json:"sample"`
+	Context     []string          `json:"context,omitempty"`
+	Count       int               `json:"count"`
+	FirstSeen   time.Time         `json:"first_seen"`
+	LastSeen    time.Time         `json:"last_seen"`
+	Targets     []string          `json:"targets,omitempty"`
+	Triage      *Triage           `json:"triage,omitempty"`
+	Responses   []ResponderResult `json:"responses,omitempty"`
+}
+
+// Key identifies the fault rather than this sighting of it, so the same crash next week has
+// the same key. A responder keys its own work on it.
+func (i Incident) Key() string {
+	return i.Deployment + "/" + i.RuleID + "/" + i.Fingerprint
+}
+
+func (i Incident) Title() string {
+	where := i.Deployment
+	if i.Service != "" {
+		where += "/" + i.Service
+	}
+	return fmt.Sprintf("%s: %s", i.RuleName, where)
+}
+
+// Message leads with the triage when there is one, and the line itself when there is not.
+func (i Incident) Message() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d occurrences in %s", i.Count, i.Deployment)
+	if i.Service != "" {
+		fmt.Fprintf(&b, " (%s)", i.Service)
+	}
+	b.WriteString(".\n\n")
+	if i.Triage != nil && i.Triage.Summary != "" {
+		b.WriteString(i.Triage.Summary)
+		if i.Triage.Cause != "" {
+			fmt.Fprintf(&b, "\n\nLikely cause: %s", i.Triage.Cause)
+		}
+		if i.Triage.NextStep != "" {
+			fmt.Fprintf(&b, "\nSuggested next step: %s", i.Triage.NextStep)
+		}
+		b.WriteString("\n\n")
+	}
+	b.WriteString(i.Sample)
+	return b.String()
+}
+
+type window struct {
+	times     []time.Time
+	lastFired time.Time
+	incident  *Incident
+}
+
+// LogEngine runs the funnel: level, pattern, burst, fingerprint cooldown, then whatever the
+// rule asked for. Everything before the last step is local, so a container writing a line a
+// millisecond costs a regex per line and nothing else.
+type LogEngine struct {
+	mu       sync.Mutex
+	rules    []LogRule
+	patterns map[string]*regexp.Regexp
+	windows  map[string]*window
+	recent   []Incident
+	now      func() time.Time
+
+	// Nil means incidents are raised untriaged rather than not raised.
+	triage       func(ctx context.Context, incident Incident) (*Triage, error)
+	contextLines int
+	recentLines  map[string][]string
+}
+
+const maxRecentIncidents = 200
+
+func NewLogEngine() *LogEngine {
+	return &LogEngine{
+		patterns:     map[string]*regexp.Regexp{},
+		windows:      map[string]*window{},
+		recentLines:  map[string][]string{},
+		now:          func() time.Time { return time.Now().UTC() },
+		contextLines: 12,
+	}
+}
+
+// OnTriage registers what explains an incident, called only for rules that asked for it.
+func (e *LogEngine) OnTriage(fn func(ctx context.Context, incident Incident) (*Triage, error)) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.triage = fn
+}
+
+func (e *LogEngine) SetContextLines(n int) {
+	if n <= 0 {
+		return
+	}
+	if n > maxLogContextLines {
+		n = maxLogContextLines
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.contextLines = n
+}
+
+// SetRules replaces the rule set, forgetting the state of rules that no longer exist.
+func (e *LogEngine) SetRules(rules []LogRule) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	live := map[string]bool{}
+	prepared := make([]LogRule, 0, len(rules))
+	compiled := map[string]*regexp.Regexp{}
+	for _, r := range rules {
+		r = r.WithDefaults()
+		if r.Pattern != "" {
+			re, err := regexp.Compile(r.Pattern)
+			if err != nil {
+				// Dropping one uncompilable rule beats losing the whole set.
+				continue
+			}
+			compiled[r.ID] = re
+		}
+		prepared = append(prepared, r)
+		live[r.ID] = true
+	}
+	e.rules = prepared
+	e.patterns = compiled
+
+	for key := range e.windows {
+		if id, _, ok := strings.Cut(key, "\x00"); ok && !live[id] {
+			delete(e.windows, key)
+		}
+	}
+}
+
+func (e *LogEngine) Rules() []LogRule {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append(make([]LogRule, 0, len(e.rules)), e.rules...)
+}
+
+func (e *LogEngine) Incidents() []Incident {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append(make([]Incident, 0, len(e.recent)), e.recent...)
+}
+
+// Offer runs one line through the funnel, returning what it raised. The caller acts; the
+// engine only decides.
+func (e *LogEngine) Offer(line LogLine) []Incident {
+	e.mu.Lock()
+
+	if line.At.IsZero() {
+		line.At = e.now()
+	}
+	e.rememberLine(line)
+
+	var raised []Incident
+	for _, rule := range e.rules {
+		if !rule.Enabled {
+			continue
+		}
+		if !e.matches(rule, line) {
+			continue
+		}
+		if incident := e.record(rule, line); incident != nil {
+			raised = append(raised, *incident)
+		}
+	}
+	triage := e.triage
+	e.mu.Unlock()
+
+	// Outside the lock: this reaches a model, and holding the engine would stall every
+	// other line on the host.
+	for i := range raised {
+		if raised[i].Triage != nil || triage == nil {
+			continue
+		}
+		if !e.ruleWantsTriage(raised[i].RuleID) {
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		verdict, err := triage(ctx, raised[i])
+		cancel()
+		if err != nil {
+			verdict = &Triage{Skipped: err.Error(), At: e.now()}
+		}
+		if verdict != nil {
+			raised[i].Triage = verdict
+			e.attachTriage(raised[i].ID, verdict)
+		}
+	}
+	return raised
+}
+
+func (e *LogEngine) ruleWantsTriage(ruleID string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, r := range e.rules {
+		if r.ID == ruleID {
+			return r.Triage
+		}
+	}
+	return false
+}
+
+func (e *LogEngine) attachTriage(incidentID string, verdict *Triage) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for i := range e.recent {
+		if e.recent[i].ID == incidentID {
+			e.recent[i].Triage = verdict
+			return
+		}
+	}
+}
+
+// AttachResponses records what the responders did.
+func (e *LogEngine) AttachResponses(incidentID string, results []ResponderResult) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for i := range e.recent {
+		if e.recent[i].ID == incidentID {
+			e.recent[i].Responses = append(e.recent[i].Responses, results...)
+			return
+		}
+	}
+}
+
+func (e *LogEngine) matches(rule LogRule, line LogLine) bool {
+	if rule.Deployment != line.Deployment {
+		return false
+	}
+	if rule.Service != "" && rule.Service != line.Service {
+		return false
+	}
+	if rule.Source != "" && line.Source != "" && rule.Source != line.Source {
+		return false
+	}
+	if !rule.matchesLevel(line.Level) {
+		return false
+	}
+	if re, ok := e.patterns[rule.ID]; ok && !re.MatchString(line.Message) {
+		return false
+	}
+	return true
+}
+
+// record applies the burst threshold and the cooldown, returning an incident only when this
+// line crosses from noise into news.
+func (e *LogEngine) record(rule LogRule, line LogLine) *Incident {
+	fp := fingerprint(line.Message)
+	key := rule.ID + "\x00" + line.Deployment + "\x00" + line.Service + "\x00" + fp
+
+	w := e.windows[key]
+	if w == nil {
+		w = &window{}
+		e.windows[key] = w
+	}
+
+	cutoff := line.At.Add(-time.Duration(rule.WindowSeconds) * time.Second)
+	kept := w.times[:0]
+	for _, t := range w.times {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	w.times = append(kept, line.At)
+
+	// Already reported and still inside the quiet period: count it and say nothing.
+	if !w.lastFired.IsZero() && line.At.Sub(w.lastFired) < time.Duration(rule.CooldownSeconds)*time.Second {
+		if w.incident != nil {
+			w.incident.Count++
+			w.incident.LastSeen = line.At
+			e.bumpRecent(w.incident.ID, line.At)
+		}
+		return nil
+	}
+
+	if len(w.times) < rule.MinCount {
+		return nil
+	}
+
+	incident := Incident{
+		ID:          fmt.Sprintf("%s-%d", fp, line.At.UnixNano()),
+		RuleID:      rule.ID,
+		RuleName:    rule.Name,
+		Deployment:  line.Deployment,
+		Service:     line.Service,
+		Source:      line.Source,
+		Level:       line.Level,
+		Fingerprint: fp,
+		Sample:      line.Raw,
+		Context:     e.contextFor(line),
+		Count:       len(w.times),
+		FirstSeen:   w.times[0],
+		LastSeen:    line.At,
+		Targets:     rule.Targets,
+	}
+	w.lastFired = line.At
+	w.incident = &incident
+	w.times = w.times[:0]
+
+	e.recent = append(e.recent, incident)
+	if len(e.recent) > maxRecentIncidents {
+		e.recent = e.recent[len(e.recent)-maxRecentIncidents:]
+	}
+	return &incident
+}
+
+func (e *LogEngine) bumpRecent(incidentID string, at time.Time) {
+	for i := range e.recent {
+		if e.recent[i].ID == incidentID {
+			e.recent[i].Count++
+			e.recent[i].LastSeen = at
+			return
+		}
+	}
+}
+
+func (e *LogEngine) streamKey(line LogLine) string {
+	return line.Deployment + "\x00" + line.Service + "\x00" + line.Source
+}
+
+func (e *LogEngine) rememberLine(line LogLine) {
+	key := e.streamKey(line)
+	tail := append(e.recentLines[key], line.Raw)
+	if len(tail) > maxLogContextLines {
+		tail = tail[len(tail)-maxLogContextLines:]
+	}
+	e.recentLines[key] = tail
+}
+
+func (e *LogEngine) contextFor(line LogLine) []string {
+	tail := e.recentLines[e.streamKey(line)]
+	if len(tail) <= e.contextLines {
+		return append([]string(nil), tail...)
+	}
+	return append([]string(nil), tail[len(tail)-e.contextLines:]...)
+}

--- a/internal/observ/logengine_test.go
+++ b/internal/observ/logengine_test.go
@@ -187,6 +187,45 @@ func TestLogEngineScopesToDeploymentAndService(t *testing.T) {
 	}
 }
 
+// The agent runs for months. Both of the engine's maps are keyed by things that come and go, a
+// stream by its service and a window by the shape of a message, so neither may grow forever.
+func TestLogEngineForgetsStreamsAndShapesItNoLongerNeeds(t *testing.T) {
+	e := NewLogEngine()
+	e.SetRules([]LogRule{testRule(func(r *LogRule) {
+		r.MinCount = 1
+		r.WindowSeconds = 60
+		r.CooldownSeconds = 60
+	})})
+
+	base := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 500; i++ {
+		l := line(base.Add(time.Duration(i)*time.Millisecond), "error", fmt.Sprintf("connection refused talking to shard %d", i))
+		l.Service = fmt.Sprintf("worker-%d", i)
+		e.Offer(l)
+	}
+
+	e.mu.Lock()
+	windows, streams := len(e.windows), len(e.recentLines)
+	e.mu.Unlock()
+	if windows == 0 || streams == 0 {
+		t.Fatalf("expected the engine to be holding state, got %d windows and %d streams", windows, streams)
+	}
+
+	// A day later, none of it is still deciding anything.
+	quiet := line(base.Add(24*time.Hour), "info", "still here")
+	quiet.Service = "web"
+	e.Offer(quiet)
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if len(e.windows) != 0 {
+		t.Errorf("windows past their cooldown should be dropped, %d left", len(e.windows))
+	}
+	if len(e.recentLines) != 1 {
+		t.Errorf("only the stream still writing should be kept, %d left", len(e.recentLines))
+	}
+}
+
 // Triage is the only part that costs money, so it must run for the incident and never per
 // line, and only when the rule asked for it.
 func TestLogEngineTriagesOncePerIncidentAndOnlyWhenAsked(t *testing.T) {

--- a/internal/observ/logengine_test.go
+++ b/internal/observ/logengine_test.go
@@ -227,11 +227,19 @@ func TestLogEngineTriagesOncePerIncidentAndOnlyWhenAsked(t *testing.T) {
 	for i := 0; i < 500; i++ {
 		raised = append(raised, e2.Offer(line(base.Add(time.Duration(i)*time.Second), "error", "connection refused"))...)
 	}
+	if got := atomic.LoadInt64(&calls); got != 0 {
+		t.Fatalf("reading a line must never reach the model on its own, got %d calls", got)
+	}
+	if len(raised) != 1 {
+		t.Fatalf("five hundred lines of one fault should raise one incident, got %d", len(raised))
+	}
+
+	verdict := e2.Explain(raised[0])
 	if got := atomic.LoadInt64(&calls); got != 1 {
 		t.Fatalf("five hundred lines of one fault should cost one triage, got %d", got)
 	}
-	if len(raised) != 1 || raised[0].Triage == nil || raised[0].Triage.Summary != "redis is down" {
-		t.Fatalf("the incident should carry the verdict, got %+v", raised)
+	if verdict == nil || verdict.Summary != "redis is down" {
+		t.Fatalf("the incident should carry the verdict, got %+v", verdict)
 	}
 }
 
@@ -250,8 +258,9 @@ func TestLogEngineRaisesWhenTriageFails(t *testing.T) {
 	if len(raised) != 1 {
 		t.Fatalf("expected the incident regardless of triage, got %d", len(raised))
 	}
-	if raised[0].Triage == nil || !strings.Contains(raised[0].Triage.Skipped, "budget") {
-		t.Errorf("the incident should record why it was not triaged, got %+v", raised[0].Triage)
+	verdict := e.Explain(raised[0])
+	if verdict == nil || !strings.Contains(verdict.Skipped, "budget") {
+		t.Errorf("the incident should record why it was not triaged, got %+v", verdict)
 	}
 }
 

--- a/internal/observ/logengine_test.go
+++ b/internal/observ/logengine_test.go
@@ -1,0 +1,277 @@
+package observ
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testRule(mutate func(*LogRule)) LogRule {
+	r := LogRule{
+		ID:         "rule-1",
+		Name:       "App errors",
+		Enabled:    true,
+		Deployment: "shop",
+	}
+	if mutate != nil {
+		mutate(&r)
+	}
+	return r.WithDefaults()
+}
+
+func line(at time.Time, level, message string) LogLine {
+	return LogLine{
+		Deployment: "shop",
+		Service:    "web",
+		Source:     "stdout",
+		Level:      level,
+		Message:    message,
+		Raw:        "shop-web | " + message,
+		At:         at,
+	}
+}
+
+// A single error is a blip. Raising an incident for it would page an operator for every
+// transient failure a healthy system produces.
+func TestLogEngineWaitsForTheBurstThreshold(t *testing.T) {
+	e := NewLogEngine()
+	e.SetRules([]LogRule{testRule(nil)})
+
+	base := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	if got := e.Offer(line(base, "error", "connection refused talking to redis")); len(got) != 0 {
+		t.Fatalf("one occurrence should not raise anything, got %d", len(got))
+	}
+	if got := e.Offer(line(base.Add(time.Second), "error", "connection refused talking to redis")); len(got) != 0 {
+		t.Fatalf("two occurrences should not raise anything, got %d", len(got))
+	}
+
+	raised := e.Offer(line(base.Add(2*time.Second), "error", "connection refused talking to redis"))
+	if len(raised) != 1 {
+		t.Fatalf("the third occurrence should raise one incident, got %d", len(raised))
+	}
+	if raised[0].Count != 3 {
+		t.Errorf("incident should carry the occurrence count, got %d", raised[0].Count)
+	}
+}
+
+// The gate that decides whether this feature is affordable: one fault repeated forever is one
+// incident, however many lines it writes.
+func TestLogEngineRaisesOneIncidentPerFaultPerCooldown(t *testing.T) {
+	e := NewLogEngine()
+	e.SetRules([]LogRule{testRule(func(r *LogRule) {
+		r.MinCount = 3
+		r.CooldownSeconds = 3600
+	})})
+
+	base := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	raisedTotal := 0
+	// The same fault, with the varying parts real logs carry, ten thousand times inside one
+	// cooldown period.
+	for i := 0; i < 10000; i++ {
+		msg := fmt.Sprintf("failed to insert order id=%d at 2026-08-06T12:00:%02d.123Z after %dms", 40000+i, i%60, 12+i%7)
+		raisedTotal += len(e.Offer(line(base.Add(time.Duration(i)*100*time.Millisecond), "error", msg)))
+	}
+
+	if raisedTotal != 1 {
+		t.Fatalf("ten thousand copies of one fault should raise one incident, got %d", raisedTotal)
+	}
+
+	incidents := e.Incidents()
+	if len(incidents) != 1 {
+		t.Fatalf("expected one incident in history, got %d", len(incidents))
+	}
+	if incidents[0].Count < 1000 {
+		t.Errorf("the repeats should be counted onto the open incident, got %d", incidents[0].Count)
+	}
+}
+
+// Distinct faults are distinct incidents, or the collapsing would hide the second problem.
+func TestLogEngineSeparatesDistinctFaults(t *testing.T) {
+	e := NewLogEngine()
+	e.SetRules([]LogRule{testRule(func(r *LogRule) { r.MinCount = 2 })})
+
+	base := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	var raised []Incident
+	for i := 0; i < 2; i++ {
+		raised = append(raised, e.Offer(line(base.Add(time.Duration(i)*time.Second), "error", "out of memory killing worker 12"))...)
+	}
+	for i := 0; i < 2; i++ {
+		raised = append(raised, e.Offer(line(base.Add(time.Duration(10+i)*time.Second), "error", "deadlock detected on table orders"))...)
+	}
+
+	if len(raised) != 2 {
+		t.Fatalf("two different faults should raise two incidents, got %d", len(raised))
+	}
+	if raised[0].Fingerprint == raised[1].Fingerprint {
+		t.Errorf("different faults should not share a fingerprint")
+	}
+}
+
+// Once the cooldown passes the same fault is worth mentioning again: it means it never went
+// away, or it came back.
+func TestLogEngineRaisesAgainAfterTheCooldown(t *testing.T) {
+	e := NewLogEngine()
+	e.SetRules([]LogRule{testRule(func(r *LogRule) {
+		r.MinCount = 1
+		r.CooldownSeconds = 60
+	})})
+
+	base := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	if got := e.Offer(line(base, "error", "disk full")); len(got) != 1 {
+		t.Fatalf("expected the first incident, got %d", len(got))
+	}
+	if got := e.Offer(line(base.Add(30*time.Second), "error", "disk full")); len(got) != 0 {
+		t.Fatalf("inside the cooldown nothing should be raised, got %d", len(got))
+	}
+	if got := e.Offer(line(base.Add(90*time.Second), "error", "disk full")); len(got) != 1 {
+		t.Fatalf("after the cooldown it should raise again, got %d", len(got))
+	}
+}
+
+func TestLogEngineGatesOnLevelAndPattern(t *testing.T) {
+	e := NewLogEngine()
+	e.SetRules([]LogRule{testRule(func(r *LogRule) {
+		r.MinCount = 1
+		r.Pattern = "(?i)out of memory"
+	})})
+
+	base := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+
+	if got := e.Offer(line(base, "warn", "out of memory soon")); len(got) != 0 {
+		t.Errorf("a warning should not match a rule watching errors")
+	}
+	if got := e.Offer(line(base.Add(time.Second), "error", "connection reset")); len(got) != 0 {
+		t.Errorf("an error not matching the pattern should not raise")
+	}
+	if got := e.Offer(line(base.Add(2*time.Second), "error", "Out Of Memory: killed")); len(got) != 1 {
+		t.Errorf("an error matching the pattern should raise, got %d", len(got))
+	}
+}
+
+// A line whose level could not be parsed must not slip past a rule that asked for errors.
+func TestLogEngineIgnoresUnparseableLevels(t *testing.T) {
+	e := NewLogEngine()
+	e.SetRules([]LogRule{testRule(func(r *LogRule) { r.MinCount = 1 })})
+
+	if got := e.Offer(line(time.Now().UTC(), "", "something happened")); len(got) != 0 {
+		t.Errorf("a line with no level should not match an error rule")
+	}
+}
+
+func TestLogEngineScopesToDeploymentAndService(t *testing.T) {
+	e := NewLogEngine()
+	e.SetRules([]LogRule{testRule(func(r *LogRule) {
+		r.MinCount = 1
+		r.Service = "worker"
+	})})
+
+	at := time.Now().UTC()
+	other := line(at, "error", "boom")
+	other.Deployment = "blog"
+	if got := e.Offer(other); len(got) != 0 {
+		t.Errorf("another deployment's line should not match")
+	}
+
+	wrongService := line(at, "error", "boom")
+	if got := e.Offer(wrongService); len(got) != 0 {
+		t.Errorf("another service's line should not match")
+	}
+
+	right := line(at, "error", "boom")
+	right.Service = "worker"
+	if got := e.Offer(right); len(got) != 1 {
+		t.Errorf("the watched service should match, got %d", len(got))
+	}
+}
+
+// Triage is the only part that costs money, so it must run for the incident and never per
+// line, and only when the rule asked for it.
+func TestLogEngineTriagesOncePerIncidentAndOnlyWhenAsked(t *testing.T) {
+	var calls int64
+	e := NewLogEngine()
+	e.OnTriage(func(_ context.Context, incident Incident) (*Triage, error) {
+		atomic.AddInt64(&calls, 1)
+		return &Triage{Summary: "redis is down"}, nil
+	})
+	e.SetRules([]LogRule{
+		testRule(func(r *LogRule) {
+			r.ID = "no-triage"
+			r.MinCount = 1
+			r.Triage = false
+		}),
+	})
+
+	base := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 50; i++ {
+		e.Offer(line(base.Add(time.Duration(i)*time.Second), "error", "connection refused"))
+	}
+	if got := atomic.LoadInt64(&calls); got != 0 {
+		t.Fatalf("a rule without triage must never reach the model, got %d calls", got)
+	}
+
+	e2 := NewLogEngine()
+	e2.OnTriage(func(_ context.Context, incident Incident) (*Triage, error) {
+		atomic.AddInt64(&calls, 1)
+		return &Triage{Summary: "redis is down"}, nil
+	})
+	e2.SetRules([]LogRule{testRule(func(r *LogRule) {
+		r.MinCount = 1
+		r.CooldownSeconds = 3600
+		r.Triage = true
+	})})
+
+	var raised []Incident
+	for i := 0; i < 500; i++ {
+		raised = append(raised, e2.Offer(line(base.Add(time.Duration(i)*time.Second), "error", "connection refused"))...)
+	}
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Fatalf("five hundred lines of one fault should cost one triage, got %d", got)
+	}
+	if len(raised) != 1 || raised[0].Triage == nil || raised[0].Triage.Summary != "redis is down" {
+		t.Fatalf("the incident should carry the verdict, got %+v", raised)
+	}
+}
+
+// A triage that fails leaves the incident intact: the operator still hears about the fault.
+func TestLogEngineRaisesWhenTriageFails(t *testing.T) {
+	e := NewLogEngine()
+	e.OnTriage(func(_ context.Context, _ Incident) (*Triage, error) {
+		return nil, fmt.Errorf("daily triage budget spent")
+	})
+	e.SetRules([]LogRule{testRule(func(r *LogRule) {
+		r.MinCount = 1
+		r.Triage = true
+	})})
+
+	raised := e.Offer(line(time.Now().UTC(), "error", "everything is on fire"))
+	if len(raised) != 1 {
+		t.Fatalf("expected the incident regardless of triage, got %d", len(raised))
+	}
+	if raised[0].Triage == nil || !strings.Contains(raised[0].Triage.Skipped, "budget") {
+		t.Errorf("the incident should record why it was not triaged, got %+v", raised[0].Triage)
+	}
+}
+
+func TestLogEngineCarriesContextForTriage(t *testing.T) {
+	e := NewLogEngine()
+	e.SetContextLines(5)
+	e.SetRules([]LogRule{testRule(func(r *LogRule) { r.MinCount = 1 })})
+
+	base := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 20; i++ {
+		e.Offer(line(base.Add(time.Duration(i)*time.Millisecond), "info", fmt.Sprintf("handling request %d", i)))
+	}
+	raised := e.Offer(line(base.Add(time.Second), "error", "panic: nil map write"))
+	if len(raised) != 1 {
+		t.Fatalf("expected one incident, got %d", len(raised))
+	}
+	if len(raised[0].Context) != 5 {
+		t.Fatalf("context should be bounded to what was asked for, got %d lines", len(raised[0].Context))
+	}
+	if !strings.Contains(raised[0].Context[len(raised[0].Context)-1], "panic") {
+		t.Errorf("the matched line should be the last of the context, got %q", raised[0].Context[len(raised[0].Context)-1])
+	}
+}

--- a/internal/observ/logrule.go
+++ b/internal/observ/logrule.go
@@ -1,0 +1,124 @@
+package observ
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Log levels a rule can gate on, ordered by severity.
+const (
+	LogLevelDebug = "debug"
+	LogLevelInfo  = "info"
+	LogLevelWarn  = "warn"
+	LogLevelError = "error"
+	LogLevelFatal = "fatal"
+)
+
+var logLevelRank = map[string]int{
+	LogLevelDebug: 1,
+	LogLevelInfo:  2,
+	LogLevelWarn:  3,
+	LogLevelError: 4,
+	LogLevelFatal: 5,
+}
+
+// Defaults chosen so a rule written without thinking still cannot run up a bill.
+const (
+	defaultLogMinCount   = 3
+	defaultLogWindowSecs = 300
+	defaultLogCooldown   = 3600
+	// Bounds what an incident keeps, and so the most a triage can ever be asked to read.
+	maxLogContextLines = 40
+)
+
+// LogRule turns lines a deployment writes into an incident. Every field except Triage exists
+// to make the expensive part rare, so a model is only asked about what survives all of them.
+type LogRule struct {
+	ID         string `json:"id" yaml:"id"`
+	Name       string `json:"name" yaml:"name"`
+	Enabled    bool   `json:"enabled" yaml:"enabled"`
+	Deployment string `json:"deployment" yaml:"deployment"`
+	Service    string `json:"service,omitempty" yaml:"service,omitempty"`
+	Source     string `json:"source,omitempty" yaml:"source,omitempty"`
+	// Defaults to error: a rule watching info is a rule watching everything.
+	MinLevel string `json:"min_level,omitempty" yaml:"min_level,omitempty"`
+	// Matched against the parsed message, not the raw line, so it cannot hit a timestamp
+	// or a service name.
+	Pattern       string `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	MinCount      int    `json:"min_count,omitempty" yaml:"min_count,omitempty"`
+	WindowSeconds int    `json:"window_seconds,omitempty" yaml:"window_seconds,omitempty"`
+	// Repeats inside the cooldown are counted onto the open incident rather than raising
+	// another.
+	CooldownSeconds int `json:"cooldown_seconds,omitempty" yaml:"cooldown_seconds,omitempty"`
+	// The only field that costs money to run, so it is off unless asked for.
+	Triage     bool     `json:"triage,omitempty" yaml:"triage,omitempty"`
+	Responders []string `json:"responders,omitempty" yaml:"responders,omitempty"`
+	Targets    []string `json:"targets,omitempty" yaml:"targets,omitempty"`
+}
+
+// WithDefaults fills the fields a rule may leave empty.
+func (r LogRule) WithDefaults() LogRule {
+	if r.MinLevel == "" {
+		r.MinLevel = LogLevelError
+	}
+	if r.Source == "" {
+		r.Source = "stdout"
+	}
+	if r.MinCount <= 0 {
+		r.MinCount = defaultLogMinCount
+	}
+	if r.WindowSeconds <= 0 {
+		r.WindowSeconds = defaultLogWindowSecs
+	}
+	if r.CooldownSeconds <= 0 {
+		r.CooldownSeconds = defaultLogCooldown
+	}
+	if len(r.Responders) == 0 {
+		r.Responders = []string{ResponderNotify}
+	}
+	return r
+}
+
+// Validate reports why a rule cannot be used, if it cannot.
+func (r LogRule) Validate() error {
+	r = r.WithDefaults()
+
+	if strings.TrimSpace(r.Name) == "" {
+		return fmt.Errorf("a rule needs a name")
+	}
+	if strings.TrimSpace(r.Deployment) == "" {
+		return fmt.Errorf("a log rule needs a deployment to watch")
+	}
+	if _, ok := logLevelRank[r.MinLevel]; !ok {
+		return fmt.Errorf("unknown level %q", r.MinLevel)
+	}
+	// This broad a rule matches most of what a chatty application writes.
+	if logLevelRank[r.MinLevel] < logLevelRank[LogLevelError] && strings.TrimSpace(r.Pattern) == "" {
+		return fmt.Errorf("a rule below error level needs a pattern, or it matches nearly every line")
+	}
+	if r.Pattern != "" {
+		if _, err := regexp.Compile(r.Pattern); err != nil {
+			return fmt.Errorf("pattern is not a valid regular expression: %w", err)
+		}
+	}
+	if r.MinCount > 1000 {
+		return fmt.Errorf("min_count above 1000 would never fire in a useful window")
+	}
+	for _, name := range r.Responders {
+		if !knownResponder(name) {
+			return fmt.Errorf("unknown responder %q", name)
+		}
+	}
+	return nil
+}
+
+// matchesLevel reports whether a parsed level is severe enough. An unparseable level does not
+// match, so it cannot slip past a rule that asked for errors.
+func (r LogRule) matchesLevel(level string) bool {
+	rank, ok := logLevelRank[strings.ToLower(strings.TrimSpace(level))]
+	if !ok {
+		return false
+	}
+	return rank >= logLevelRank[r.WithDefaults().MinLevel]
+}

--- a/internal/observ/logrule_store.go
+++ b/internal/observ/logrule_store.go
@@ -1,0 +1,71 @@
+package observ
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LogRuleStore keeps log rules in a flat file beside the metric rules.
+type LogRuleStore struct {
+	path string
+	mu   sync.RWMutex
+}
+
+func NewLogRuleStore(basePath string) *LogRuleStore {
+	return &LogRuleStore{path: filepath.Join(basePath, ".flatrun", "log-rules.yml")}
+}
+
+type logRuleFile struct {
+	Rules []LogRule `yaml:"rules"`
+}
+
+func (s *LogRuleStore) Load() []LogRule {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return nil
+	}
+
+	var f logRuleFile
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil
+	}
+	for i := range f.Rules {
+		f.Rules[i] = f.Rules[i].WithDefaults()
+	}
+	return f.Rules
+}
+
+func (s *LogRuleStore) Save(rules []LogRule) error {
+	for i := range rules {
+		rules[i] = rules[i].WithDefaults()
+		if err := rules[i].Validate(); err != nil {
+			return err
+		}
+		if rules[i].ID == "" {
+			id, err := newRuleID()
+			if err != nil {
+				return err
+			}
+			rules[i].ID = id
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(s.path), 0755); err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(logRuleFile{Rules: rules})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.path, data, 0644)
+}

--- a/internal/observ/logrule_test.go
+++ b/internal/observ/logrule_test.go
@@ -1,0 +1,163 @@
+package observ
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// The rule that would cost the most is the one a user writes without thinking, so the
+// defaults have to be the safe ones.
+func TestLogRuleDefaultsAreConservative(t *testing.T) {
+	r := LogRule{Name: "anything", Deployment: "shop"}.WithDefaults()
+
+	if r.MinLevel != LogLevelError {
+		t.Errorf("a rule should watch errors unless told otherwise, got %q", r.MinLevel)
+	}
+	if r.MinCount < 2 {
+		t.Errorf("a single occurrence should not be an incident, got min_count %d", r.MinCount)
+	}
+	if r.CooldownSeconds < 600 {
+		t.Errorf("the quiet period should be long enough to matter, got %ds", r.CooldownSeconds)
+	}
+	if r.Triage {
+		t.Errorf("triage must be opt-in, or writing a rule spends money by accident")
+	}
+	if len(r.Responders) != 1 || r.Responders[0] != ResponderNotify {
+		t.Errorf("a rule should notify by default, got %v", r.Responders)
+	}
+}
+
+// A rule watching warnings with no pattern matches most of what a chatty app writes.
+func TestLogRuleRejectsBroadLowLevelRules(t *testing.T) {
+	err := LogRule{Name: "everything", Deployment: "shop", MinLevel: LogLevelWarn}.Validate()
+	if err == nil {
+		t.Fatal("a warn-level rule with no pattern should be refused")
+	}
+	if !strings.Contains(err.Error(), "pattern") {
+		t.Errorf("the refusal should say what would fix it, got %q", err)
+	}
+
+	ok := LogRule{Name: "oom warnings", Deployment: "shop", MinLevel: LogLevelWarn, Pattern: "out of memory"}.Validate()
+	if ok != nil {
+		t.Errorf("a warn-level rule with a pattern is fine, got %v", ok)
+	}
+}
+
+func TestLogRuleValidation(t *testing.T) {
+	cases := []struct {
+		name string
+		rule LogRule
+		want string
+	}{
+		{"no name", LogRule{Deployment: "shop"}, "name"},
+		{"no deployment", LogRule{Name: "x"}, "deployment"},
+		{"bad level", LogRule{Name: "x", Deployment: "shop", MinLevel: "loud"}, "level"},
+		{"bad pattern", LogRule{Name: "x", Deployment: "shop", Pattern: "("}, "regular expression"},
+		{"unknown responder", LogRule{Name: "x", Deployment: "shop", Responders: []string{"telepathy"}}, "responder"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.rule.Validate()
+			if err == nil {
+				t.Fatalf("expected a refusal")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("refusal should mention %q, got %q", tc.want, err)
+			}
+		})
+	}
+}
+
+// Notify is always valid so a rule written today keeps working after a responder is added or
+// removed from a build.
+func TestNotifyResponderIsAlwaysAvailable(t *testing.T) {
+	if err := (LogRule{Name: "x", Deployment: "shop", Responders: []string{ResponderNotify}}).Validate(); err != nil {
+		t.Errorf("notify should always validate, got %v", err)
+	}
+}
+
+// The framework has to carry a new kind of response without the engine knowing about it.
+func TestResponderRegistryRunsWhatARuleAsksFor(t *testing.T) {
+	var seen []string
+	RegisterResponder(ResponderFunc{
+		ResponderName: "test-issue-filer",
+		Fn: func(_ context.Context, incident Incident) (string, error) {
+			seen = append(seen, incident.Key())
+			return "filed issue #1", nil
+		},
+	})
+	t.Cleanup(func() {
+		registry.mu.Lock()
+		delete(registry.m, "test-issue-filer")
+		registry.mu.Unlock()
+	})
+
+	if err := (LogRule{Name: "x", Deployment: "shop", Responders: []string{"test-issue-filer"}}).Validate(); err != nil {
+		t.Fatalf("a registered responder should validate, got %v", err)
+	}
+
+	incident := Incident{RuleID: "r1", Deployment: "shop", Fingerprint: "abc"}
+	results := runResponders(context.Background(), []string{"test-issue-filer"}, incident)
+	if len(results) != 1 || results[0].Detail != "filed issue #1" {
+		t.Fatalf("the responder's outcome should be recorded, got %+v", results)
+	}
+	if len(seen) != 1 || seen[0] != "shop/r1/abc" {
+		t.Errorf("a responder should be handed a stable key for the fault, got %v", seen)
+	}
+}
+
+// One responder failing must not stop the rest: an incident that could not be filed still has
+// to reach a person.
+func TestRespondersAreIndependent(t *testing.T) {
+	RegisterResponder(ResponderFunc{
+		ResponderName: "test-broken",
+		Fn:            func(context.Context, Incident) (string, error) { return "", fmt.Errorf("service down") },
+	})
+	var notified bool
+	RegisterResponder(ResponderFunc{
+		ResponderName: "test-ok",
+		Fn:            func(context.Context, Incident) (string, error) { notified = true; return "done", nil },
+	})
+	t.Cleanup(func() {
+		registry.mu.Lock()
+		delete(registry.m, "test-broken")
+		delete(registry.m, "test-ok")
+		registry.mu.Unlock()
+	})
+
+	results := runResponders(context.Background(), []string{"test-broken", "test-ok"}, Incident{})
+	if len(results) != 2 {
+		t.Fatalf("every responder should report, got %d", len(results))
+	}
+	if results[0].Error == "" {
+		t.Errorf("the failure should be recorded")
+	}
+	if !notified {
+		t.Errorf("a failing responder must not stop the ones after it")
+	}
+}
+
+// A rule naming a responder this build does not have is recorded, not fatal.
+func TestUnknownResponderIsRecordedNotFatal(t *testing.T) {
+	results := runResponders(context.Background(), []string{"not-built"}, Incident{})
+	if len(results) != 1 || results[0].Error == "" {
+		t.Fatalf("expected one recorded failure, got %+v", results)
+	}
+}
+
+func TestFingerprintCollapsesTheVaryingParts(t *testing.T) {
+	same := []string{
+		`failed to insert order id=48291 at 2026-08-06T12:00:31.123Z after 14ms`,
+		`failed to insert order id=99999 at 2026-08-07T03:11:02.500Z after 9ms`,
+	}
+	if fingerprint(same[0]) != fingerprint(same[1]) {
+		t.Errorf("the same fault with different ids and times should share a fingerprint")
+	}
+
+	if fingerprint("out of memory") == fingerprint("deadlock detected") {
+		t.Errorf("different faults should not share a fingerprint")
+	}
+}

--- a/internal/observ/logwatch.go
+++ b/internal/observ/logwatch.go
@@ -44,9 +44,14 @@ type LogWatcher struct {
 	rules   func() []LogRule
 	respond func(incident Incident, responders []string)
 
+	raised chan Incident
+
 	mu      sync.Mutex
 	running map[string]context.CancelFunc
 }
+
+// Deep enough that the funnel's cooldown makes filling it mean something is already very wrong.
+const incidentQueueDepth = 256
 
 func NewLogWatcher(engine *LogEngine, base, token string) *LogWatcher {
 	return &LogWatcher{
@@ -55,6 +60,7 @@ func NewLogWatcher(engine *LogEngine, base, token string) *LogWatcher {
 		token:  token,
 		// No timeout: a follow never ends on purpose. Cancellation is by context.
 		client:  &http.Client{},
+		raised:  make(chan Incident, incidentQueueDepth),
 		running: map[string]context.CancelFunc{},
 	}
 }
@@ -71,6 +77,7 @@ func (w *LogWatcher) Run(ctx context.Context, interval time.Duration) {
 	if interval <= 0 {
 		interval = 30 * time.Second
 	}
+	go w.explainAndRespond(ctx)
 	w.reconcile(ctx)
 
 	ticker := time.NewTicker(interval)
@@ -223,19 +230,60 @@ func (w *LogWatcher) readOnce(ctx context.Context, ref streamRef) error {
 			Level:      incoming.Record.Level,
 			Message:    message,
 			Raw:        incoming.Line,
-			At:         time.Now().UTC(),
+			At:         lineTime(incoming.Record.Timestamp),
 		})
 	}
 	return scanner.Err()
 }
 
+// lineTime prefers when the line was written over when it was read: a reconnect would otherwise
+// squeeze a spread-out burst into an instant. A stamp far from now is a wrong clock, not
+// information, so arrival time stands in.
+func lineTime(stamp string) time.Time {
+	now := time.Now().UTC()
+	if stamp == "" {
+		return now
+	}
+	at, err := time.Parse(time.RFC3339, stamp)
+	if err != nil {
+		return now
+	}
+	if drift := now.Sub(at); drift > maxLineClockDrift || drift < -maxLineClockDrift {
+		return now
+	}
+	return at.UTC()
+}
+
+const maxLineClockDrift = 10 * time.Minute
+
 func (w *LogWatcher) handle(line LogLine) {
 	for _, incident := range w.engine.Offer(line) {
-		if w.respond == nil {
-			continue
+		select {
+		case w.raised <- incident:
+		default:
+			// The incident is recorded either way, so it reaches the page unexplained rather
+			// than holding up the reader.
+			log.Printf("observ: incident queue full, %s goes unexplained", incident.Key())
 		}
-		responders := w.respondersFor(incident.RuleID)
-		w.respond(incident, responders)
+	}
+}
+
+// explainAndRespond runs the slow half of an incident one at a time, so neither the model call
+// nor the responders can hold up reading logs, and a storm of incidents cannot become a storm of
+// model calls.
+func (w *LogWatcher) explainAndRespond(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case incident := <-w.raised:
+			if verdict := w.engine.Explain(incident); verdict != nil {
+				incident.Triage = verdict
+			}
+			if w.respond != nil {
+				w.respond(incident, w.respondersFor(incident.RuleID))
+			}
+		}
 	}
 }
 

--- a/internal/observ/logwatch.go
+++ b/internal/observ/logwatch.go
@@ -1,0 +1,252 @@
+package observ
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// streamRef is one open stream. Rules watching the same deployment share one, so ten rules
+// on one app cost one reader.
+type streamRef struct {
+	Deployment string
+	Service    string
+	Source     string
+}
+
+func (s streamRef) key() string { return s.Deployment + "\x00" + s.Service + "\x00" + s.Source }
+
+type agentLine struct {
+	Type   string `json:"type"`
+	Line   string `json:"line"`
+	Record struct {
+		Timestamp string `json:"timestamp"`
+		Service   string `json:"service"`
+		Level     string `json:"level"`
+		Message   string `json:"message"`
+	} `json:"record"`
+}
+
+// LogWatcher keeps a reader open per stream the enabled rules need and feeds the engine.
+type LogWatcher struct {
+	engine  *LogEngine
+	base    string
+	token   string
+	client  *http.Client
+	rules   func() []LogRule
+	respond func(incident Incident, responders []string)
+
+	mu      sync.Mutex
+	running map[string]context.CancelFunc
+}
+
+func NewLogWatcher(engine *LogEngine, base, token string) *LogWatcher {
+	return &LogWatcher{
+		engine: engine,
+		base:   strings.TrimRight(base, "/"),
+		token:  token,
+		// No timeout: a follow never ends on purpose. Cancellation is by context.
+		client:  &http.Client{},
+		running: map[string]context.CancelFunc{},
+	}
+}
+
+func (w *LogWatcher) OnIncident(fn func(incident Incident, responders []string)) {
+	w.respond = fn
+}
+
+func (w *LogWatcher) SetRules(rules func() []LogRule) { w.rules = rules }
+
+// Run reconciles open streams with what the rules ask for. Rules change while it runs, so
+// this is a loop rather than one-time setup.
+func (w *LogWatcher) Run(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	w.reconcile(ctx)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			w.stopAll()
+			return
+		case <-ticker.C:
+			w.reconcile(ctx)
+		}
+	}
+}
+
+func (w *LogWatcher) desired() map[string]streamRef {
+	want := map[string]streamRef{}
+	if w.rules == nil {
+		return want
+	}
+	for _, r := range w.rules() {
+		if !r.Enabled || r.Deployment == "" {
+			continue
+		}
+		r = r.WithDefaults()
+		ref := streamRef{Deployment: r.Deployment, Service: r.Service, Source: r.Source}
+		want[ref.key()] = ref
+	}
+	return want
+}
+
+func (w *LogWatcher) reconcile(ctx context.Context) {
+	want := w.desired()
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	for key, cancel := range w.running {
+		if _, ok := want[key]; !ok {
+			cancel()
+			delete(w.running, key)
+		}
+	}
+	for key, ref := range want {
+		if _, ok := w.running[key]; ok {
+			continue
+		}
+		streamCtx, cancel := context.WithCancel(ctx)
+		w.running[key] = cancel
+		go w.follow(streamCtx, ref)
+	}
+}
+
+func (w *LogWatcher) stopAll() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for key, cancel := range w.running {
+		cancel()
+		delete(w.running, key)
+	}
+}
+
+// follow keeps one stream open, reconnecting with a backoff. A stopped deployment is normal
+// here rather than an error, so only the first failure of a run is logged.
+func (w *LogWatcher) follow(ctx context.Context, ref streamRef) {
+	backoff := 2 * time.Second
+	const maxBackoff = time.Minute
+	complained := false
+
+	for ctx.Err() == nil {
+		err := w.readOnce(ctx, ref)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil && !complained {
+			log.Printf("observability: log watch on %s paused: %v", ref.Deployment, err)
+			complained = true
+		}
+		if err == nil {
+			backoff = 2 * time.Second
+			complained = false
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < maxBackoff {
+			backoff *= 2
+		}
+	}
+}
+
+func (w *LogWatcher) readOnce(ctx context.Context, ref streamRef) error {
+	params := url.Values{}
+	params.Set("deployment", ref.Deployment)
+	if ref.Service != "" {
+		params.Set("service", ref.Service)
+	}
+	if ref.Source != "" {
+		params.Set("source", ref.Source)
+	}
+	// No backlog: replaying history would re-raise incidents already dealt with.
+	params.Set("tail", "0")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, w.base+"/internal/logs/stream?"+params.Encode(), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Plugin-Token", w.token)
+
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("log stream returned %s", resp.Status)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		raw := bytes.TrimSpace(scanner.Bytes())
+		if len(raw) == 0 {
+			continue
+		}
+		var incoming agentLine
+		if err := json.Unmarshal(raw, &incoming); err != nil {
+			continue
+		}
+		if incoming.Type != "log" {
+			continue
+		}
+
+		service := incoming.Record.Service
+		if service == "" {
+			service = ref.Service
+		}
+		message := incoming.Record.Message
+		if message == "" {
+			message = incoming.Line
+		}
+
+		w.handle(LogLine{
+			Deployment: ref.Deployment,
+			Service:    service,
+			Source:     ref.Source,
+			Level:      incoming.Record.Level,
+			Message:    message,
+			Raw:        incoming.Line,
+			At:         time.Now().UTC(),
+		})
+	}
+	return scanner.Err()
+}
+
+func (w *LogWatcher) handle(line LogLine) {
+	for _, incident := range w.engine.Offer(line) {
+		if w.respond == nil {
+			continue
+		}
+		responders := w.respondersFor(incident.RuleID)
+		w.respond(incident, responders)
+	}
+}
+
+func (w *LogWatcher) respondersFor(ruleID string) []string {
+	if w.rules == nil {
+		return []string{ResponderNotify}
+	}
+	for _, r := range w.rules() {
+		if r.ID == ruleID {
+			return r.WithDefaults().Responders
+		}
+	}
+	return []string{ResponderNotify}
+}

--- a/internal/observ/logwatch_test.go
+++ b/internal/observ/logwatch_test.go
@@ -1,0 +1,186 @@
+package observ
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The other half of the wire contract pinned in the agent's TestInternalLogEnvelopeShape: the
+// watcher decodes what that envelope marshals to, including the level the agent parsed, so a
+// rule watching errors matches without the app parsing a line a second time.
+func TestLogWatcherRaisesFromTheAgentsEnvelope(t *testing.T) {
+	lines := []string{
+		`{"type":"log","line":"web-1  | 2026-08-06T12:00:31.123456Z ERROR connection refused talking to redis","record":{"timestamp":"2026-08-06T12:00:31.123456Z","service":"web-1","level":"error","message":"ERROR connection refused talking to redis","raw":"web-1  | 2026-08-06T12:00:31.123456Z ERROR connection refused talking to redis"}}`,
+		`{"type":"log","line":"web-1  | 2026-08-06T12:00:32.000000Z INFO serving request","record":{"timestamp":"2026-08-06T12:00:32.000000Z","service":"web-1","level":"info","message":"INFO serving request","raw":"web-1  | 2026-08-06T12:00:32.000000Z INFO serving request"}}`,
+		`{"type":"log","line":"web-1  | 2026-08-06T12:00:33.000000Z ERROR connection refused talking to redis","record":{"timestamp":"2026-08-06T12:00:33.000000Z","service":"web-1","level":"error","message":"ERROR connection refused talking to redis","raw":"web-1  | 2026-08-06T12:00:33.000000Z ERROR connection refused talking to redis"}}`,
+	}
+
+	var gotToken string
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.Header.Get("X-Plugin-Token")
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for _, line := range lines {
+			fmt.Fprintln(w, line)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		// Hold the response open the way a real follow does, until the watcher leaves.
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	engine := NewLogEngine()
+	rule := LogRule{
+		ID:         "rule-1",
+		Name:       "App errors",
+		Enabled:    true,
+		Deployment: "shop",
+		MinCount:   2,
+	}
+	engine.SetRules([]LogRule{rule.WithDefaults()})
+
+	watcher := NewLogWatcher(engine, server.URL, "plugin-secret")
+	watcher.SetRules(engine.Rules)
+
+	var (
+		mu        sync.Mutex
+		incidents []Incident
+	)
+	got := make(chan struct{})
+	var once sync.Once
+	watcher.OnIncident(func(incident Incident, responders []string) {
+		mu.Lock()
+		incidents = append(incidents, incident)
+		mu.Unlock()
+		once.Do(func() { close(got) })
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go watcher.Run(ctx, time.Hour)
+
+	select {
+	case <-got:
+	case <-ctx.Done():
+		t.Fatal("the watcher never raised an incident from the agent's lines")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(incidents) != 1 {
+		t.Fatalf("two matching errors and one info line should raise one incident, got %d", len(incidents))
+	}
+	incident := incidents[0]
+	if incident.Deployment != "shop" {
+		t.Errorf("deployment = %q", incident.Deployment)
+	}
+	if incident.Service != "web-1" {
+		t.Errorf("service should come from the record the agent parsed, got %q", incident.Service)
+	}
+	if incident.Level != "error" {
+		t.Errorf("level should come from the record the agent parsed, got %q", incident.Level)
+	}
+	if incident.Count != 2 {
+		t.Errorf("count = %d, want the two matching lines", incident.Count)
+	}
+	if gotToken != "plugin-secret" {
+		t.Errorf("the watcher must authenticate with the plugin token, got %q", gotToken)
+	}
+	// Replaying history on reconnect would re-raise incidents that were already handled.
+	if !strings.Contains(gotQuery, "tail=0") {
+		t.Errorf("the watcher should ask for no backlog, got query %q", gotQuery)
+	}
+}
+
+// A stream that is not there is a normal condition (a stopped deployment, a restarting
+// agent), so the watcher keeps trying rather than giving up on the rule.
+func TestLogWatcherKeepsTryingWhenTheStreamIsUnavailable(t *testing.T) {
+	var attempts int
+	var mu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		attempts++
+		mu.Unlock()
+		http.Error(w, "deployment not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	engine := NewLogEngine()
+	missing := LogRule{ID: "r", Name: "n", Enabled: true, Deployment: "gone"}
+	engine.SetRules([]LogRule{missing.WithDefaults()})
+
+	watcher := NewLogWatcher(engine, server.URL, "plugin-secret")
+	watcher.SetRules(engine.Rules)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	go watcher.Run(ctx, time.Hour)
+
+	deadline := time.After(6 * time.Second)
+	for {
+		mu.Lock()
+		n := attempts
+		mu.Unlock()
+		if n >= 2 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("expected the watcher to retry, saw %d attempts", n)
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+}
+
+// A rule that is deleted should take its reader with it.
+func TestLogWatcherClosesStreamsItNoLongerNeeds(t *testing.T) {
+	open := make(chan struct{}, 4)
+	closed := make(chan struct{}, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		open <- struct{}{}
+		<-r.Context().Done()
+		closed <- struct{}{}
+	}))
+	defer server.Close()
+
+	engine := NewLogEngine()
+	watched := LogRule{ID: "r", Name: "n", Enabled: true, Deployment: "shop"}
+	engine.SetRules([]LogRule{watched.WithDefaults()})
+
+	watcher := NewLogWatcher(engine, server.URL, "plugin-secret")
+	watcher.SetRules(engine.Rules)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go watcher.Run(ctx, 200*time.Millisecond)
+
+	select {
+	case <-open:
+	case <-ctx.Done():
+		t.Fatal("the watcher never opened a stream")
+	}
+
+	engine.SetRules(nil)
+
+	select {
+	case <-closed:
+	case <-ctx.Done():
+		t.Fatal("the watcher kept reading a stream no rule asked for")
+	}
+}

--- a/internal/observ/logwatch_test.go
+++ b/internal/observ/logwatch_test.go
@@ -103,6 +103,70 @@ func TestLogWatcherRaisesFromTheAgentsEnvelope(t *testing.T) {
 	}
 }
 
+// The model call is the slowest thing in the pipeline, and a reader that waits on it stops
+// reading the deployment's logs for as long as it takes.
+func TestLogWatcherKeepsReadingWhileTriageIsSlow(t *testing.T) {
+	lines := []string{
+		`{"type":"log","line":"web-1  | ERROR connection refused talking to redis","record":{"service":"web-1","level":"error","message":"connection refused talking to redis"}}`,
+		`{"type":"log","line":"web-1  | ERROR disk is full","record":{"service":"web-1","level":"error","message":"disk is full"}}`,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for _, line := range lines {
+			fmt.Fprintln(w, line)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	triaging := make(chan struct{})
+	release := make(chan struct{})
+	engine := NewLogEngine()
+	engine.OnTriage(func(_ context.Context, _ Incident) (*Triage, error) {
+		close(triaging)
+		<-release
+		return &Triage{Summary: "redis is down"}, nil
+	})
+	engine.SetRules([]LogRule{
+		LogRule{ID: "redis", Name: "Redis", Enabled: true, Deployment: "shop", Pattern: "redis", MinCount: 1, Triage: true}.WithDefaults(),
+		LogRule{ID: "disk", Name: "Disk", Enabled: true, Deployment: "shop", Pattern: "disk", MinCount: 1}.WithDefaults(),
+	})
+
+	watcher := NewLogWatcher(engine, server.URL, "plugin-secret")
+	watcher.SetRules(engine.Rules)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	go watcher.Run(ctx, time.Hour)
+	defer close(release)
+
+	select {
+	case <-triaging:
+	case <-ctx.Done():
+		t.Fatal("triage never ran")
+	}
+
+	// Triage is still blocked here, so the second line only lands if reading kept going.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		for _, incident := range engine.Incidents() {
+			if incident.RuleID == "disk" {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the reader stopped taking lines while the model was answering")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 // A stream that is not there is a normal condition (a stopped deployment, a restarting
 // agent), so the watcher keeps trying rather than giving up on the rule.
 func TestLogWatcherKeepsTryingWhenTheStreamIsUnavailable(t *testing.T) {

--- a/internal/observ/plugin.go
+++ b/internal/observ/plugin.go
@@ -124,15 +124,50 @@ func RunPlugin() error {
 	defer close(alertStop)
 	go engine.Run(alertStop, cfg.sampleInterval()*3)
 
+	// Rules over what deployments write. Only what survives the whole funnel is ever sent
+	// to the assistant.
+	logRuleStore := NewLogRuleStore(dataDir)
+	logEngine := NewLogEngine()
+	logEngine.SetRules(logRuleStore.Load())
+	logEngine.SetContextLines(cfg.triageContextLines())
+
+	agentBase, agentToken := pluginsdk.AgentCallback()
+	RegisterResponder(NewNotifyResponder(func(title, message string, targets []string) {
+		emitNotificationTo(title, message, targets)
+	}))
+
+	if cfg.LogTriage {
+		triage := NewTriageClient(agentBase, agentToken)
+		logEngine.OnTriage(triage.Explain)
+	}
+
+	logWatcher := NewLogWatcher(logEngine, agentBase, agentToken)
+	logWatcher.SetRules(logEngine.Rules)
+	logWatcher.OnIncident(func(incident Incident, responders []string) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		results := runResponders(ctx, responders, incident)
+		logEngine.AttachResponses(incident.ID, results)
+	})
+	logCtx, stopLogWatch := context.WithCancel(ctx)
+	defer stopLogWatch()
+	go logWatcher.Run(logCtx, 30*time.Second)
+
 	go collector.Run(ctx)
 	go NewHostCollector(store, SystemHostSource, cfg.sampleInterval()).Run(ctx)
 	go watcher.Run(ctx)
 
 	applyConfig := func(c Config) {
 		watcher.SetEnabled(c.AutoRestart)
+		logEngine.SetContextLines(c.triageContextLines())
 	}
 
-	handler := HandlerWithAlerts(store, history, watcher, cfgStore, applyConfig, alerts{engine: engine, store: alertStore})
+	handler := HandlerWithAlerts(store, history, watcher, cfgStore, applyConfig, alerts{
+		engine:    engine,
+		store:     alertStore,
+		logEngine: logEngine,
+		logStore:  logRuleStore,
+	})
 	return pluginsdk.Serve(PluginInfo, handler, buildTools(store, watcher, cfgStore)...)
 }
 

--- a/internal/observ/responder.go
+++ b/internal/observ/responder.go
@@ -1,0 +1,122 @@
+package observ
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+const (
+	ResponderNotify = "notify"
+)
+
+// Responder acts on an incident: notifying, filing an issue, handing it to an agent that
+// opens a pull request. A new one is a registration rather than a change to the engine.
+//
+// One that reaches an external system should key its work on Incident.Key(), so a retry
+// cannot produce a second issue for one fault.
+type Responder interface {
+	Name() string
+	// Respond describes what it did in a sentence; both that and any error are recorded.
+	Respond(ctx context.Context, incident Incident) (string, error)
+}
+
+type ResponderFunc struct {
+	ResponderName string
+	Fn            func(ctx context.Context, incident Incident) (string, error)
+}
+
+func (r ResponderFunc) Name() string { return r.ResponderName }
+
+func (r ResponderFunc) Respond(ctx context.Context, incident Incident) (string, error) {
+	return r.Fn(ctx, incident)
+}
+
+type ResponderResult struct {
+	Responder string    `json:"responder"`
+	Detail    string    `json:"detail,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	At        time.Time `json:"at"`
+}
+
+// Package-level because rule validation runs wherever a rule is saved.
+var registry = struct {
+	mu sync.RWMutex
+	m  map[string]Responder
+}{m: map[string]Responder{}}
+
+// RegisterResponder makes a responder available to rules, replacing one of the same name.
+func RegisterResponder(r Responder) {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	registry.m[r.Name()] = r
+}
+
+func KnownResponders() []string {
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	names := make([]string, 0, len(registry.m))
+	for name := range registry.m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func knownResponder(name string) bool {
+	// Always valid: a rule saved before its responder registers must not be rejected.
+	if name == ResponderNotify {
+		return true
+	}
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	_, ok := registry.m[name]
+	return ok
+}
+
+func lookupResponder(name string) (Responder, bool) {
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	r, ok := registry.m[name]
+	return r, ok
+}
+
+// runResponders runs a rule's responders in order. One failing never stops the others: an
+// incident that could not be filed must still reach a human.
+func runResponders(ctx context.Context, names []string, incident Incident) []ResponderResult {
+	results := make([]ResponderResult, 0, len(names))
+	for _, name := range names {
+		r, ok := lookupResponder(name)
+		if !ok {
+			results = append(results, ResponderResult{
+				Responder: name,
+				Error:     fmt.Sprintf("responder %q is not available in this build", name),
+				At:        time.Now().UTC(),
+			})
+			continue
+		}
+		detail, err := r.Respond(ctx, incident)
+		res := ResponderResult{Responder: name, Detail: detail, At: time.Now().UTC()}
+		if err != nil {
+			res.Error = err.Error()
+		}
+		results = append(results, res)
+	}
+	return results
+}
+
+// NewNotifyResponder delivers the incident to the operator's configured targets.
+func NewNotifyResponder(send func(title, message string, targets []string)) Responder {
+	return ResponderFunc{
+		ResponderName: ResponderNotify,
+		Fn: func(_ context.Context, incident Incident) (string, error) {
+			if send == nil {
+				return "", fmt.Errorf("no notification transport")
+			}
+			send(incident.Title(), incident.Message(), incident.Targets)
+			return "notified", nil
+		},
+	}
+}

--- a/internal/observ/triage_client.go
+++ b/internal/observ/triage_client.go
@@ -1,0 +1,146 @@
+package observ
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// triageCache makes a fault recurring next week reuse its verdict rather than pay again.
+type triageCache struct {
+	mu      sync.Mutex
+	entries map[string]cachedTriage
+	ttl     time.Duration
+	max     int
+}
+
+type cachedTriage struct {
+	verdict Triage
+	at      time.Time
+}
+
+func newTriageCache(ttl time.Duration, max int) *triageCache {
+	if ttl <= 0 {
+		ttl = 7 * 24 * time.Hour
+	}
+	if max <= 0 {
+		max = 500
+	}
+	return &triageCache{entries: map[string]cachedTriage{}, ttl: ttl, max: max}
+}
+
+func (c *triageCache) get(key string) (Triage, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok || time.Since(entry.at) > c.ttl {
+		return Triage{}, false
+	}
+	return entry.verdict, true
+}
+
+func (c *triageCache) put(key string, verdict Triage) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.entries) >= c.max {
+		// Any victim will do: a wrong choice costs one extra call.
+		for k := range c.entries {
+			delete(c.entries, k)
+			break
+		}
+	}
+	c.entries[key] = cachedTriage{verdict: verdict, at: time.Now()}
+}
+
+// TriageClient asks the agent to explain an incident. The model, its key and the daily
+// ceiling live in the agent; this decides what to send and remembers the answer.
+type TriageClient struct {
+	base   string
+	token  string
+	client *http.Client
+	cache  *triageCache
+}
+
+func NewTriageClient(base, token string) *TriageClient {
+	return &TriageClient{
+		base:   strings.TrimRight(base, "/"),
+		token:  token,
+		client: &http.Client{Timeout: 60 * time.Second},
+		cache:  newTriageCache(7*24*time.Hour, 500),
+	}
+}
+
+type triageEnvelope struct {
+	Triage struct {
+		Summary    string `json:"summary"`
+		Cause      string `json:"cause"`
+		NextStep   string `json:"next_step"`
+		Severity   string `json:"severity"`
+		Confidence string `json:"confidence"`
+	} `json:"triage"`
+	Error string `json:"error"`
+}
+
+func (t *TriageClient) Explain(ctx context.Context, incident Incident) (*Triage, error) {
+	if t.base == "" || t.token == "" {
+		return nil, fmt.Errorf("no route to the assistant")
+	}
+
+	cacheKey := incident.Deployment + "/" + incident.Fingerprint
+	if verdict, ok := t.cache.get(cacheKey); ok {
+		return &verdict, nil
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"rule_name":  incident.RuleName,
+		"deployment": incident.Deployment,
+		"service":    incident.Service,
+		"level":      incident.Level,
+		"count":      incident.Count,
+		"sample":     incident.Sample,
+		"context":    incident.Context,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.base+"/internal/ai/triage", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Plugin-Token", t.token)
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var envelope triageEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("the assistant's reply could not be read: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		if envelope.Error != "" {
+			return nil, fmt.Errorf("%s", envelope.Error)
+		}
+		return nil, fmt.Errorf("triage returned %s", resp.Status)
+	}
+
+	verdict := Triage{
+		Summary:    envelope.Triage.Summary,
+		Cause:      envelope.Triage.Cause,
+		NextStep:   envelope.Triage.NextStep,
+		Severity:   envelope.Triage.Severity,
+		Confidence: envelope.Triage.Confidence,
+		At:         time.Now().UTC(),
+	}
+	t.cache.put(cacheKey, verdict)
+	return &verdict, nil
+}

--- a/internal/system/network.go
+++ b/internal/system/network.go
@@ -12,14 +12,14 @@ import (
 )
 
 type NetworkHealth struct {
-	ExternalAccess bool              `json:"external_access"`
-	DNS            DNSHealth         `json:"dns"`
+	ExternalAccess bool               `json:"external_access"`
+	DNS            DNSHealth          `json:"dns"`
 	Interfaces     []NetworkInterface `json:"interfaces"`
-	CheckedAt      time.Time         `json:"checked_at"`
+	CheckedAt      time.Time          `json:"checked_at"`
 }
 
 type DNSHealth struct {
-	Healthy  bool             `json:"healthy"`
+	Healthy   bool            `json:"healthy"`
 	Resolvers []ResolverCheck `json:"resolvers"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,6 +135,9 @@ type AIConfig struct {
 	Model   string        `yaml:"model" json:"model"`
 	Timeout time.Duration `yaml:"timeout" json:"timeout"`
 	DocsURL string        `yaml:"docs_url" json:"docs_url"`
+	// TriageDailyCap bounds the log incidents a day the assistant may be asked to explain.
+	// Triage runs unattended, so it gets a ceiling that operator-initiated chat does not need.
+	TriageDailyCap int `yaml:"triage_daily_cap" json:"triage_daily_cap"`
 }
 
 type PlansConfig struct {

--- a/templates/infra/nginx/nginx.conf
+++ b/templates/infra/nginx/nginx.conf
@@ -10,7 +10,9 @@ http {
     include mime.types;
     default_type application/octet-stream;
 
-    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+    # The host leads every line so an access line says which site it belongs to; one proxy
+    # serves every deployment, and without it the log cannot be read per deployment.
+    log_format main '$host $remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
 

--- a/templates/infra/nginx/nginx.lua.conf
+++ b/templates/infra/nginx/nginx.lua.conf
@@ -10,7 +10,9 @@ http {
     include mime.types;
     default_type application/octet-stream;
 
-    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+    # The host leads every line so an access line says which site it belongs to; one proxy
+    # serves every deployment, and without it the log cannot be read per deployment.
+    log_format main '$host $remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
 


### PR DESCRIPTION
The panel could not show the proxy's own logs, so a request that never reached a deployment was
invisible everywhere, and the access log could not say which site a line belonged to. Access lines
now lead with the host, which is what makes one shared log readable per deployment.

Log triage is bounded on purpose. Lines are collapsed by shape before anything is counted, so a
thousand repeats of one fault are one incident; only an incident reaches the assistant, the
context handed over is capped, and a daily ceiling bounds the spend. Acting on an incident goes
through a registry so notifying is the first responder rather than the only possible one.

Deleting a log truncates in place rather than unlinking, so the application keeps writing to the
same file. A source the runtime does not keep on disk is refused with the reason instead of
appearing to succeed.

The service filter was a regression: it had been dropped from the compose call.

Needs the matching ui branch. `internal/docker` tests time out on `TestPullDeployment`, which
pulls images over the network and does the same on main.
