### PR TITLE
fix(notifications): Embed email images reliably

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/compose v0.41.0
 	github.com/whilesmartgo/agents v0.4.0
 	github.com/whilesmartgo/mcp v0.2.0
+	github.com/wneessen/go-mail v0.7.2
 	go.opentelemetry.io/otel v1.41.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.41.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.41.0

--- a/go.sum
+++ b/go.sum
@@ -522,6 +522,8 @@ github.com/whilesmartgo/agents v0.4.0 h1:DEzeO28Kh31aixHsz55Sq7guYooKEOAUmN2J2Vb
 github.com/whilesmartgo/agents v0.4.0/go.mod h1:MTuXbfen/M5GGphQk3kggnO52i8thPBf3RfywfuxOOM=
 github.com/whilesmartgo/mcp v0.2.0 h1:oXEI2dagW9rFuRvK4U87iLPd7pxZ08RdAi1HSy8hyrY=
 github.com/whilesmartgo/mcp v0.2.0/go.mod h1:GD0Gg3H8rJOSfCQ0o68kXjOg5Kv3QqkAHRwtV4L+xKk=
+github.com/wneessen/go-mail v0.7.2 h1:xxPnhZ6IZLSgxShebmZ6DPKh1b6OJcoHfzy7UjOkzS8=
+github.com/wneessen/go-mail v0.7.2/go.mod h1:+TkW6QP3EVkgTEqHtVmnAE/1MRhmzb8Y9/W3pweuS+k=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/internal/notify/email.go
+++ b/internal/notify/email.go
@@ -48,6 +48,17 @@ type emailData struct {
 	Panels     []emailPanel
 }
 
+type emailEmbed struct {
+	name string
+	mime string
+	data []byte
+}
+
+type renderedEmail struct {
+	html   string
+	embeds []emailEmbed
+}
+
 func normalizeKind(kind Kind) Kind {
 	switch kind {
 	case KindPositive, KindNegative:
@@ -84,22 +95,61 @@ func safeImageURL(raw string) template.URL {
 }
 
 func RenderEmail(notification Notification) (string, error) {
+	logo := "data:" + defaultEmailTheme.logoMIME + ";base64," + base64.StdEncoding.EncodeToString(defaultEmailTheme.logo)
+	return renderEmail(notification, template.URL(logo), false)
+}
+
+func renderEmailForDelivery(notification Notification) (renderedEmail, error) {
+	const logoName = "flatrun-logo.png"
+	body, err := renderEmail(notification, template.URL("cid:"+logoName), true)
+	if err != nil {
+		return renderedEmail{}, err
+	}
+	embeds := []emailEmbed{{name: logoName, mime: defaultEmailTheme.logoMIME, data: defaultEmailTheme.logo}}
+	for i, panel := range notification.Panels {
+		data, ok := pngData(panel.ImageURL)
+		if !ok {
+			continue
+		}
+		embeds = append(embeds, emailEmbed{
+			name: fmt.Sprintf("flatrun-panel-%d.png", i+1), mime: "image/png", data: data,
+		})
+	}
+	return renderedEmail{html: body, embeds: embeds}, nil
+}
+
+func renderEmail(notification Notification, logo template.URL, embedPanels bool) (string, error) {
 	accent, accentSoft, status := palette(notification.Kind)
 	panels := make([]emailPanel, 0, len(notification.Panels))
-	for _, panel := range notification.Panels {
+	for i, panel := range notification.Panels {
+		imageURL := safeImageURL(panel.ImageURL)
+		if embedPanels {
+			if _, ok := pngData(panel.ImageURL); ok {
+				imageURL = template.URL(fmt.Sprintf("cid:flatrun-panel-%d.png", i+1))
+			}
+		}
 		panels = append(panels, emailPanel{
-			Title: panel.Title, Value: panel.Value, Detail: panel.Detail, ImageURL: safeImageURL(panel.ImageURL),
+			Title: panel.Title, Value: panel.Value, Detail: panel.Detail, ImageURL: imageURL,
 		})
 	}
 	var body bytes.Buffer
 	err := defaultEmailTheme.template.ExecuteTemplate(&body, defaultEmailTheme.main, emailData{
-		Title: notification.Title, Message: notification.Message, Logo: defaultEmailTheme.logo,
+		Title: notification.Title, Message: notification.Message, Logo: logo,
 		Accent: accent, AccentSoft: accentSoft, Status: status, Panels: panels,
 	})
 	if err != nil {
 		return "", fmt.Errorf("render email notification: %w", err)
 	}
 	return body.String(), nil
+}
+
+func pngData(raw string) ([]byte, bool) {
+	const prefix = "data:image/png;base64,"
+	if !strings.HasPrefix(raw, prefix) {
+		return nil, false
+	}
+	data, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(raw, prefix))
+	return data, err == nil && len(data) >= 8 && bytes.Equal(data[:8], []byte("\x89PNG\r\n\x1a\n"))
 }
 
 func formatDelivery(rawURL string, notification Notification) (string, string, error) {

--- a/internal/notify/email_sender.go
+++ b/internal/notify/email_sender.go
@@ -1,0 +1,111 @@
+package notify
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"os"
+
+	"github.com/nicholas-fedor/shoutrrr/pkg/router"
+	shoutrrrsmtp "github.com/nicholas-fedor/shoutrrr/pkg/services/email/smtp"
+	mail "github.com/wneessen/go-mail"
+)
+
+func sendEmail(rawURL string, notification Notification, serviceRouter *router.ServiceRouter) error {
+	service, err := serviceRouter.Locate(rawURL)
+	if err != nil {
+		return err
+	}
+	smtpService, ok := service.(*shoutrrrsmtp.Service)
+	if !ok {
+		return fmt.Errorf("notification target is not SMTP")
+	}
+	config := smtpService.Config.Clone()
+	config.FixEmailTags()
+	message, err := buildEmailMessage(notification, &config)
+	if err != nil {
+		return err
+	}
+	client, err := mail.NewClient(config.Host, smtpClientOptions(&config)...)
+	if err != nil {
+		return err
+	}
+	return client.DialAndSend(message)
+}
+
+func buildEmailMessage(notification Notification, config *shoutrrrsmtp.Config) (*mail.Msg, error) {
+	rendered, err := renderEmailForDelivery(notification)
+	if err != nil {
+		return nil, err
+	}
+	message := mail.NewMsg()
+	if config.FromName == "" {
+		err = message.From(config.FromAddress)
+	} else {
+		err = message.FromFormat(config.FromName, config.FromAddress)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := message.To(config.ToAddresses...); err != nil {
+		return nil, err
+	}
+	message.Subject(config.Subject)
+	message.SetBodyString(mail.TypeTextPlain, plainMessage(notification))
+	message.AddAlternativeString(mail.TypeTextHTML, rendered.html)
+	for _, embed := range rendered.embeds {
+		if err := message.EmbedReader(embed.name, bytes.NewReader(embed.data),
+			mail.WithFileContentType(mail.ContentType(embed.mime))); err != nil {
+			return nil, err
+		}
+	}
+	return message, nil
+}
+
+func smtpClientOptions(config *shoutrrrsmtp.Config) []mail.Option {
+	clientHost := config.ClientHost
+	if clientHost == "auto" {
+		clientHost, _ = os.Hostname()
+	}
+	if clientHost == "" {
+		clientHost = "localhost"
+	}
+	options := []mail.Option{
+		mail.WithPort(int(config.Port)),
+		mail.WithTimeout(config.Timeout),
+		mail.WithHELO(clientHost),
+	}
+	if config.Username != "" {
+		options = append(options, mail.WithUsername(config.Username), mail.WithPassword(config.Password))
+	}
+	switch config.Auth {
+	case shoutrrrsmtp.AuthTypes.Plain:
+		options = append(options, mail.WithSMTPAuth(mail.SMTPAuthPlain))
+	case shoutrrrsmtp.AuthTypes.CRAMMD5:
+		options = append(options, mail.WithSMTPAuth(mail.SMTPAuthCramMD5))
+	case shoutrrrsmtp.AuthTypes.OAuth2:
+		options = append(options, mail.WithSMTPAuth(mail.SMTPAuthXOAUTH2))
+	default:
+		options = append(options, mail.WithSMTPAuth(mail.SMTPAuthNoAuth))
+	}
+	implicitTLS := config.Encryption == shoutrrrsmtp.EncMethods.ImplicitTLS ||
+		(config.Encryption == shoutrrrsmtp.EncMethods.Auto && config.Port == shoutrrrsmtp.ImplicitTLSPort)
+	if implicitTLS {
+		options = append(options, mail.WithSSL())
+	} else if config.UseStartTLS {
+		policy := mail.TLSOpportunistic
+		if config.RequireStartTLS {
+			policy = mail.TLSMandatory
+		}
+		options = append(options, mail.WithTLSPolicy(policy))
+	} else {
+		options = append(options, mail.WithTLSPolicy(mail.NoTLS))
+	}
+	if config.SkipTLSVerify {
+		// #nosec G402 The administrator explicitly enabled certificate verification bypass.
+		options = append(options, mail.WithTLSConfig(&tls.Config{
+			ServerName: config.Host, MinVersion: tls.VersionTLS12, InsecureSkipVerify: true,
+		}))
+	}
+	return options
+}

--- a/internal/notify/email_theme.go
+++ b/internal/notify/email_theme.go
@@ -3,7 +3,6 @@ package notify
 import (
 	"bytes"
 	"embed"
-	"encoding/base64"
 	"fmt"
 	"html/template"
 	"io/fs"
@@ -30,7 +29,8 @@ type emailThemeManifest struct {
 type emailTheme struct {
 	template *template.Template
 	main     string
-	logo     template.URL
+	logo     []byte
+	logoMIME string
 }
 
 //go:embed templates/default
@@ -75,6 +75,8 @@ func loadEmailTheme(fsys fs.FS, root string) (*emailTheme, error) {
 	if manifest.Assets.Logo.MIME != "image/png" {
 		return nil, fmt.Errorf("unsupported email theme logo type %q", manifest.Assets.Logo.MIME)
 	}
-	logo := "data:" + manifest.Assets.Logo.MIME + ";base64," + base64.StdEncoding.EncodeToString(logoData)
-	return &emailTheme{template: parsed, main: path.Base(manifest.Templates.Main), logo: template.URL(logo)}, nil
+	return &emailTheme{
+		template: parsed, main: path.Base(manifest.Templates.Main),
+		logo: logoData, logoMIME: manifest.Assets.Logo.MIME,
+	}, nil
 }

--- a/internal/notify/email_theme_test.go
+++ b/internal/notify/email_theme_test.go
@@ -16,7 +16,7 @@ func TestLoadEmailThemeFromManifest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if theme.main != "notification.html" || theme.logo == "" {
+	if theme.main != "notification.html" || len(theme.logo) == 0 {
 		t.Fatal("theme manifest was not loaded")
 	}
 }

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -10,13 +10,11 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/nicholas-fedor/shoutrrr"
 	"github.com/nicholas-fedor/shoutrrr/pkg/router"
-	"github.com/nicholas-fedor/shoutrrr/pkg/types"
 	"gopkg.in/yaml.v3"
 )
 
@@ -165,21 +163,7 @@ func sendFormatted(rawURL string, notification Notification) error {
 	if err != nil || parsed.Scheme != "smtp" {
 		return shoutrrr.Send(rawURL, plainMessage(notification))
 	}
-	service, err := (&router.ServiceRouter{}).Locate(rawURL)
-	if err != nil {
-		return err
-	}
-	htmlBody, err := RenderEmail(notification)
-	if err != nil {
-		return err
-	}
-	if err := service.SetTemplateString("plain", `{{printf "%s" `+strconv.Quote(plainMessage(notification))+`}}`); err != nil {
-		return err
-	}
-	if err := service.SetTemplateString("HTML", `{{printf "%s" `+strconv.Quote(htmlBody)+`}}`); err != nil {
-		return err
-	}
-	return service.Send("", &types.Params{})
+	return sendEmail(rawURL, notification, &router.ServiceRouter{})
 }
 
 func plainMessage(notification Notification) string {

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -1,11 +1,14 @@
 package notify
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"net/url"
 	"strings"
 	"testing"
+
+	shoutrrrsmtp "github.com/nicholas-fedor/shoutrrr/pkg/services/email/smtp"
 )
 
 func TestTargetJSONMasksURL(t *testing.T) {
@@ -19,6 +22,35 @@ func TestTargetJSONMasksURL(t *testing.T) {
 	}
 	if !strings.Contains(out, MaskedURL) {
 		t.Errorf("URL should be masked: %s", out)
+	}
+}
+
+func TestEmailMessageEmbedsImagesReferencedByContentID(t *testing.T) {
+	png := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+	message, err := buildEmailMessage(Notification{
+		Title: "Alert", Message: "Details", Panels: []Panel{{Title: "CPU", ImageURL: png}},
+	}, &shoutrrrsmtp.Config{
+		FromAddress: "alerts@example.com", ToAddresses: []string{"admin@example.com"}, Subject: "Alert",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw bytes.Buffer
+	if _, err := message.WriteTo(&raw); err != nil {
+		t.Fatal(err)
+	}
+	body := raw.String()
+	for _, expected := range []string{
+		"multipart/related", "cid:flatrun-logo.png", "cid:flatrun-panel-1.png",
+		"Content-Id: <flatrun-logo.png>", "Content-Id: <flatrun-panel-1.png>",
+		"Content-Disposition: inline",
+	} {
+		if !strings.Contains(body, expected) {
+			t.Errorf("serialized email missing %q", expected)
+		}
+	}
+	if strings.Contains(body, "data:image/png;base64,") {
+		t.Error("serialized email still contains a data URL")
 	}
 }
 


### PR DESCRIPTION
Alert emails now embed the logo and generated PNG panels as inline images instead of data URLs, which produced broken images in mail clients.