### PR TITLE
docs: Add the README brand header

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,8 +1,17 @@
-# FlatRun
+<p align="center">
+  <a href="https://flatrun.dev">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://flatrun.dev/flatrun-logo-white.svg">
+      <img src="https://flatrun.dev/flatrun-logo.svg" alt="FlatRun" width="360">
+    </picture>
+  </a>
+</p>
 
-[English](README.md) | [Français](README.fr.md) | Español | [Português do Brasil](README.pt-BR.md) | [简体中文](README.zh-CN.md)
+<p align="center">
+  <a href="README.md">English</a> · <a href="README.fr.md">Français</a> · Español · <a href="README.pt-BR.md">Português do Brasil</a> · <a href="README.zh-CN.md">简体中文</a>
+</p>
 
-## Ejecuta aplicaciones en contenedores en tus propios servidores
+# Ejecuta aplicaciones en contenedores en tus propios servidores
 
 FlatRun permite desplegar, proteger, diagnosticar, automatizar y administrar
 aplicaciones en contenedores desde un solo lugar. Ejecuta proyectos Docker

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,8 +1,17 @@
-# FlatRun
+<p align="center">
+  <a href="https://flatrun.dev">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://flatrun.dev/flatrun-logo-white.svg">
+      <img src="https://flatrun.dev/flatrun-logo.svg" alt="FlatRun" width="360">
+    </picture>
+  </a>
+</p>
 
-[English](README.md) | Français | [Español](README.es.md) | [Português do Brasil](README.pt-BR.md) | [简体中文](README.zh-CN.md)
+<p align="center">
+  <a href="README.md">English</a> · Français · <a href="README.es.md">Español</a> · <a href="README.pt-BR.md">Português do Brasil</a> · <a href="README.zh-CN.md">简体中文</a>
+</p>
 
-## Exécutez des applications conteneurisées sur vos propres serveurs
+# Exécutez des applications conteneurisées sur vos propres serveurs
 
 FlatRun permet de déployer, sécuriser, diagnostiquer, automatiser et gérer des
 applications conteneurisées depuis une seule interface. Il exécute directement

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
-# FlatRun
+<p align="center">
+  <a href="https://flatrun.dev">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://flatrun.dev/flatrun-logo-white.svg">
+      <img src="https://flatrun.dev/flatrun-logo.svg" alt="FlatRun" width="360">
+    </picture>
+  </a>
+</p>
 
-English | [Français](README.fr.md) | [Español](README.es.md) | [Português do Brasil](README.pt-BR.md) | [简体中文](README.zh-CN.md)
+<p align="center">
+  English · <a href="README.fr.md">Français</a> · <a href="README.es.md">Español</a> · <a href="README.pt-BR.md">Português do Brasil</a> · <a href="README.zh-CN.md">简体中文</a>
+</p>
 
-[![CI](https://github.com/flatrun/agent/actions/workflows/ci.yml/badge.svg)](https://github.com/flatrun/agent/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+<p align="center">
+  <a href="https://github.com/flatrun/agent/actions/workflows/ci.yml"><img src="https://github.com/flatrun/agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT License"></a>
+</p>
 
 # Run containerized applications on your own servers
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,8 +1,17 @@
-# FlatRun
+<p align="center">
+  <a href="https://flatrun.dev">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://flatrun.dev/flatrun-logo-white.svg">
+      <img src="https://flatrun.dev/flatrun-logo.svg" alt="FlatRun" width="360">
+    </picture>
+  </a>
+</p>
 
-[English](README.md) | [Français](README.fr.md) | [Español](README.es.md) | Português do Brasil | [简体中文](README.zh-CN.md)
+<p align="center">
+  <a href="README.md">English</a> · <a href="README.fr.md">Français</a> · <a href="README.es.md">Español</a> · Português do Brasil · <a href="README.zh-CN.md">简体中文</a>
+</p>
 
-## Execute aplicações em contêineres nos seus próprios servidores
+# Execute aplicações em contêineres nos seus próprios servidores
 
 O FlatRun permite implantar, proteger, diagnosticar, automatizar e gerenciar
 aplicações em contêineres em um só lugar. Ele executa projetos Docker Compose

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,8 +1,17 @@
-# FlatRun
+<p align="center">
+  <a href="https://flatrun.dev">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://flatrun.dev/flatrun-logo-white.svg">
+      <img src="https://flatrun.dev/flatrun-logo.svg" alt="FlatRun" width="360">
+    </picture>
+  </a>
+</p>
 
-[English](README.md) | [Français](README.fr.md) | [Español](README.es.md) | [Português do Brasil](README.pt-BR.md) | 简体中文
+<p align="center">
+  <a href="README.md">English</a> · <a href="README.fr.md">Français</a> · <a href="README.es.md">Español</a> · <a href="README.pt-BR.md">Português do Brasil</a> · 简体中文
+</p>
 
-## 在自己的服务器上运行容器应用
+# 在自己的服务器上运行容器应用
 
 FlatRun 让你从一个位置部署、保护、诊断、自动化和管理容器应用。它直接运行标准
 Docker Compose 项目，也可以通过 Docker Swarm 或 k3s 扩展符合条件的工作负载。


### PR DESCRIPTION
Give every README translation a consistent FlatRun header that remains readable in light and dark themes.